### PR TITLE
Delete unget function

### DIFF
--- a/web/src/components/TopicDeletion.jsx
+++ b/web/src/components/TopicDeletion.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { getPTeamTagsSummary, unget } from "../slices/pteam";
+import { getPTeamTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
 import { commonButtonStyle, modalCommonButtonStyle, sxModal } from "../utils/const";
 
@@ -30,7 +30,6 @@ export default function TopicDeletion(props) {
       .then(async () => {
         await Promise.all([
           dispatch(getPTeamTagsSummary(pteamId)),
-          dispatch(unget("topicsSummary")),
           onDelete && onDelete(),
           enqueueSnackbar("delete topic succeeded", { variant: "success" }),
         ]);

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -31,7 +31,6 @@ import {
   getPTeamTagsSummary,
   getPTeamTopicActions,
   getPTeamUnsolvedTaggedTopicIds,
-  unget,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import {
@@ -170,7 +169,6 @@ export default function TopicModal(props) {
         dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId })),
       ]);
     }
-    dispatch(unget("topicsSummary"));
   };
 
   const handleCreateTopic = async () => {

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -179,17 +179,6 @@ const pteamSlice = createSlice({
       ...(action.payload && state.pteamId === action.payload ? state : _initialState),
       pteamId: action.payload,
     }),
-    unget: (state, action) => ({
-      ...state,
-      [action.payload]: undefined,
-    }),
-    ungetTopicStatus: (state, action) => ({
-      ...state,
-      topicStatus: {
-        ...state.topicStatus,
-        [action.payload]: undefined,
-      },
-    }),
   },
   extraReducers: (builder) => {
     builder
@@ -270,6 +259,6 @@ const pteamSlice = createSlice({
 
 const { actions, reducer } = pteamSlice;
 
-export const { clearPTeam, setPTeamId, unget, ungetTopicStatus } = actions;
+export const { clearPTeam, setPTeamId } = actions;
 
 export default reducer;

--- a/web/src/slices/topics.js
+++ b/web/src/slices/topics.js
@@ -10,12 +10,6 @@ export const getTopic = createAsyncThunk(
 const topicsSlice = createSlice({
   name: "topics",
   initialState: {},
-  reducers: {
-    ungetTopic: (state, action) => ({
-      ...state,
-      [action.payload]: undefined,
-    }),
-  },
   extraReducers: (builder) => {
     builder.addCase(getTopic.fulfilled, (state, action) => ({
       ...state,
@@ -26,8 +20,6 @@ const topicsSlice = createSlice({
   },
 });
 
-const { actions, reducer } = topicsSlice;
-
-export const { ungetTopic } = actions;
+const { reducer } = topicsSlice;
 
 export default reducer;


### PR DESCRIPTION
## PR の目的
無限ループの恐れがある unget 関数を削除しました。

## 経緯・意図・意思決定
[経緯](https://gikai.slack.com/archives/C01166LFVAL/p1693547917894949?thread_ts=1693545467.961129&cid=C01166LFVAL)

unget 関数を削除しました。
unget を getPTeamTopicStatusesSummary に書き換えるという話もありましたが、対応してません。
理由は、この関数で得られるstate.pteams.topicsSummary は他のUIファイルで使用されていないためです。
このtopicsSummaryもsliceから削除してもいいかもしれません。

## 参考文献
