### PR TITLE
fix slice structure of topics

### DIFF
--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -53,7 +53,7 @@ export default function PTeamEditAction(props) {
 
   const user = useSelector((state) => state.user.user);
   const pteamId = useSelector((state) => state.pteam.pteamId);
-  const topics = useSelector((state) => state.topics);
+  const topics = useSelector((state) => state.topics.topics);
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
   const src = topics[presetTopicId];

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -45,7 +45,7 @@ export default function ReportCompletedActions(props) {
   const { enqueueSnackbar } = useSnackbar();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
-  const topics = useSelector((state) => state.topics); // dispatched by parent
+  const topics = useSelector((state) => state.topics.topics); // dispatched by parent
   const user = useSelector((state) => state.user.user);
 
   const dispatch = useDispatch();


### PR DESCRIPTION
## PR の目的
- topics のスライス構造が変化したことに対応するため修正しました。

## 経緯・意図・意思決定
- web/src/components/PTeamEditAction.jsx と web/src/components/ReportCompletedActions.jsxにあるstate.topicsの部分を
state.topics.topicsに修正しました。

## 参考文献
