### PR TITLE
Create Pteam Group List

### DIFF
--- a/web/src/components/PTeamGroupList.jsx
+++ b/web/src/components/PTeamGroupList.jsx
@@ -1,24 +1,24 @@
 import { Box, Chip } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-const groupList = [
-  {
-    id: 1,
-    name: "flashsence",
-  },
-  {
-    id: 2,
-    name: "misp-server",
-  },
-  {
-    id: 3,
-    name: "threatconnectome",
-  },
-];
+import { getPTeamGroups } from "../slices/pteam";
 
 export default function PTeamGroupList() {
   const [selectedGroup, setSelectedGroup] = useState("");
+
+  const dispatch = useDispatch();
+
+  const pteamId = useSelector((state) => state.pteam.pteamId);
+  const groups = useSelector((state) => state.pteam.groups);
+
+  useEffect(() => {
+    if (!pteamId) return;
+    if (!groups) {
+      dispatch(getPTeamGroups(pteamId));
+    }
+  }, [pteamId, groups, dispatch]);
 
   const handleSelectGroup = (group) => {
     if (selectedGroup === group) {
@@ -31,24 +31,25 @@ export default function PTeamGroupList() {
   return (
     <>
       <Box>
-        {groupList.map((group) => (
-          <Chip
-            key={group.id}
-            label={group.name}
-            variant={group === selectedGroup ? "" : "outlined"}
-            sx={{
-              mt: 1,
-              borderRadius: "2px",
-              border: `1px solid ${grey[300]}`,
-              borderLeft: `5px solid ${grey[300]}`,
-              mr: 1,
-              background: group === selectedGroup ? grey[400] : "",
-            }}
-            onClick={() => {
-              handleSelectGroup(group);
-            }}
-          />
-        ))}
+        {groups &&
+          groups.map((group) => (
+            <Chip
+              key={group}
+              label={group}
+              variant={group === selectedGroup ? "" : "outlined"}
+              sx={{
+                mt: 1,
+                borderRadius: "2px",
+                border: `1px solid ${grey[300]}`,
+                borderLeft: `5px solid ${grey[300]}`,
+                mr: 1,
+                background: group === selectedGroup ? grey[400] : "",
+              }}
+              onClick={() => {
+                handleSelectGroup(group);
+              }}
+            />
+          ))}
       </Box>
     </>
   );

--- a/web/src/components/PTeamGroupList.jsx
+++ b/web/src/components/PTeamGroupList.jsx
@@ -2,12 +2,11 @@ import { Box, Chip } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation, useNavigate } from "react-router";
 
 import { getPTeamGroups } from "../slices/pteam";
 
 export default function PTeamGroupList() {
-  const [selectedGroup, setSelectedGroup] = useState("");
-
   const dispatch = useDispatch();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
@@ -20,12 +19,19 @@ export default function PTeamGroupList() {
     }
   }, [pteamId, groups, dispatch]);
 
+  const location = useLocation();
+  const navigate = useNavigate();
+  const params = new URLSearchParams(location.search);
+  const selectedGroup = params.get("group") ?? "";
+
   const handleSelectGroup = (group) => {
-    if (selectedGroup === group) {
-      setSelectedGroup("");
+    if (group === selectedGroup) {
+      params.delete("group");
     } else {
-      setSelectedGroup(group);
+      params.set("group", group);
+      params.set("page", 1); // reset page
     }
+    navigate(location.pathname + "?" + params.toString());
   };
 
   return (

--- a/web/src/components/PTeamGroupList.jsx
+++ b/web/src/components/PTeamGroupList.jsx
@@ -1,0 +1,55 @@
+import { Box, Chip } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import React, { useState } from "react";
+
+const groupList = [
+  {
+    id: 1,
+    name: "flashsence",
+  },
+  {
+    id: 2,
+    name: "misp-server",
+  },
+  {
+    id: 3,
+    name: "threatconnectome",
+  },
+];
+
+export default function PTeamGroupList() {
+  const [selectedGroup, setSelectedGroup] = useState("");
+
+  const handleSelectGroup = (group) => {
+    if (selectedGroup === group) {
+      setSelectedGroup("");
+    } else {
+      setSelectedGroup(group);
+    }
+  };
+
+  return (
+    <>
+      <Box>
+        {groupList.map((group) => (
+          <Chip
+            key={group.id}
+            label={group.name}
+            variant={group === selectedGroup ? "" : "outlined"}
+            sx={{
+              mt: 1,
+              borderRadius: "2px",
+              border: `1px solid ${grey[300]}`,
+              borderLeft: `5px solid ${grey[300]}`,
+              mr: 1,
+              background: group === selectedGroup ? grey[400] : "",
+            }}
+            onClick={() => {
+              handleSelectGroup(group);
+            }}
+          />
+        ))}
+      </Box>
+    </>
+  );
+}

--- a/web/src/components/PTeamGroupList.jsx
+++ b/web/src/components/PTeamGroupList.jsx
@@ -1,6 +1,6 @@
 import { Box, Chip } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -30,6 +30,7 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
+import PTeamGroupList from "../components/PTeamGroupList";
 import PTeamLabel from "../components/PTeamLabel";
 import PTeamStatusCard from "../components/PTeamStatusCard";
 import {
@@ -281,6 +282,7 @@ export default function PTeamStatus() {
         <PTeamLabel defaultTabIndex={1} />
         <Box flexGrow={1} />
       </Box>
+      <PTeamGroupList />
       {summary.tags.length === 0 ? (
         <Box display="flex">
           {notRegistered}

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -14,6 +14,7 @@ import {
   getPTeamTopicStatus as apiGetPTeamTopicStatus,
   getPTeamTopicStatusesSummary as apiGetPTeamTopicStatusesSummary,
   getPTeamWatcher as apiGetPTeamWatcher,
+  getPTeamGroups as apiGetPTeamGroups,
 } from "../utils/api";
 
 export const getPTeam = createAsyncThunk(
@@ -150,6 +151,15 @@ export const getPTeamWatcher = createAsyncThunk(
     }))
 );
 
+export const getPTeamGroups = createAsyncThunk(
+  "pteam/getPTeamGroups",
+  async (pteamId) =>
+    await apiGetPTeamGroups(pteamId).then((response) => ({
+      data: response.data,
+      pteamId: pteamId,
+    }))
+);
+
 const _initialState = {
   pteamId: undefined,
   pteam: undefined,
@@ -163,6 +173,7 @@ const _initialState = {
   taggedTopics: {},
   topicStatus: {},
   topicActions: {},
+  groups: undefined,
 };
 
 const pteamSlice = createSlice({
@@ -253,6 +264,10 @@ const pteamSlice = createSlice({
           ...state.topicActions,
           [action.payload.topicId]: action.payload.actions,
         },
+      }))
+      .addCase(getPTeamGroups.fulfilled, (state, action) => ({
+        ...state,
+        groups: action.payload.data.groups,
       }));
   },
 });

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -155,7 +155,7 @@ export const getPTeamGroups = createAsyncThunk(
   "pteam/getPTeamGroups",
   async (pteamId) =>
     await apiGetPTeamGroups(pteamId).then((response) => ({
-      data: response.data,
+      groups: response.data.groups,
       pteamId: pteamId,
     }))
 );
@@ -267,7 +267,7 @@ const pteamSlice = createSlice({
       }))
       .addCase(getPTeamGroups.fulfilled, (state, action) => ({
         ...state,
-        groups: action.payload.data.groups,
+        groups: action.payload.groups,
       }));
   },
 });

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -85,6 +85,8 @@ export const getPTeamWatcher = async (pteamId) => axios.get(`/pteams/${pteamId}/
 export const removeWatcherATeam = async (pteamId, ateamId) =>
   axios.delete(`/pteams/${pteamId}/watchers/${ateamId}`);
 
+export const getPTeamGroups = async (pteamId) => axios.get(`/pteams/${pteamId}/groups`);
+
 // ateams
 export const updateATeam = async (ateamId, data) => axios.put(`/ateams/${ateamId}`, data);
 


### PR DESCRIPTION
## PR の目的

- 機能追加の場合
  - PTeamのStatus画面上部にそのPTeamが管理しているグループの一覧を表示する
  - チップを押下すると、リスト内抽出が可能になる
  - 現在は直データを参照しており、押下しても抽出はされない

## 経緯・意図・意思決定
選択中のチップの背景色ですが、デフォルトだと薄かったのでgrey[400]で設定しています
また、線の色はgrey[300] です

## 参考文献
https://docs.google.com/presentation/d/1y26OURtwNuV5_vXt2uirrw8BT7lTQ2Q4bbxJt1oKb_0/edit?usp=sharing

デザインは上記参考