### PR TITLE
Topic/api implementation of group list display

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -157,7 +157,7 @@ def get_pteam(
     return _extend_pteam_tags(pteam)
 
 
-@router.get("/{pteam_id}/groups",response_model=schemas.PTeamGroupResponse)
+@router.get("/{pteam_id}/groups", response_model=schemas.PTeamGroupResponse)
 def get_pteam_groups(
     pteam_id: UUID,
     current_user: models.Account = Depends(get_current_user),
@@ -169,7 +169,7 @@ def get_pteam_groups(
     pteam = validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     assert pteam
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
-    set_groups=set()
+    set_groups = set()
     for pteamtag in pteam.pteamtags:
         for reference in pteamtag.references:
             group = reference.get("group", None)
@@ -177,6 +177,7 @@ def get_pteam_groups(
                 set_groups.add(reference["group"])
 
     return schemas.PTeamGroupResponse(groups=list(set_groups))
+
 
 @router.get("/{pteam_id}/tags", response_model=List[schemas.ExtTagResponse])
 def get_pteam_tags(
@@ -1276,7 +1277,10 @@ def get_pteam_achievements(
             (
                 true()
                 if check_pteam_auth(
-                    db, pteam_id, MEMBER_UUID, required_auth  # all members are allowed
+                    db,
+                    pteam_id,
+                    MEMBER_UUID,
+                    required_auth,  # all members are allowed
                 )
                 else models.SecBadge.user_id.in_(
                     db.query(models.PTeamAuthority.user_id).filter(  # individually allowed users

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -169,7 +169,10 @@ def get_pteam_groups(
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
     unique_groups = set()
-    pteam = db.query(models.PTeam).options(joinedload(models.PTeam.pteamtags)).get(str(pteam_id))
+    pteam = ( db.query(models.PTeam).options(joinedload(models.PTeam.pteamtags))
+             .filter(models.PTeam.pteam_id == str(pteam_id))
+             .one_or_none()
+    )
     assert pteam
     for pteamtag in pteam.pteamtags:
         for reference in pteamtag.references:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -169,9 +169,11 @@ def get_pteam_groups(
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
     unique_groups = set()
-    pteam = ( db.query(models.PTeam).options(joinedload(models.PTeam.pteamtags))
-             .filter(models.PTeam.pteam_id == str(pteam_id))
-             .one_or_none()
+    pteam = (
+        db.query(models.PTeam)
+        .options(joinedload(models.PTeam.pteamtags))
+        .filter(models.PTeam.pteam_id == str(pteam_id))
+        .one_or_none()
     )
     assert pteam
     for pteamtag in pteam.pteamtags:

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -192,6 +192,7 @@ class ExtTagResponse(TagResponse):
     references: List[dict] = []
     text: Optional[str] = None
 
+
 class PTeamGroupResponse(ORMModel):
     groups: List[str] = []
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -192,6 +192,9 @@ class ExtTagResponse(TagResponse):
     references: List[dict] = []
     text: Optional[str] = None
 
+class PTeamGroupResponse(ORMModel):
+    groups: List[str] = []
+
 
 class PTeamtagRequest(ORMModel):
     references: Optional[List[dict]] = None

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import tempfile
 from datetime import datetime, timedelta
@@ -335,6 +336,36 @@ def test_update_pteam__by_not_admin():
     assert response.status_code == 403
     assert response.reason_phrase == "Forbidden"
 
+
+def test_get_pteam_groups():
+    create_user(USER1)
+    pteam2 = create_pteam(USER1, PTEAM2)
+
+    response = client.get(f"/pteams/{pteam2.pteam_id}/groups", headers=headers(USER1))
+    assert response.status_code == 200
+    response_groups = response.json()
+    response_groups_set = set(list(response_groups.values())[0])
+
+    pteam2_groups=set()
+    pteam2_references = [x["references"] for x in PTEAM2["tags"]]
+    for reference in pteam2_references:
+        for group in reference:
+            pteam2_groups.add(group["group"])
+
+    assert response_groups_set == pteam2_groups
+
+def test_get_pteam_not_groups():
+    create_user(USER1)
+
+    pteam1_not_group = copy.deepcopy(PTEAM1)
+    for pteam1_tags in pteam1_not_group["tags"]:
+        for pteam1_references in pteam1_tags["references"]:
+            del pteam1_references["group"]
+
+    pteam1 = create_pteam(USER1, pteam1_not_group)
+    response = client.get(f"/pteams/{pteam1.pteam_id}/groups", headers=headers(USER1))
+    assert response.status_code == 200
+    assert response.json()["groups"] == []
 
 def test_get_pteam_tags():
     create_user(USER1)

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -346,13 +346,14 @@ def test_get_pteam_groups():
     response_groups = response.json()
     response_groups_set = set(list(response_groups.values())[0])
 
-    pteam2_groups=set()
+    pteam2_groups = set()
     pteam2_references = [x["references"] for x in PTEAM2["tags"]]
     for reference in pteam2_references:
         for group in reference:
             pteam2_groups.add(group["group"])
 
     assert response_groups_set == pteam2_groups
+
 
 def test_get_pteam_not_groups():
     create_user(USER1)
@@ -366,6 +367,7 @@ def test_get_pteam_not_groups():
     response = client.get(f"/pteams/{pteam1.pteam_id}/groups", headers=headers(USER1))
     assert response.status_code == 200
     assert response.json()["groups"] == []
+
 
 def test_get_pteam_tags():
     create_user(USER1)


### PR DESCRIPTION
## PR の目的
- グループ一覧の表示のAPI実装について対応しました。

## 経緯・意図・意思決定
- pteam_idに付随する情報を全て取得し、referencesの中にあるgroupをset_groupsに格納しています。pteamのデータを取得した際にgroupのkeyが存在しないことを考慮して存在しない場合、空のリストを返すようにしています。(api/app/routers/pteams.py)
- グループの一覧のレスポンスモデルを作成しました。(api/app/schemas.py)
- グループ一覧の表示をするAPI実装に伴い、テストケースを2つ作成しました。(api/app/tests/medium/routers/test_pteams.py)
   - 1つ目がdef test_get_pteam_groups()です。登録してある情報とapiのレスポンスの内容が一致しているかをテストしています。
   - 2つ目がdef test_get_pteam_not_groups()です。登録してある情報の中にgroupがないとき、空のリストがレスポンスで返ってきているかを検証しています。