### PR TITLE
remove alpine from debian package family

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -1764,7 +1764,7 @@ class PackageFamily(Enum):
     @classmethod
     def from_registry(cls, registry: str) -> "PackageFamily":
         fixed_registry = registry.lower()
-        if re.match(r"^(alpine|debian|ubuntu)", fixed_registry):  # TODO: need maintenance
+        if re.match(r"^(debian|ubuntu)", fixed_registry):  # TODO: need maintenance
             return cls.DEBIAN
         return cls.UNKNOWN
 


### PR DESCRIPTION
## PR の目的

- alpine の package family を default (semver) に修正。

