### PR TITLE
余白や幅などに関する軽微な修正

### DIFF
--- a/web/src/components/ATeamCreationModal.jsx
+++ b/web/src/components/ATeamCreationModal.jsx
@@ -6,6 +6,7 @@ import {
   Typography,
   IconButton,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogTitle,
 } from "@mui/material";
@@ -17,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 
 import { getUser } from "../slices/user";
 import { createATeam } from "../utils/api";
+import { modalCommonButtonStyle } from "../utils/const";
 
 export default function ATeamCreationModal(props) {
   const { open, setOpen, closeTeamSelector } = props;
@@ -84,16 +86,13 @@ export default function ATeamCreationModal(props) {
               onChange={(event) => setContactInfo(event.target.value)}
               margin="dense"
             ></TextField>
-            <Button
-              onClick={handleCreate}
-              color="success"
-              variant="contained"
-              disabled={!ateamName}
-            >
-              Create
-            </Button>
           </Box>
         </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCreate} disabled={!ateamName} sx={modalCommonButtonStyle}>
+            Create
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/components/ATeamInvitationModal.jsx
+++ b/web/src/components/ATeamInvitationModal.jsx
@@ -79,7 +79,7 @@ export default function ATeamInvitationModal(props) {
       <Button onClick={handleOpen} sx={commonButtonStyle}>
         {text}
       </Button>
-      <Dialog open={open} PaperProps={{ sx: { minWidth: "600px", maxWidth: "95%" } }}>
+      <Dialog open={open} fullWidth>
         <DialogTitle>
           <Typography variant="inherit">Create New Invitation Link</Typography>
         </DialogTitle>
@@ -99,7 +99,7 @@ export default function ATeamInvitationModal(props) {
               </Box>
             ) : (
               <Grid container alignItems="center">
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <DateTimePicker
                     inputFormat="YYYY/MM/DD HH:mm"
                     label="Expiration Date (future date)"
@@ -109,12 +109,18 @@ export default function ATeamInvitationModal(props) {
                       setData({ ...data, expiration: moment ? moment.toDate() : "" })
                     }
                     renderInput={(params) => (
-                      <TextField fullWidth margin="dense" required {...params} />
+                      <TextField
+                        fullWidth
+                        margin="dense"
+                        required
+                        {...params}
+                        sx={{ width: "100%" }}
+                      />
                     )}
                     value={data.expiration}
                   />
                 </Grid>
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <Box display="flex" flexDirection="column" justifyContent="center">
                     <Typography>Max uses: {data.max_uses || "unlimited"}</Typography>
                     <Box mx={1}>
@@ -128,6 +134,7 @@ export default function ATeamInvitationModal(props) {
                         min={0}
                         onChange={(_, value) => setData({ ...data, max_uses: value })}
                         value={data.max_uses}
+                        sx={{ width: "100%" }}
                       />
                     </Box>
                   </Box>

--- a/web/src/components/ATeamTopicCreationModal.jsx
+++ b/web/src/components/ATeamTopicCreationModal.jsx
@@ -292,7 +292,8 @@ export function ATeamTopicCreationModal(props) {
                   error={!validateNotEmpty(title)}
                   onChange={(event) => setTitle(event.target.value)}
                   mb={4}
-                  sx={{ minWidth: "400px" }}
+                  // sx={{ minWidth: "400px" }}
+                  sx={{ width: "100%" }}
                 />
                 <Typography variant="body2" sx={{ fontWeight: 600, mt: 2 }}>
                   Topic ID(UUID)
@@ -332,7 +333,8 @@ export function ATeamTopicCreationModal(props) {
                     multiline
                     rows={3}
                     variant="outlined"
-                    sx={{ minWidth: "480px" }}
+                    // sx={{ minWidth: "480px" }}
+                    sx={{ width: "100%" }}
                   />
                   {abst === "" ? (
                     <SentimentVeryDissatisfiedIcon sx={{ color: red[600], mt: 9, ml: 1 }} />
@@ -357,7 +359,8 @@ export function ATeamTopicCreationModal(props) {
                     .filter((tag) => tagIds.includes(tag.tag_id))
                     .map((tag) => tag.tag_name)
                     .join(", ")}
-                  sx={{ minWidth: "720px" }}
+                  // sx={{ minWidth: "720px" }}
+                  sx={{ width: "100%" }}
                   inputProps={{ readOnly: true }}
                 />
                 <Box display="flex" flexDirection="row" alignItems="center" mt={2}>
@@ -382,7 +385,8 @@ export function ATeamTopicCreationModal(props) {
                     (zonesRelatedTeams === undefined ||
                       Object.values(zonesRelatedTeams.pteams).length === 0)
                   }
-                  sx={{ minWidth: "720px" }}
+                  // sx={{ minWidth: "720px" }}
+                  sx={{ width: "100%" }}
                   inputProps={{ readOnly: true }}
                 />
                 <Box display="flex" flexDirection="row" alignItems="center" mt={2}>

--- a/web/src/components/GTeamCreationModal.jsx
+++ b/web/src/components/GTeamCreationModal.jsx
@@ -6,6 +6,7 @@ import {
   Typography,
   IconButton,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogTitle,
 } from "@mui/material";
@@ -17,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 
 import { getUser } from "../slices/user";
 import { createGTeam } from "../utils/api";
+import { modalCommonButtonStyle } from "../utils/const";
 
 export default function GTeamCreationModal(props) {
   const { open, setOpen, closeTeamSelector } = props;
@@ -84,16 +86,13 @@ export default function GTeamCreationModal(props) {
               onChange={(event) => setContactInfo(event.target.value)}
               margin="dense"
             ></TextField>
-            <Button
-              onClick={handleCreate}
-              color="success"
-              variant="contained"
-              disabled={!gteamName}
-            >
-              Create
-            </Button>
           </Box>
         </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCreate} disabled={!gteamName} sx={modalCommonButtonStyle}>
+            Create
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/components/GTeamInvitationModal.jsx
+++ b/web/src/components/GTeamInvitationModal.jsx
@@ -79,7 +79,7 @@ export default function GTeamInvitationModal(props) {
       <Button onClick={handleOpen} sx={commonButtonStyle}>
         {text}
       </Button>
-      <Dialog open={open} PaperProps={{ sx: { minWidth: "600px", maxWidth: "95%" } }}>
+      <Dialog open={open} fullWidth>
         <DialogTitle>
           <Typography variant="inherit">Create New Invitation Link</Typography>
         </DialogTitle>
@@ -99,7 +99,7 @@ export default function GTeamInvitationModal(props) {
               </Box>
             ) : (
               <Grid container alignItems="center">
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <DateTimePicker
                     inputFormat="YYYY/MM/DD HH:mm"
                     label="Expiration Date (future date)"
@@ -114,7 +114,7 @@ export default function GTeamInvitationModal(props) {
                     value={data.expiration}
                   />
                 </Grid>
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <Box display="flex" flexDirection="column" justifyContent="center">
                     <Typography>Max uses: {data.max_uses || "unlimited"}</Typography>
                     <Box mx={1}>
@@ -128,6 +128,7 @@ export default function GTeamInvitationModal(props) {
                         min={0}
                         onChange={(_, value) => setData({ ...data, max_uses: value })}
                         value={data.max_uses}
+                        sx={{ width: "100%" }}
                       />
                     </Box>
                   </Box>

--- a/web/src/components/PTeamCreationModal.jsx
+++ b/web/src/components/PTeamCreationModal.jsx
@@ -6,6 +6,7 @@ import {
   Typography,
   IconButton,
   Dialog,
+  DialogActions,
   DialogContent,
   DialogTitle,
 } from "@mui/material";
@@ -17,6 +18,7 @@ import { useNavigate } from "react-router-dom";
 
 import { getUser } from "../slices/user";
 import { createPTeam } from "../utils/api";
+import { modalCommonButtonStyle } from "../utils/const";
 
 export default function PTeamCreationModal(props) {
   const { open, setOpen, closeTeamSelector } = props;
@@ -92,16 +94,13 @@ export default function PTeamCreationModal(props) {
               onChange={(event) => setSlackUrl(event.target.value)}
               margin="dense"
             ></TextField>
-            <Button
-              onClick={handleCreate}
-              color="success"
-              variant="contained"
-              disabled={!pteamName}
-            >
-              Create
-            </Button>
           </Box>
         </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCreate} disabled={!pteamName} sx={modalCommonButtonStyle}>
+            Create
+          </Button>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/components/PTeamInvitationModal.jsx
+++ b/web/src/components/PTeamInvitationModal.jsx
@@ -77,7 +77,7 @@ export default function PTeamInvitationModal(props) {
       <Button onClick={handleOpen} sx={commonButtonStyle}>
         {text}
       </Button>
-      <Dialog open={open} PaperProps={{ sx: { minWidth: "600px", maxWidth: "95%" } }}>
+      <Dialog open={open} fullWidth>
         <DialogTitle>
           <Typography variant="inherit">Create New Invitation Link</Typography>
         </DialogTitle>
@@ -97,7 +97,7 @@ export default function PTeamInvitationModal(props) {
               </Box>
             ) : (
               <Grid container alignItems="center">
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <DateTimePicker
                     inputFormat="YYYY/MM/DD HH:mm"
                     label="Expiration Date (future date)"
@@ -112,7 +112,7 @@ export default function PTeamInvitationModal(props) {
                     value={data.expiration}
                   />
                 </Grid>
-                <Grid item p={1} xs={12} sm={6}>
+                <Grid item p={1} xs={6} sm={6}>
                   <Box display="flex" flexDirection="column" justifyContent="center">
                     <Typography>Max uses: {data.max_uses || "unlimited"}</Typography>
                     <Box mx={1}>
@@ -126,6 +126,7 @@ export default function PTeamInvitationModal(props) {
                         min={0}
                         onChange={(_, value) => setData({ ...data, max_uses: value })}
                         value={data.max_uses}
+                        sx={{ width: "100%" }}
                       />
                     </Box>
                   </Box>

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -446,172 +446,169 @@ export default function TopicModal(props) {
               </Box>
             )}
             {activeStep === 1 && (
-              <Box display="flex" flexDirection="row" m={1}>
-                <Box display="flex" flexDirection="column" m={1}>
-                  <Box display="flex" flexDirection="row" mb={1}>
-                    <Box mr={2}>
-                      <Typography sx={{ fontWeight: 900 }} mb={1}>
-                        Title
-                      </Typography>
-                      <TextField
-                        size="small"
-                        required
-                        variant="outlined"
-                        value={title}
-                        onChange={(event) => {
-                          setTitle(event.target.value);
-                          updateErrors("title", event.target.value, validateNotEmpty);
-                        }}
-                        error={!validateNotEmpty(title)}
-                        sx={{ minWidth: "360px" }}
-                      />
-                    </Box>
-                    <Box>
-                      <Typography sx={{ fontWeight: 900 }} mb={2}>
-                        Topic ID(UUID)
-                      </Typography>
-                      <Typography>{topicId}</Typography>
-                    </Box>
-                  </Box>
-                  <Box mb={1}>
+              <Box display="flex" flexDirection="column" m={1}>
+                {/* <Box display="flex" flexDirection="column" m={1}> */}
+                <Box display="flex" flexDirection="row" mb={1}>
+                  <Box mr={2} sx={{ width: "50%" }}>
                     <Typography sx={{ fontWeight: 900 }} mb={1}>
-                      Abstract
+                      Title
                     </Typography>
                     <TextField
                       size="small"
-                      multiline
+                      required
                       variant="outlined"
-                      value={abst}
+                      value={title}
                       onChange={(event) => {
-                        setAbst(event.target.value);
+                        setTitle(event.target.value);
+                        updateErrors("title", event.target.value, validateNotEmpty);
                       }}
-                      sx={{ minWidth: "480px" }}
+                      error={!validateNotEmpty(title)}
+                      // sx={{ minWidth: "450px" }}
+                      sx={{ width: "100%" }}
+                    />
+                  </Box>
+                  <Box>
+                    <Typography sx={{ fontWeight: 900 }} mb={2}>
+                      Topic ID(UUID)
+                    </Typography>
+                    <Typography>{topicId}</Typography>
+                  </Box>
+                </Box>
+                <Box mb={1}>
+                  <Typography sx={{ fontWeight: 900 }} mb={1}>
+                    Abstract
+                  </Typography>
+                  <TextField
+                    size="small"
+                    multiline
+                    variant="outlined"
+                    value={abst}
+                    onChange={(event) => {
+                      setAbst(event.target.value);
+                    }}
+                    // sx={{ minWidth: "830px" }}
+                    sx={{ width: "99%" }}
+                  />
+                </Box>
+                <Box mb={1}>
+                  <Typography sx={{ fontWeight: 900 }} mb={1}>
+                    Threat impact
+                  </Typography>
+                  <ButtonGroup variant="outlined">
+                    {[1, 2, 3, 4].map((impact) => (
+                      <Button key={impact} variant="text" onClick={() => setThreatImpact(impact)}>
+                        <ThreatImpactChip
+                          threatImpact={impact}
+                          reverse={parseInt(threatImpact) !== impact}
+                          sx={{ cursor: "pointer" }}
+                        />
+                      </Button>
+                    ))}
+                  </ButtonGroup>
+                </Box>
+                <Box mb={1}>
+                  <Box display="flex" flexDirection="row" alignItems="center" mb={1}>
+                    <Typography sx={{ fontWeight: 900 }}>Actions</Typography>
+                    <ActionGeneratorModal />
+                  </Box>
+                  {actions?.length > 0 || (
+                    <Box
+                      display="flex"
+                      flexDirection="row"
+                      alignItems="center"
+                      sx={{ color: grey[500] }}
+                    >
+                      <ContentPasteIcon fontSize="small" sx={{ mr: 0.5 }} />
+                      <Typography variant="body2">Please add action</Typography>
+                    </Box>
+                  )}
+                  {actions
+                    .slice()
+                    .sort(
+                      (a, b) =>
+                        actionTypes.indexOf(a.action_type) - actionTypes.indexOf(b.action_type)
+                    )
+                    .map((action, idx) => (
+                      <Box key={idx} display="flex" flexDirection="row" alignItems="center" mb={1}>
+                        <ActionItem
+                          key={idx}
+                          action={action.action}
+                          actionId={action.action_id}
+                          actionType={action.action_type}
+                          recommended={action.recommended}
+                          zones={action.zones}
+                          ext={action.ext}
+                          onChangeRecommended={() =>
+                            setActions(
+                              actions.map((item) =>
+                                item !== action ? item : { ...item, recommended: !item.recommended }
+                              )
+                            )
+                          }
+                          onDelete={() => setActions(actions.filter((item) => item !== action))}
+                          sx={{ flexGrow: 1 }}
+                        />
+                        <IconButton
+                          onClick={() => {
+                            setEditActionTarget(action);
+                            setEditActionOpen(true);
+                          }}
+                        >
+                          <EditIcon />
+                        </IconButton>
+                      </Box>
+                    ))}
+                </Box>
+                <Box mb={1}>
+                  <Box mb={1}>
+                    <Box display="flex" flexDirection="row" alignItems="center">
+                      <Typography sx={{ fontWeight: 900 }}>Artifact Tags</Typography>
+                      <TopicTagSelectorModal />
+                    </Box>
+                    <TextField
+                      size="small"
+                      variant="outlined"
+                      value={allTags
+                        .filter((tag) => tagIds.includes(tag.tag_id))
+                        .map((tag) => tag.tag_name)
+                        .join(", ")}
+                      // sx={{ minWidth: "830px" }}
+                      sx={{ width: "99%" }}
+                      inputProps={{ readOnly: true }}
                     />
                   </Box>
                   <Box mb={1}>
-                    <Typography sx={{ fontWeight: 900 }} mb={1}>
-                      Threat impact
+                    <Box display="flex" flexDirection="row" alignItems="center">
+                      <Typography sx={{ fontWeight: 900 }}>Zones</Typography>
+                      <ZoneSelectorModal
+                        currentZoneNames={zoneNames}
+                        onApply={(ary) => setZoneNames(ary)}
+                      />
+                    </Box>
+                    <TextField
+                      size="small"
+                      variant="outlined"
+                      value={zoneNames.slice().sort().join(", ")}
+                      // sx={{ minWidth: "830px" }}
+                      sx={{ width: "99%" }}
+                      inputProps={{ readOnly: true }}
+                    />
+                  </Box>
+                  <Box>
+                    <Typography sx={{ fontWeight: 900, mt: "7px", mb: 1.7 }}>
+                      Misp Tags (CSV)
                     </Typography>
-                    <ButtonGroup variant="outlined">
-                      {[1, 2, 3, 4].map((impact) => (
-                        <Button key={impact} variant="text" onClick={() => setThreatImpact(impact)}>
-                          <ThreatImpactChip
-                            threatImpact={impact}
-                            reverse={parseInt(threatImpact) !== impact}
-                            sx={{ cursor: "pointer" }}
-                          />
-                        </Button>
-                      ))}
-                    </ButtonGroup>
-                  </Box>
-                  <Box mb={1}>
-                    <Box display="flex" flexDirection="row" alignItems="center" mb={1}>
-                      <Typography sx={{ fontWeight: 900 }}>Actions</Typography>
-                      <ActionGeneratorModal />
-                    </Box>
-                    {actions?.length > 0 || (
-                      <Box
-                        display="flex"
-                        flexDirection="row"
-                        alignItems="center"
-                        sx={{ color: grey[500] }}
-                      >
-                        <ContentPasteIcon fontSize="small" sx={{ mr: 0.5 }} />
-                        <Typography variant="body2">Please add action</Typography>
-                      </Box>
-                    )}
-                    {actions
-                      .slice()
-                      .sort(
-                        (a, b) =>
-                          actionTypes.indexOf(a.action_type) - actionTypes.indexOf(b.action_type)
-                      )
-                      .map((action, idx) => (
-                        <Box
-                          key={idx}
-                          display="flex"
-                          flexDirection="row"
-                          alignItems="center"
-                          mb={1}
-                        >
-                          <ActionItem
-                            key={idx}
-                            action={action.action}
-                            actionId={action.action_id}
-                            actionType={action.action_type}
-                            recommended={action.recommended}
-                            zones={action.zones}
-                            ext={action.ext}
-                            onChangeRecommended={() =>
-                              setActions(
-                                actions.map((item) =>
-                                  item !== action
-                                    ? item
-                                    : { ...item, recommended: !item.recommended }
-                                )
-                              )
-                            }
-                            onDelete={() => setActions(actions.filter((item) => item !== action))}
-                            sx={{ flexGrow: 1 }}
-                          />
-                          <IconButton
-                            onClick={() => {
-                              setEditActionTarget(action);
-                              setEditActionOpen(true);
-                            }}
-                          >
-                            <EditIcon />
-                          </IconButton>
-                        </Box>
-                      ))}
-                  </Box>
-                  <Box mb={1}>
-                    <Box mr={2} mb={1}>
-                      <Box display="flex" flexDirection="row" alignItems="center">
-                        <Typography sx={{ fontWeight: 900 }}>Artifact Tags</Typography>
-                        <TopicTagSelectorModal />
-                      </Box>
-                      <TextField
-                        size="small"
-                        variant="outlined"
-                        value={allTags
-                          .filter((tag) => tagIds.includes(tag.tag_id))
-                          .map((tag) => tag.tag_name)
-                          .join(", ")}
-                        sx={{ minWidth: "720px" }}
-                        inputProps={{ readOnly: true }}
-                      />
-                    </Box>
-                    <Box mr={2} mb={1}>
-                      <Box display="flex" flexDirection="row" alignItems="center">
-                        <Typography sx={{ fontWeight: 900 }}>Zones</Typography>
-                        <ZoneSelectorModal
-                          currentZoneNames={zoneNames}
-                          onApply={(ary) => setZoneNames(ary)}
-                        />
-                      </Box>
-                      <TextField
-                        size="small"
-                        variant="outlined"
-                        value={zoneNames.slice().sort().join(", ")}
-                        sx={{ minWidth: "720px" }}
-                        inputProps={{ readOnly: true }}
-                      />
-                    </Box>
-                    <Box>
-                      <Typography sx={{ fontWeight: 900, mt: "7px", mb: 1.7 }}>
-                        Misp Tags (CSV)
-                      </Typography>
-                      <TextField
-                        size="small"
-                        variant="outlined"
-                        value={mispTags}
-                        onChange={(event) => setMispTags(event.target.value)}
-                        sx={{ minWidth: "720px" }}
-                      />
-                    </Box>
+                    <TextField
+                      size="small"
+                      variant="outlined"
+                      value={mispTags}
+                      onChange={(event) => setMispTags(event.target.value)}
+                      // sx={{ minWidth: "720px" }}
+                      sx={{ width: "99%" }}
+                    />
                   </Box>
                 </Box>
+                {/* </Box> */}
               </Box>
             )}
             <Box sx={{ display: "flex", flexDirection: "row", pt: 2 }}>

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -12,7 +12,7 @@ import { avatarGroupStyle, difficulty, noATeamMessage, experienceColors } from "
 import { a11yProps } from "../utils/func.js";
 
 export default function ATeam() {
-  const [filterMode, setFilterMode] = useState("ateam");
+  const [filterMode, setFilterMode] = useState("ATeam");
   const [tabValue, setTabValue] = useState(0);
 
   const user = useSelector((state) => state.user.user);
@@ -24,7 +24,7 @@ export default function ATeam() {
 
   const dispatch = useDispatch();
 
-  const filterModes = ["all", "ateam"];
+  const filterModes = ["All", "ATeam"];
 
   useEffect(() => {
     if (!ateamId) return;
@@ -36,9 +36,9 @@ export default function ATeam() {
 
   const handleFilter = (achievement) => {
     switch (filterMode) {
-      case "ateam":
+      case "ATeam":
         return achievement.ateam_id === ateamId;
-      case "all":
+      case "All":
       default:
         return true;
     }

--- a/web/src/pages/PTeam.jsx
+++ b/web/src/pages/PTeam.jsx
@@ -12,7 +12,7 @@ import { avatarGroupStyle, experienceColors, difficulty, noPTeamMessage } from "
 import { a11yProps } from "../utils/func.js";
 
 export default function PTeam() {
-  const [filterMode, setFilterMode] = useState("pteam");
+  const [filterMode, setFilterMode] = useState("PTeam");
   const [tabValue, setTabValue] = useState(0);
 
   const user = useSelector((state) => state.user.user);
@@ -35,13 +35,13 @@ export default function PTeam() {
     return (authorities?.find((x) => x.user_id === userId)?.authorities ?? []).includes("admin");
   };
 
-  const filterModes = ["all", "pteam"];
+  const filterModes = ["All", "PTeam"];
 
   const handleFilter = (achievement) => {
     switch (filterMode) {
-      case "pteam":
+      case "PTeam":
         return achievement.pteam_id === pteamId;
-      case "all":
+      case "All":
       default:
         return true;
     }


### PR DESCRIPTION
## PR の目的

- 全ての画面において、余白やモーダル幅などを調整した


## 経緯・意図・意思決定
- PTeam /Cteate Topic
　- モーダル幅に対して中のコンテンツ幅が中途半端な位置だったので、いっぱいに広がるように調整

- ATeam,PTeam/Filter
　- フィルター内の選択が小文字だったので先頭大文字に変更

-  ATeam,PTeam,GTeam/Createモーダル
　- ボタンデザインが他のモーダルと異なっていたので、統一するよう調整

- ATeam,PTeam,GTeam/メンバー招待モーダル
　- 画面を小さくした時にモーダル幅が可変にならなかったのを修正。それに伴い、中身のコンテンツ幅も修正

- ATeam/NewTopic
　- 画面を小さくした時にモーダル幅が可変にならなかったのを修正。それに伴い、中身のコンテンツ幅も修正

## 参考文献
デザイン参照：https://docs.google.com/presentation/d/1WUTwacC1T2mYytEmsWoRaWTO5zi9oyKVKFj-JEby_XA/edit?usp=sharing

P7から本PR該当箇所