### PR TITLE
Topic/get uid from firebase token

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -34,10 +34,10 @@ def create_user(
     """
     verify_id_token(token)
     decoded_token = auth.verify_id_token(token.credentials)
-    uid = decoded_token['uid']
+    uid = decoded_token["uid"]
     if db.query(models.Account).filter(models.Account.email == data.email).first():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
-    user = models.Account(uid = uid, **data.model_dump())
+    user = models.Account(uid=uid, **data.model_dump())
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import HTTPAuthorizationCredentials
+from firebase_admin import auth
 from sqlalchemy.orm import Session, selectinload
 
 from app import models, schemas
@@ -32,9 +33,11 @@ def create_user(
     Create a user.
     """
     verify_id_token(token)
+    decoded_token = auth.verify_id_token(token.credentials)
+    uid = decoded_token['uid']
     if db.query(models.Account).filter(models.Account.email == data.email).first():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
-    user = models.Account(**data.model_dump())
+    user = models.Account(uid = uid, **data.model_dump())
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import HTTPAuthorizationCredentials
-from firebase_admin import auth
 from sqlalchemy.orm import Session, selectinload
 
 from app import models, schemas
@@ -32,8 +31,7 @@ def create_user(
     """
     Create a user.
     """
-    verify_id_token(token)
-    decoded_token = auth.verify_id_token(token.credentials)
+    decoded_token = verify_id_token(token)
     uid = decoded_token["uid"]
     if db.query(models.Account).filter(models.Account.email == data.email).first():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -140,7 +140,6 @@ class UserResponse(ORMModel):
 
 class UserCreateRequest(ORMModel):
     email: str
-    uid: str
     years: int = 0
 
 

--- a/api/app/tests/medium/constants.py
+++ b/api/app/tests/medium/constants.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 USER1 = {  # see firebase/data-test/auth_export/accounts.json
     "email": "test1@example.com",
     "pass": "testpass1",  # see tail of passwordHash on accounts.json
-    "uid": "2TXjRSTVkhjq4sbGOesYUJWdKwzj",  # localId on accounts.json
     "disabled": False,
     "years": 2,
 }

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -4882,7 +4882,6 @@ def test_disable_pteam():
     assert user_response.status_code == 200
     data = user_response.json()
     assert data["email"] == USER1["email"]
-    assert data["uid"] == USER1["uid"]
     assert data["disabled"] == USER1["disabled"]
     assert data["years"] == USER1["years"]
     assert len(data["pteams"]) == 2

--- a/api/app/tests/medium/routers/test_users.py
+++ b/api/app/tests/medium/routers/test_users.py
@@ -20,7 +20,6 @@ client = TestClient(app)
 def test_create_user():
     user1 = create_user(USER1)
     assert user1.email == USER1["email"]
-    assert user1.uid == USER1["uid"]
     assert user1.years == USER1["years"]
     assert user1.user_id != ZERO_FILLED_UUID
     assert user1.favorite_badge is None
@@ -35,7 +34,6 @@ def test_duplicate_user():
 def test_create_user_without_auth():
     request = {
         "email": USER1["email"],
-        "uid": USER1["uid"],
     }
     response = client.post("/users", json=request)  # no headers
     assert response.status_code == 401
@@ -66,14 +64,14 @@ def test_delete_user():
 
 
 def test_get_my_user_with_refresh():
-    create_user(USER1)
+    user1 = create_user(USER1)
     old = get_access_token(USER1["email"], USER1["pass"])
     _headers = refresh_headers(old["refresh_token"])
     response = client.get("/users/me", headers=_headers)
     assert response.status_code == 200
     user = response.json()
     assert user["email"] == USER1["email"]
-    assert user["uid"] == USER1["uid"]
+    assert user["uid"] == user1.uid
     assert user["disabled"] == USER1["disabled"]
     assert user["years"] == USER1["years"]
 

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -91,7 +91,7 @@ export default function Login() {
       data.get("password")
     );
     if (userCredential === undefined) return;
-    const { accessToken, email, uid } = userCredential.user;
+    const { accessToken, email } = userCredential.user;
     setToken(accessToken);
     setCookie(authCookieName, accessToken, cookiesOptions);
     try {
@@ -113,7 +113,7 @@ export default function Login() {
           break;
         }
         case "No such user":
-          await createUser({ email, uid }); // other values are default
+          await createUser({ email }); // other values are default
           // TODO: navigate to the first time login page, or say hello on snackbar.
           navigate("/account", {
             state: {


### PR DESCRIPTION
## PR の目的
- create_userの際、uidをfirebase tokenから取得するのに対応

## 経緯・意図・意思決定
- 既存ユーザのuidと同じuidを登録できないようにするために、uidをfirebase tokenから取得するように変更
- create_userのapiで今までリクエストで送られてきたuidをAccoutデーブルに登録していたのをfirebase tokenから取得したuidを登録するように変更(api/app/routers/users.py)
- リクエストに含まれるuidを削除しました(api/app/schemas.py)
- create_userのapiの変更するのに伴いテストケースを修正しました(api/app/tests/medium/constants.py, api/app/tests/medium/routers/test_users.py, api/app/tests/medium/routers/test_users.py)
- フロントエンドのログインでuidに該当する部分を削除しました(web/src/pages/Login.jsx)
