### PR TITLE
Topic/get email from firebase token

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -33,9 +33,10 @@ def create_user(
     """
     decoded_token = verify_id_token(token)
     uid = decoded_token["uid"]
-    if db.query(models.Account).filter(models.Account.email == data.email).first():
+    email = decoded_token["email"]
+    if db.query(models.Account).filter(models.Account.email == email).first():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
-    user = models.Account(uid=uid, **data.model_dump())
+    user = models.Account(uid=uid, email=email, **data.model_dump())
     db.add(user)
     db.commit()
     db.refresh(user)

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -139,7 +139,6 @@ class UserResponse(ORMModel):
 
 
 class UserCreateRequest(ORMModel):
-    email: str
     years: int = 0
 
 

--- a/api/app/tests/medium/routers/test_users.py
+++ b/api/app/tests/medium/routers/test_users.py
@@ -32,10 +32,7 @@ def test_duplicate_user():
 
 
 def test_create_user_without_auth():
-    request = {
-        "email": USER1["email"],
-    }
-    response = client.post("/users", json=request)  # no headers
+    response = client.post("/users", json={})  # no headers
     assert response.status_code == 401
     assert response.reason_phrase == "Unauthorized"
 

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -50,6 +50,7 @@ def random_string(number: int) -> str:
 
 def create_user(user: dict) -> schemas.UserResponse:
     request = {**user}
+    del request["email"]
     del request["pass"]
 
     response = client.post("/users", headers=headers(user), json=request)

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -91,7 +91,7 @@ export default function Login() {
       data.get("password")
     );
     if (userCredential === undefined) return;
-    const { accessToken, email } = userCredential.user;
+    const { accessToken } = userCredential.user;
     setToken(accessToken);
     setCookie(authCookieName, accessToken, cookiesOptions);
     try {
@@ -113,7 +113,7 @@ export default function Login() {
           break;
         }
         case "No such user":
-          await createUser({ email }); // other values are default
+          await createUser({}); // other values are default
           // TODO: navigate to the first time login page, or say hello on snackbar.
           navigate("/account", {
             state: {


### PR DESCRIPTION
## PR の目的
- create_userの際、emailをfirebase tokenから取得すのに対応

## 経緯・意図・意思決定
- emailを任意の値で登録できるためfirebase のemailと変えて登録できないように、emaiilをfirebase tokenから取得するように変更
- create_userのapiで今までリクエストで送られてきたemailをAccoutデーブルに登録していたのをfirebase tokenから取得したemailを登録するように変更(api/app/routers/users.py)
- リクエストに含まれるemailを削除しました(api/app/schemas.py)
- create_userのapiの変更するのに伴いテストケースを修正しました(api/app/tests/medium/utils.py, api/app/tests/medium/routers/test_users.py)
- フロントエンドのログイン部分でemailに該当する部分を削除しました(web/src/pages/Login.jsx)


## 参考文献
