### PR TITLE
Changed from modal to dialog

### DIFF
--- a/web/src/components/ATeamMemberMenu.jsx
+++ b/web/src/components/ATeamMemberMenu.jsx
@@ -3,7 +3,7 @@ import {
   MoreVert as MoreVertIcon,
   PersonOff as PersonOffIcon,
 } from "@mui/icons-material";
-import { Box, Button, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -11,7 +11,6 @@ import { useDispatch, useSelector } from "react-redux";
 import ATeamAuthEditor from "../components/ATeamAuthEditor";
 import ATeamMemberRemove from "../components/ATeamMemberRemove";
 import { getUser } from "../slices/user";
-import { sxModal } from "../utils/const";
 
 export default function ATeamMemberMenu(props) {
   const { userId, userEmail, isAdmin } = props;
@@ -37,14 +36,6 @@ export default function ATeamMemberMenu(props) {
   const handleRemoveMember = () => {
     handleClose();
     setOpenRemove(true);
-  };
-
-  const sxAuthModal = {
-    ...sxModal,
-    minWidth: "800px",
-  };
-  const sxRemoveModal = {
-    ...sxModal,
   };
 
   if (!userMe || !ateamId || !ateam || !authorities) return <></>;
@@ -76,21 +67,21 @@ export default function ATeamMemberMenu(props) {
         {(isAdmin || userId === userMe.user_id) && (
           <MenuItem onClick={handleRemoveMember}>
             <PersonOffIcon sx={{ mr: 1 }} />
-            Remove from ateam
+            Remove from ATeam
           </MenuItem>
         )}
       </Menu>
-      <Modal open={openAuth}>
-        <Box sx={sxAuthModal}>
+      <Dialog open={openAuth}>
+        <DialogContent>
           <ATeamAuthEditor
             userId={userId}
             userEmail={userEmail}
             onClose={() => setOpenAuth(false)}
           />
-        </Box>
-      </Modal>
-      <Modal open={openRemove}>
-        <Box sx={sxRemoveModal}>
+        </DialogContent>
+      </Dialog>
+      <Dialog fullWidth open={openRemove}>
+        <DialogContent>
           <ATeamMemberRemove
             userId={userId}
             userName={userEmail}
@@ -101,8 +92,8 @@ export default function ATeamMemberMenu(props) {
               setOpenRemove(false);
             }}
           />
-        </Box>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/components/ATeamMemberRemove.jsx
+++ b/web/src/components/ATeamMemberRemove.jsx
@@ -36,7 +36,7 @@ export default function ATeamMemberRemove(props) {
   return (
     <>
       <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
+      <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
         <Typography>Are you sure you want to remove </Typography>
         <Typography
           variant="h6"

--- a/web/src/components/ATeamWatchingMenu.jsx
+++ b/web/src/components/ATeamWatchingMenu.jsx
@@ -1,12 +1,11 @@
 import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
-import { Box, Button, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
 import ATeamWatchingStop from "../components/ATeamWatchingStop";
 import { getATeam } from "../slices/ateam";
-import { sxModal } from "../utils/const";
 
 export default function ATeamWatchingMenu(props) {
   const { ateam, watchingPteamId, watchingPteamName, isAdmin } = props;
@@ -56,8 +55,8 @@ export default function ATeamWatchingMenu(props) {
       ) : (
         <></>
       )}
-      <Modal open={openRemove}>
-        <Box sx={sxModal}>
+      <Dialog open={openRemove}>
+        <DialogContent>
           <ATeamWatchingStop
             watchingPteamId={watchingPteamId}
             watchingPteamName={watchingPteamName}
@@ -68,8 +67,8 @@ export default function ATeamWatchingMenu(props) {
               setOpenRemove(false);
             }}
           />
-        </Box>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/components/GTeamMemberMenu.jsx
+++ b/web/src/components/GTeamMemberMenu.jsx
@@ -3,7 +3,7 @@ import {
   MoreVert as MoreVertIcon,
   PersonOff as PersonOffIcon,
 } from "@mui/icons-material";
-import { Box, Button, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -11,7 +11,6 @@ import { useDispatch, useSelector } from "react-redux";
 import GTeamAuthEditor from "../components/GTeamAuthEditor";
 import GTeamMemberRemove from "../components/GTeamMemberRemove";
 import { getUser } from "../slices/user";
-import { sxModal } from "../utils/const";
 
 export default function GTeamMemberMenu(props) {
   const { userId, userEmail, isAdmin } = props;
@@ -37,14 +36,6 @@ export default function GTeamMemberMenu(props) {
   const handleRemoveMember = () => {
     handleClose();
     setOpenRemove(true);
-  };
-
-  const sxAuthModal = {
-    ...sxModal,
-    minWidth: "800px",
-  };
-  const sxRemoveModal = {
-    ...sxModal,
   };
 
   if (!userMe || !gteamId || !gteam || !authorities) return <></>;
@@ -76,21 +67,21 @@ export default function GTeamMemberMenu(props) {
         {(isAdmin || userId === userMe.user_id) && (
           <MenuItem onClick={handleRemoveMember}>
             <PersonOffIcon sx={{ mr: 1 }} />
-            Remove from gteam
+            Remove from GTeam
           </MenuItem>
         )}
       </Menu>
-      <Modal open={openAuth}>
-        <Box sx={sxAuthModal}>
+      <Dialog open={openAuth}>
+        <DialogContent>
           <GTeamAuthEditor
             userId={userId}
             userEmail={userEmail}
             onClose={() => setOpenAuth(false)}
           />
-        </Box>
-      </Modal>
-      <Modal open={openRemove}>
-        <Box sx={sxRemoveModal}>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={openRemove}>
+        <DialogContent>
           <GTeamMemberRemove
             userId={userId}
             userName={userEmail}
@@ -101,8 +92,8 @@ export default function GTeamMemberMenu(props) {
               setOpenRemove(false);
             }}
           />
-        </Box>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/components/GTeamMemberRemove.jsx
+++ b/web/src/components/GTeamMemberRemove.jsx
@@ -35,7 +35,7 @@ export default function GTeamMemberRemove(props) {
   return (
     <>
       <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
+      <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
         <Typography>Are you sure you want to remove </Typography>
         <Typography
           variant="h6"

--- a/web/src/components/PTeamMemberMenu.jsx
+++ b/web/src/components/PTeamMemberMenu.jsx
@@ -3,7 +3,7 @@ import {
   MoreVert as MoreVertIcon,
   PersonOff as PersonOffIcon,
 } from "@mui/icons-material";
-import { Box, Button, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -11,7 +11,6 @@ import { useDispatch, useSelector } from "react-redux";
 import PTeamAuthEditor from "../components/PTeamAuthEditor";
 import PTeamMemberRemove from "../components/PTeamMemberRemove";
 import { getUser } from "../slices/user";
-import { sxModal } from "../utils/const";
 
 export default function PTeamMemberMenu(props) {
   const { userId, userEmail, isAdmin } = props;
@@ -37,14 +36,6 @@ export default function PTeamMemberMenu(props) {
   const handleRemoveMember = () => {
     handleClose();
     setOpenRemove(true);
-  };
-
-  const sxAuthModal = {
-    ...sxModal,
-    minWidth: "800px",
-  };
-  const sxRemoveModal = {
-    ...sxModal,
   };
 
   if (!userMe || !pteamId || !pteam || !authorities) return <></>;
@@ -76,21 +67,21 @@ export default function PTeamMemberMenu(props) {
         {(isAdmin || userId === userMe.user_id) && (
           <MenuItem onClick={handleRemoveMember}>
             <PersonOffIcon sx={{ mr: 1 }} />
-            Remove from pteam
+            Remove from PTeam
           </MenuItem>
         )}
       </Menu>
-      <Modal open={openAuth}>
-        <Box sx={sxAuthModal}>
+      <Dialog open={openAuth}>
+        <DialogContent>
           <PTeamAuthEditor
             userId={userId}
             userEmail={userEmail}
             onClose={() => setOpenAuth(false)}
           />
-        </Box>
-      </Modal>
-      <Modal open={openRemove}>
-        <Box sx={sxRemoveModal}>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={openRemove}>
+        <DialogContent>
           <PTeamMemberRemove
             userId={userId}
             userName={userEmail}
@@ -101,8 +92,8 @@ export default function PTeamMemberMenu(props) {
               setOpenRemove(false);
             }}
           />
-        </Box>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/components/PTeamMemberRemove.jsx
+++ b/web/src/components/PTeamMemberRemove.jsx
@@ -36,7 +36,7 @@ export default function PTeamMemberRemove(props) {
   return (
     <>
       <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
+      <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
         <Typography>Are you sure you want to remove </Typography>
         <Typography
           variant="h6"

--- a/web/src/components/PTeamWatcherMenu.jsx
+++ b/web/src/components/PTeamWatcherMenu.jsx
@@ -1,12 +1,11 @@
 import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
-import { Box, Button, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
 import PTeamWatcherRemove from "../components/PTeamWatcherRemove";
 import { getPTeam } from "../slices/pteam";
-import { sxModal } from "../utils/const";
 
 export default function PTeamWatcherMenu(props) {
   const { pteam, watcherAteamId, watcherAteamName, isAdmin } = props;
@@ -56,8 +55,8 @@ export default function PTeamWatcherMenu(props) {
       ) : (
         <></>
       )}
-      <Modal open={openRemove}>
-        <Box sx={sxModal}>
+      <Dialog open={openRemove}>
+        <DialogContent>
           <PTeamWatcherRemove
             watcherAteamId={watcherAteamId}
             watcherAteamName={watcherAteamName}
@@ -68,8 +67,8 @@ export default function PTeamWatcherMenu(props) {
               setOpenRemove(false);
             }}
           />
-        </Box>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/web/src/components/TopicDeletion.jsx
+++ b/web/src/components/TopicDeletion.jsx
@@ -1,4 +1,4 @@
-import { Button, Box, Modal, Typography } from "@mui/material";
+import { Button, Box, Dialog, DialogContent, Typography } from "@mui/material";
 import { red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { getPTeamTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle, sxModal } from "../utils/const";
+import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
 
 export default function TopicDeletion(props) {
   const { topicId, setOpenTopicModal, onDelete } = props;
@@ -38,11 +38,6 @@ export default function TopicDeletion(props) {
     setOpenTopicModal(false);
   }
 
-  const style = {
-    ...sxModal,
-    maxWidth: "80%",
-  };
-
   return (
     <>
       <Button
@@ -58,13 +53,12 @@ export default function TopicDeletion(props) {
       >
         Delete Topic
       </Button>
-      <Modal hideBackdrop open={open} onClose={() => setOpen(false)}>
+      <Dialog hideBackdrop open={open} onClose={() => setOpen(false)}>
         <>
-          <Box sx={{ ...style }}>
+          <DialogContent>
             <Typography variant="h5">Confirm</Typography>
             <Typography>Are you sure you want to delete this topic?</Typography>
             <Typography>This deletion affects other pteams.</Typography>
-
             <Box display="flex">
               <Box flexGrow={1} />
               <Button onClick={() => setOpen(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
@@ -82,9 +76,9 @@ export default function TopicDeletion(props) {
                 Delete
               </Button>
             </Box>
-          </Box>
+          </DialogContent>
         </>
-      </Modal>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## PR の目的

- 一部で＜Modal＞で実装されていたものを＜Dialog＞での実装に変更する
- 対象ファイルは以下
  - ATeamMemberMenu.jsx
  - ATeamMemberRemove.jsx(Dialogに変更したら表示が崩れたので調整)
  - ATeamWatchingMenu.jsx
  - GTeamMemberMenu.jsx
  - GTeamMemberRemove.jsx(Dialogに変更したら表示が崩れたので調整)
  - PTeamMemberMenu.jsx
  - PTeamMemberRemove.jsx(Dialogに変更したら表示が崩れたので調整)
  - PTeamWatcherMenu.jsx
  - TopicDeletion.jsx

## 経緯・意図・意思決定
- 他のファイルではDialogを使用していたため
- 公式でDialogの使用を推奨されていたため
> If you are creating a modal dialog, you probably want to use the [Dialog](https://mui.com/material-ui/react-dialog/) component rather than directly using Modal. Modal is a lower-level construct that is leveraged by the following components:

## 参考文献
https://mui.com/material-ui/react-modal/
