### PR TITLE
Topic/use packaging version for pypi

### DIFF
--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -146,9 +146,9 @@ class TestComparableVersion:
         @pytest.mark.parametrize(
             "version_string, expected",
             # expected: Union[Tuple[int, int, int, tuple], str]
-            #           -- (epoch,release,pre,dev,local) or exception
+            #           -- (epoch,release,pre,post,dev,local) or exception
             [
-                # might be tested in package version.
+                # might be tested in packaging version.
                 ("", "Invalid version: "),
                 ("a", "Invalid version: "),
                 ("a.1", "Invalid version: "),

--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.version import (
     ExtDebianVersion,
+    ExtPypiVersion,
     PackageFamily,
     SemverVersion,  # from univers
     VulnerableRange,
@@ -141,6 +142,115 @@ class TestComparableVersion:
                 return
             assert (debian_obj >= target_obj and debian_obj <= target_obj) == expected
 
+    class TestPypiVersion(_TestVersion):
+        @pytest.mark.parametrize(
+            "version_string, expected",
+            # expected: Union[Tuple[int, int, int, tuple], str]
+            #           -- (epoch,release,pre,dev,local) or exception
+            [
+                # might be tested in package version.
+                ("", "Invalid version: "),
+                ("a", "Invalid version: "),
+                ("a.1", "Invalid version: "),
+                (".", "Invalid version: "),
+                (".2", "Invalid version: "),
+                ("-1.2", "Invalid version: "),
+                ("1", (0, (1,), None, None, None, None)),
+                ("1.", "Invalid version: "),  # different from semver behavior
+                ("1.2", (0, (1, 2), None, None, None, None)),
+                ("1.2.", "Invalid version: "),  # different from semver behavior
+                ("1.2.3", (0, (1, 2, 3), None, None, None, None)),
+                ("1.2.3.", "Invalid version: "),  # different from semver behavior
+                ("1.2.3.4", (0, (1, 2, 3, 4), None, None, None, None)),  # CAUTION!
+                ("1.2.3-4", (0, (1, 2, 3), None, 4, None, None)),
+                ("1.2.3-4.5", "Invalid version: "),  # different from semver behavior
+                ("1.2.3-4-5", "Invalid version: "),  # different from semver behavior
+                ("1.2.3-rc4.alpha5", "Invalid version: "),
+                ("1.2.3-rc4+build5", (0, (1, 2, 3), ("rc", 4), None, None, "build5")),
+                ("2!1.2.3b4post6dev31+build5", (2, (1, 2, 3), ("b", 4), 6, 31, "build5")),
+                ("2021.06", (0, (2021, 6), None, None, None, None)),
+                ("0.5.0b3.dev31", (0, (0, 5, 0), ("b", 3), None, 31, None)),
+                ("2.0.0a1", (0, (2, 0, 0), ("a", 1), None, None, None)),
+                ("1!2.0.0", (1, (2, 0, 0), None, None, None, None)),
+            ],
+        )
+        def test_gen_instance(self, version_string, expected):
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    gen_version_instance(PackageFamily.PYPI, version_string)
+                return
+            pypi_obj = gen_version_instance(PackageFamily.PYPI, version_string)
+            assert isinstance(pypi_obj, ExtPypiVersion)
+            assert (
+                pypi_obj.epoch,
+                pypi_obj.release,
+                pypi_obj.pre,
+                pypi_obj.post,
+                pypi_obj.dev,
+                pypi_obj.local,
+            ) == expected
+
+        @pytest.mark.parametrize(
+            "left, right, operator, expected",
+            # left, right: version_strings to compare
+            # operator: one of "==", ">=", ">", "<=", "<".
+            # expected: Union[bool, str] -- expected result or exception
+            [
+                ("1.2", "1.2", "==", True),
+                ("1.2", "1.2", "<=", True),
+                ("1.2", "1.2", "<", False),
+                ("1.2", "1.2", ">=", True),
+                ("1.2", "1.2", ">", False),
+                ("1.2", "1.2.0", "==", True),  # different from debian
+                ("1.2", "1.2.0", "<", False),  # different from debian
+                ("1.2", "1.2.0", "<=", True),
+                ("1.2", "1.2.0", ">", False),
+                ("1.2", "1.2.0", ">=", True),
+                ("1.3", "1.2.3", "==", False),
+                ("1.3", "1.2.3", ">=", True),
+                ("1.3", "1.2.3", ">", True),
+                ("1.3", "1.2.3", "<=", False),
+                ("1.3", "1.2.3", "<", False),
+                ("1!1.2", "1.2", "==", True),  # epoch should be ignored
+                ("1!1.2", "1.2.0", "==", True),  # epoch should be ignored, different from debian
+                ("1!1.2", "1.2.0", "<", False),  # epoch should be ignored, different from debian
+                ("1!1.2", "1.2.0", "<=", True),  # epoch should be ignored
+                ("1!1.2", "1.2.0", ">", False),  # epoch should be ignored
+                ("1!1.2", "1.2.0", ">=", True),  # epoch should be ignored
+                ("1.2", "1!1.2", "==", True),  # epoch should be ignored
+                ("1.2", "1!1.2.0", "==", True),  # epoch should be ignored
+                ("1.2", "1!1.2.0", "<", False),  # epoch should be ignored
+                ("1.2", "1!1.2.0", "<=", True),  # epoch should be ignored
+                ("1.2", "1!1.2.0", ">", False),  # epoch should be ignored
+                ("1.2", "1!1.2.0", ">=", True),  # epoch should be ignored
+                ("0!2.3", "2.3", "==", True),
+                ("2.3", "0!2.3", "==", True),
+                ("1.2+abc", "1.2", "==", True),  # local should be ignored
+                ("1.2+abc", "1.2", "<", False),  # local should be ignored
+                ("1.2+abc", "1.2", "<=", True),  # local should be ignored
+                ("1.2+abc", "1.2", ">", False),  # local should be ignored
+                ("1.2+abc", "1.2", ">=", True),  # local should be ignored
+                ("1.2+abc", "1.2+xyz", "==", True),  # local should be ignored
+                ("1.2+abc", "1.2+xyz", "<", False),  # local should be ignored
+                ("1.2+abc", "1.2+xyz", "<=", True),  # local should be ignored
+                ("1.2+abc", "1.2+xyz", ">", False),  # local should be ignored
+                ("1.2+abc", "1.2+xyz", ">=", True),  # local should be ignored
+                ("3!1.2+abc", "4!1.2+xyz", "==", True),  # epoch & local should be ignored
+                ("3!1.2+abc", "4!1.2+xyz", "<", False),  # epoch & local should be ignored
+                ("3!1.2+abc", "4!1.2+xyz", "<=", True),  # epoch & local should be ignored
+                ("3!1.2+abc", "4!1.2+xyz", ">", False),  # epoch & local should be ignored
+                ("3!1.2+abc", "4!1.2+xyz", ">=", True),  # epoch & local should be ignored
+            ],
+        )
+        def test_compare(self, left, right, operator, expected):
+            left_obj = gen_version_instance(PackageFamily.PYPI, left)
+            right_obj = gen_version_instance(PackageFamily.PYPI, right)
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    self.eval_operator(left_obj, right_obj, operator)
+                return
+            assert self.eval_operator(left_obj, right_obj, operator) == expected
+
     class TestSemverVersion(_TestVersion):
         @pytest.mark.parametrize(
             "version_string, expected",
@@ -237,6 +347,7 @@ class TestVulnerableRange:
     def gen_preset_versions(self):
         self.semver_version1 = gen_version_instance(PackageFamily.UNKNOWN, "1.0")
         self.debian_version1 = gen_version_instance(PackageFamily.DEBIAN, "1.0")
+        self.pypi_version1 = gen_version_instance(PackageFamily.PYPI, "1.0")
 
     @pytest.mark.parametrize(
         "attrs",
@@ -259,6 +370,8 @@ class TestVulnerableRange:
         assert VulnerableRange(ge=self.debian_version1, lt=self.debian_version1)
         with pytest.raises(ValueError, match=r"Ambiguous "):
             VulnerableRange(ge=self.semver_version1, lt=self.debian_version1)
+        with pytest.raises(ValueError, match=r"Ambiguous "):
+            VulnerableRange(ge=self.pypi_version1, lt=self.debian_version1)
 
     class TestExtDebianVersion:
         @pytest.mark.parametrize(
@@ -301,11 +414,69 @@ class TestVulnerableRange:
             "package_family, version_string, expected",
             [
                 (PackageFamily.DEBIAN, "1.2.3", True),
+                (PackageFamily.PYPI, "1.2.3", "'==' not supported between instances of "),
                 (PackageFamily.UNKNOWN, "1.2.3", "'==' not supported between instances of "),
             ],
         )
         def test_with_different_family(self, package_family, version_string, expected):
             vulnerable = VulnerableRange.from_string(PackageFamily.DEBIAN, "=1.2.3")
+            target_obj = gen_version_instance(package_family, version_string)
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    assert vulnerable.detect_matched([target_obj])
+                return
+            assert vulnerable.detect_matched([target_obj]) == expected
+
+    class TestPypiVersion:
+        @pytest.mark.parametrize(
+            "references, vulnerable, expected",
+            [
+                (["9.50+build1"], "=9.50+build1", True),
+                (["9.50+build1"], "=9.50+build1", True),
+                (["9.50+build1"], "<=9.50+build1", True),
+                (["9.50+build1"], "<=9.50+build1", True),
+                (["9.50+build1"], "<9.50+build1", False),
+                (["9.50+build1"], "<9.50+build1", False),
+                (["9.50+build1"], ">=9.50+build1", True),
+                (["9.50+build1"], ">=9.50+build1", True),
+                (["9.50+build1"], ">9.50+build1", False),
+                (["9.50+build1"], ">9.50+build1", False),
+                (["0!9.50+build1"], "=9.50+5build1", True),
+                (["9.50+5build1"], "=1!9.50+5build1", True),
+                (["1!9.50+5build1"], "=9.50+5build1", True),
+                (["1!9.50+5build1"], "=2!9.50+5build1", True),
+                (["1!9.50+5build1"], "=1!9.50+5build1", True),
+                (["2.3.4"], ">=2.0.0 <2.3.4", False),
+                (["2.3.4"], ">=2.0.0 <2.3.5", True),
+                (["2.3.4"], ">=2.0.0 <=2.3.3", False),
+                (["2.3.4"], ">=2.0.0 <=2.3.4", True),
+                (["2.3.4"], ">=2.0.0 <2.3.4post1", True),  # CAUTION!
+                (["2.3.4"], ">=2.0.0 <2.3.4dev1", False),  # CAUTION!
+                (["2.3.4"], ">=2.0.0 <2.3.4pre1", False),  # CAUTION!
+                (["2.3.4post1"], ">=2.0.0 <2.3.4", False),  # CAUTION!
+                (["2.3.4pre1"], ">=2.0.0 <2.3.4", True),  # CAUTION!
+                (["2.3.4dev1+build1"], ">=2.0.0 <2.3.4dev1", False),
+            ],
+        )
+        def test_detect_matched(self, references, vulnerable, expected):
+            reference_objs = [gen_version_instance(PackageFamily.PYPI, ref) for ref in references]
+            vulnerable_range = VulnerableRange.from_string(PackageFamily.PYPI, vulnerable)
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    vulnerable_range.detect_matched(reference_objs)
+                return
+            assert vulnerable_range.detect_matched(reference_objs) == expected
+
+        @pytest.mark.parametrize(
+            "package_family, version_string, expected",
+            [
+                (PackageFamily.DEBIAN, "1.2.3", "'==' not supported between instances of "),
+                (PackageFamily.PYPI, "1.2.3", True),
+                (PackageFamily.UNKNOWN, "1.2.3", "'==' not supported between instances of "),
+            ],
+        )
+        def test_with_different_family(self, package_family, version_string, expected):
+            vulnerable = VulnerableRange.from_string(PackageFamily.PYPI, "=1.2.3")
             target_obj = gen_version_instance(package_family, version_string)
             if isinstance(expected, str):
                 with pytest.raises(ValueError, match=expected):
@@ -349,6 +520,7 @@ class TestVulnerableRange:
             "package_family, version_string, expected",
             [
                 (PackageFamily.DEBIAN, "1.2.3", "'==' not supported between instances of "),
+                (PackageFamily.PYPI, "1.2.3", "'==' not supported between instances of "),
                 (PackageFamily.UNKNOWN, "1.2.3", True),
             ],
         )

--- a/api/app/version.py
+++ b/api/app/version.py
@@ -65,7 +65,8 @@ class ExtPypiVersion(PypiVersion):
                 f"and '{other.__class__}'"
             )
 
-    def _remove_epoch(self, version_str: str):
+    @staticmethod
+    def _remove_epoch(version_str: str):
         return re.sub("[0-9]+!", "", version_str)
 
     # ignore epoch & local to compare.

--- a/api/app/version.py
+++ b/api/app/version.py
@@ -69,6 +69,7 @@ class ExtPypiVersion(PypiVersion):
         return re.sub("[0-9]+!", "", version_str)
 
     # ignore epoch & local to compare.
+    # PypiVersion.public is version string without `local`
 
     def __lt__(self, other):
         self._check_comparable(other, "<")

--- a/api/app/version.py
+++ b/api/app/version.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Set, TypeAlias, Union
 
+from packaging.version import Version as PypiVersion
 from univers.debian import Version as DebianVersion
 from univers.versions import SemverVersion
 
@@ -10,12 +11,15 @@ from univers.versions import SemverVersion
 class PackageFamily(Enum):
     UNKNOWN = 0
     DEBIAN = 1
+    PYPI = 2
 
     @classmethod
     def from_registry(cls, registry: str) -> "PackageFamily":
         fixed_registry = registry.lower()
         if re.match(r"^(debian|ubuntu)", fixed_registry):  # TODO: need maintenance
             return cls.DEBIAN
+        if re.match(r"^(pypi)", fixed_registry):
+            return cls.PYPI
         return cls.UNKNOWN
 
     @classmethod
@@ -53,12 +57,50 @@ class ExtDebianVersion(DebianVersion):
         return DebianVersion.from_string(self.upstream) >= DebianVersion.from_string(other.upstream)
 
 
+class ExtPypiVersion(PypiVersion):
+    def _check_comparable(self, other: Any, operator: str):
+        if not isinstance(other, self.__class__):
+            raise ValueError(
+                f"'{operator}' not supported between instances of '{self.__class__}' "
+                f"and '{other.__class__}'"
+            )
+
+    def _remove_epoch(self, version_str: str):
+        return re.sub("[0-9]+!", "", version_str)
+
+    # ignore epoch & local to compare.
+
+    def __lt__(self, other):
+        self._check_comparable(other, "<")
+        return PypiVersion(self._remove_epoch(self.public)) < PypiVersion(
+            self._remove_epoch(other.public)
+        )
+
+    def __gt__(self, other):
+        self._check_comparable(other, ">")
+        return PypiVersion(self._remove_epoch(self.public)) > PypiVersion(
+            self._remove_epoch(other.public)
+        )
+
+    def __le__(self, other):
+        self._check_comparable(other, "<=")
+        return PypiVersion(self._remove_epoch(self.public)) <= PypiVersion(
+            self._remove_epoch(other.public)
+        )
+
+    def __ge__(self, other):
+        self._check_comparable(other, ">=")
+        return PypiVersion(self._remove_epoch(self.public)) >= PypiVersion(
+            self._remove_epoch(other.public)
+        )
+
+
 # supported version classes:
 #   - should be hashable.
 #   - required implemented __gt__, __ge__, __lt__, __le__.
 #     Note: __eq__ cannot be used to compare versions. use >= and <= instead.
 #   - may raise ValueError on errors.
-ComparableVersion: TypeAlias = Union[ExtDebianVersion, SemverVersion]
+ComparableVersion: TypeAlias = Union[ExtDebianVersion, ExtPypiVersion, SemverVersion]
 
 
 def gen_version_instance(
@@ -67,6 +109,8 @@ def gen_version_instance(
 ) -> ComparableVersion:
     if package_family == PackageFamily.DEBIAN:
         return ExtDebianVersion.from_string(version_string)
+    if package_family == PackageFamily.PYPI:
+        return ExtPypiVersion(version_string)
     return SemverVersion(version_string)
 
 


### PR DESCRIPTION
## PR の目的
pypiのversion比較を、packaging versionを用いて行う

## 経緯・意図・意思決定
- pypiのversion比較を、packaging versionを用いて行う
- version比較は、epochとlocalを無視し、release,  post, dev, preは考慮するようにする

## 参考文献
