### PR TITLE
Topic/npm version compare

### DIFF
--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -341,7 +341,6 @@ class TestComparableVersion:
                 return
             assert (semver_obj >= target_obj and semver_obj <= target_obj) == expected
 
-
     class TestNpmVersion(_TestVersion):
         @pytest.mark.parametrize(
             "version_string, expected",
@@ -351,8 +350,8 @@ class TestComparableVersion:
                 # other cases are tested in TestSemverVersion
                 ("1.2.3", (1, 2, 3, ())),
                 ("1.2.x", (1, 2, 0, ())),
-                ("99.999.99999", (99,999,99999, ())),
-                ("2.1.0-M1", (2,1,0, ("M1"))),
+                ("99.999.99999", (99, 999, 99999, ())),
+                ("2.1.0-M1", (2, 1, 0, ("M1"))),
             ],
         )
         def test_gen_instance(self, version_string, expected):

--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -351,7 +351,7 @@ class TestComparableVersion:
                 ("1.2.3", (1, 2, 3, ())),
                 ("1.2.x", (1, 2, 0, ())),
                 ("99.999.99999", (99, 999, 99999, ())),
-                ("2.1.0-M1", (2, 1, 0, ("M1"))),
+                ("2.1.0-M1", (2, 1, 0, ("M1",))),
             ],
         )
         def test_gen_instance(self, version_string, expected):

--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -342,6 +342,29 @@ class TestComparableVersion:
             assert (semver_obj >= target_obj and semver_obj <= target_obj) == expected
 
 
+    class TestNpmVersion(_TestVersion):
+        @pytest.mark.parametrize(
+            "version_string, expected",
+            # expected: Union[Tuple[int, int, int, tuple], str]
+            #           -- (major, minor, patch, prerelease) or exception
+            [
+                # other cases are tested in TestSemverVersion
+                ("1.2.3", (1, 2, 3, ())),
+                ("1.2.x", (1, 2, 0, ())),
+                ("99.999.99999", (99,999,99999, ())),
+                ("2.1.0-M1", (2,1,0, ("M1"))),
+            ],
+        )
+        def test_gen_instance(self, version_string, expected):
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    gen_version_instance(PackageFamily.NPM, version_string)
+                return
+            sem_obj = gen_version_instance(PackageFamily.NPM, version_string)
+            assert isinstance(sem_obj, SemverVersion)
+            assert (sem_obj.major, sem_obj.minor, sem_obj.patch, sem_obj.prerelease) == expected
+
+
 class TestVulnerableRange:
     @pytest.fixture(scope="function", name="gen_preset_versions")
     def gen_preset_versions(self):

--- a/api/app/version.py
+++ b/api/app/version.py
@@ -12,6 +12,7 @@ class PackageFamily(Enum):
     UNKNOWN = 0
     DEBIAN = 1
     PYPI = 2
+    NPM = 3
 
     @classmethod
     def from_registry(cls, registry: str) -> "PackageFamily":
@@ -20,6 +21,8 @@ class PackageFamily(Enum):
             return cls.DEBIAN
         if re.match(r"^(pypi)", fixed_registry):
             return cls.PYPI
+        if re.match(r"^(npm)", fixed_registry):
+            return cls.NPM
         return cls.UNKNOWN
 
     @classmethod
@@ -113,6 +116,8 @@ def gen_version_instance(
         return ExtDebianVersion.from_string(version_string)
     if package_family == PackageFamily.PYPI:
         return ExtPypiVersion(version_string)
+    if package_family == PackageFamily.NPM:
+        return SemverVersion(version_string)
     return SemverVersion(version_string)
 
 


### PR DESCRIPTION
## PR の目的
npmのversion比較をuniversのsemverを用いるようにしました。

## 経緯・意図・意思決定

- [univers.NpmVersionRange](https://github.com/nexB/univers/blob/205d7c48835dfeb6b694c9196728d2b4fa0a011a/src/univers/version_range.py#L297) はあるが、versionの形式はSemver のため、univers SemverVersionを用いることとなった。
- 現状のコードでも、npmは`UNKNOWN`に判別され、Semverが適用されるが、`univers.SemverVersion`を明示的に用いるようにした。
- テストは、trivydbの npm にあった特殊なもののみを追加しました。他のテストケースは、`TestSemverVersion`やunivers自体で行っているため。


## 参考文献
