### PR TITLE
Remove unused slice function around watching

### DIFF
--- a/web/src/components/ATeamWatchingStop.jsx
+++ b/web/src/components/ATeamWatchingStop.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
-import { getWatchingPTeams } from "../slices/ateam";
+import { getATeam } from "../slices/ateam";
 import { removeWatchingPTeam } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
@@ -17,7 +17,7 @@ export function ATeamWatchingStop(props) {
 
   const handleRemove = async () => {
     function onSuccess(success) {
-      dispatch(getWatchingPTeams(ateamId));
+      dispatch(getATeam(ateamId));
       enqueueSnackbar(`Stop watching ${watchingPteamName} succeeded`, {
         variant: "success",
       });

--- a/web/src/components/PTeamWatcherRemoveModal.jsx
+++ b/web/src/components/PTeamWatcherRemoveModal.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
-import { getPTeamWatcher } from "../slices/pteam";
+import { getPTeam } from "../slices/pteam";
 import { removeWatcherATeam } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
@@ -17,7 +17,7 @@ export function PTeamWatcherRemoveModal(props) {
 
   const handleRemove = async () => {
     function onSuccess(success) {
-      dispatch(getPTeamWatcher(pteamId));
+      dispatch(getPTeam(pteamId));
       enqueueSnackbar(`Remove watcher ${watcherAteamName} succeeded`, {
         variant: "success",
       });

--- a/web/src/pages/AcceptATeamWatchingRequest.jsx
+++ b/web/src/pages/AcceptATeamWatchingRequest.jsx
@@ -42,6 +42,7 @@ export function AcceptATeamWatchingRequest() {
         `Now pteam '${pteam?.pteam_name}' is watched by ateam '${detail.ateam_name}'`,
         { variant: "info" }
       );
+      dispatch(getPTeam(pteamId));
       params.delete("token");
       params.set("pteamId", pteamId);
       navigate("/pteam?" + params.toString());

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -6,7 +6,6 @@ import {
   getATeamAuthInfo as apiGetATeamAuthInfo,
   getATeamMembers as apiGetATeamMembers,
   getATeamTopics as apiGetATeamTopics,
-  getWatchingPTeams as apiGetWatchingPTeams,
 } from "../utils/api";
 
 export const getATeam = createAsyncThunk(
@@ -46,15 +45,6 @@ export const getATeamMembers = createAsyncThunk(
         }),
         {}
       ),
-      ateamId: ateamId,
-    }))
-);
-
-export const getWatchingPTeams = createAsyncThunk(
-  "ateam/getWatchingPTeams",
-  async (ateamId) =>
-    await apiGetWatchingPTeams(ateamId).then((response) => ({
-      data: response.data,
       ateamId: ateamId,
     }))
 );

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -143,7 +143,7 @@ export const getPTeamTopicActions = createAsyncThunk(
 );
 
 export const getPTeamWatcher = createAsyncThunk(
-  "pteam/getAteamWatcher",
+  "pteam/getPteamWatcher",
   async (pteamId) =>
     await apiGetPTeamWatcher(pteamId).then((response) => ({
       data: response.data,

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -13,7 +13,6 @@ import {
   getPTeamTopicActions as apiGetPTeamTopicActions,
   getPTeamTopicStatus as apiGetPTeamTopicStatus,
   getPTeamTopicStatusesSummary as apiGetPTeamTopicStatusesSummary,
-  getPTeamWatcher as apiGetPTeamWatcher,
   getPTeamGroups as apiGetPTeamGroups,
 } from "../utils/api";
 
@@ -139,15 +138,6 @@ export const getPTeamTopicActions = createAsyncThunk(
       actions: response.data.actions,
       pteamId: data.pteamId,
       topicId: data.topicId,
-    }))
-);
-
-export const getPTeamWatcher = createAsyncThunk(
-  "pteam/getPTeamWatcher",
-  async (pteamId) =>
-    await apiGetPTeamWatcher(pteamId).then((response) => ({
-      data: response.data,
-      pteamId: pteamId,
     }))
 );
 

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -143,7 +143,7 @@ export const getPTeamTopicActions = createAsyncThunk(
 );
 
 export const getPTeamWatcher = createAsyncThunk(
-  "pteam/getPteamWatcher",
+  "pteam/getPTeamWatcher",
   async (pteamId) =>
     await apiGetPTeamWatcher(pteamId).then((response) => ({
       data: response.data,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -80,8 +80,6 @@ export const getPTeamTopicStatusesSummary = async (pteamId, tagId) =>
 export const getPTeamTopicActions = async (pteamId, topicId) =>
   axios.get(`/topics/${topicId}/actions/pteam/${pteamId}`);
 
-export const getPTeamWatcher = async (pteamId) => axios.get(`/pteams/${pteamId}/watchers`);
-
 export const removeWatcherATeam = async (pteamId, ateamId) =>
   axios.delete(`/pteams/${pteamId}/watchers/${ateamId}`);
 
@@ -113,8 +111,6 @@ export const getATeamAuth = async (ateamId) => axios.get(`/ateams/${ateamId}/aut
 
 export const updateATeamAuth = async (ateamId, data) =>
   axios.post(`/ateams/${ateamId}/authority`, data);
-
-export const getWatchingPTeams = async (ateamId) => axios.get(`/ateams/${ateamId}/watching_pteams`);
 
 export const removeWatchingPTeam = async (ateamId, pteamId) =>
   axios.delete(`/ateams/${ateamId}/watching_pteams/${pteamId}`);


### PR DESCRIPTION
## PR の目的
watchingまわりの修正

- 現状pteamのwatcher / ateamのwatching は全く使っていないため、削除しました。
- ateam/pteam 自体の更新をdispatchするように変更しました
- AcceptAteamWatchingRequest画面でwatching requestを承認した後、遷移先のwatcherリストに、そのateamが表示されない問題の修正。 
![image](https://github.com/nttcom/threatconnectome/assets/92132688/08ebd712-b025-42f1-9177-258cda3395ff)




## 参考文献
