### PR TITLE
Topic/golang version compare

### DIFF
--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -5,6 +5,7 @@ import pytest
 from app.version import (
     ExtDebianVersion,
     ExtPypiVersion,
+    GolangVersion,
     PackageFamily,
     SemverVersion,  # from univers
     VulnerableRange,
@@ -362,6 +363,33 @@ class TestComparableVersion:
             sem_obj = gen_version_instance(PackageFamily.NPM, version_string)
             assert isinstance(sem_obj, SemverVersion)
             assert (sem_obj.major, sem_obj.minor, sem_obj.patch, sem_obj.prerelease) == expected
+
+
+    class TestGoVersion(_TestVersion):
+        @pytest.mark.parametrize(
+            "version_string, expected",
+            [
+                ("1.2.3", (1, 2, 3, ())),
+                ("0.0.0-20180523222229-09b5706aa936", (0, 0, 0, ("20180523222229-09b5706aa936",))),
+                ("0.15.0-rc.1", (0, 15, 0, ("rc", "1",))),
+                ("0.5.0-alpha.5.0.20190108173120-83c051b701d3", (0, 5, 0, ("alpha","5","0","20190108173120-83c051b701d3",))),
+                ("0.15.4-beta", (0, 15, 4, ("beta",))),
+                ("0.0.1-alpha-1", (0, 0, 1, ("alpha-1",))),
+                ("2.0.0-dev", (2, 0, 0, ("dev",))),
+                ("1.12.1-stable", (1, 12, 1, ("stable",))),
+                ("4.0.0-preview1", (4, 0, 0, ("preview1",))),
+            ],
+        )
+        def test_gen_instance(self, version_string, expected):
+            if isinstance(expected, str):
+                with pytest.raises(ValueError, match=expected):
+                    gen_version_instance(PackageFamily.GO, version_string)
+                return
+            sem_obj = gen_version_instance(PackageFamily.GO, version_string)
+            assert isinstance(sem_obj, GolangVersion)
+            assert (sem_obj.major, sem_obj.minor, sem_obj.patch, sem_obj.prerelease) == expected
+
+
 
 
 class TestVulnerableRange:

--- a/api/app/tests/small/test_version.py
+++ b/api/app/tests/small/test_version.py
@@ -364,15 +364,38 @@ class TestComparableVersion:
             assert isinstance(sem_obj, SemverVersion)
             assert (sem_obj.major, sem_obj.minor, sem_obj.patch, sem_obj.prerelease) == expected
 
-
     class TestGoVersion(_TestVersion):
         @pytest.mark.parametrize(
             "version_string, expected",
             [
                 ("1.2.3", (1, 2, 3, ())),
                 ("0.0.0-20180523222229-09b5706aa936", (0, 0, 0, ("20180523222229-09b5706aa936",))),
-                ("0.15.0-rc.1", (0, 15, 0, ("rc", "1",))),
-                ("0.5.0-alpha.5.0.20190108173120-83c051b701d3", (0, 5, 0, ("alpha","5","0","20190108173120-83c051b701d3",))),
+                (
+                    "0.15.0-rc.1",
+                    (
+                        0,
+                        15,
+                        0,
+                        (
+                            "rc",
+                            "1",
+                        ),
+                    ),
+                ),
+                (
+                    "0.5.0-alpha.5.0.20190108173120-83c051b701d3",
+                    (
+                        0,
+                        5,
+                        0,
+                        (
+                            "alpha",
+                            "5",
+                            "0",
+                            "20190108173120-83c051b701d3",
+                        ),
+                    ),
+                ),
                 ("0.15.4-beta", (0, 15, 4, ("beta",))),
                 ("0.0.1-alpha-1", (0, 0, 1, ("alpha-1",))),
                 ("2.0.0-dev", (2, 0, 0, ("dev",))),
@@ -388,8 +411,6 @@ class TestComparableVersion:
             sem_obj = gen_version_instance(PackageFamily.GO, version_string)
             assert isinstance(sem_obj, GolangVersion)
             assert (sem_obj.major, sem_obj.minor, sem_obj.patch, sem_obj.prerelease) == expected
-
-
 
 
 class TestVulnerableRange:

--- a/api/app/version.py
+++ b/api/app/version.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Set, TypeAlias, Union
 
 from packaging.version import Version as PypiVersion
 from univers.debian import Version as DebianVersion
-from univers.versions import SemverVersion
+from univers.versions import GolangVersion, SemverVersion
 
 
 class PackageFamily(Enum):
@@ -13,6 +13,7 @@ class PackageFamily(Enum):
     DEBIAN = 1
     PYPI = 2
     NPM = 3
+    GO = 4
 
     @classmethod
     def from_registry(cls, registry: str) -> "PackageFamily":
@@ -23,6 +24,8 @@ class PackageFamily(Enum):
             return cls.PYPI
         if re.match(r"^(npm)", fixed_registry):
             return cls.NPM
+        if re.match(r"^(golang)", fixed_registry):
+            return cls.GO
         return cls.UNKNOWN
 
     @classmethod
@@ -118,6 +121,9 @@ def gen_version_instance(
         return ExtPypiVersion(version_string)
     if package_family == PackageFamily.NPM:
         return SemverVersion(version_string)
+    if package_family == PackageFamily.GO:
+        return GolangVersion(version_string)
+
     return SemverVersion(version_string)
 
 


### PR DESCRIPTION
## PR の目的
- goのversion比較をuniversのGolangVersion(中身はunivers SemverVersionを継承しています)を用いるようにしました。

## 経緯・意図・意思決定
- universのGolangVersionを用いて、goのバージョンを比較するように実装しました。
- テストは、trivydbのgoにあった特殊なもののみを追加しました。他のテストケースは、TestSemverVersionやunivers自体で行っているため。