### PR TITLE
Topic/switch momentjs to datefns

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,6 @@
         "axios": "^1.2.2",
         "date-fns": "^2.30.0",
         "firebase": "^9.15.0",
-        "moment": "^2.29.4",
         "notistack": "^2.0.8",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -12763,6 +12762,8 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/x-date-pickers": "^5.0.13",
         "@reduxjs/toolkit": "^1.9.1",
         "axios": "^1.2.2",
+        "date-fns": "^2.30.0",
         "firebase": "^9.15.0",
         "moment": "^2.29.4",
         "notistack": "^2.0.8",
@@ -7847,6 +7848,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,6 @@
     "axios": "^1.2.2",
     "date-fns": "^2.30.0",
     "firebase": "^9.15.0",
-    "moment": "^2.29.4",
     "notistack": "^2.0.8",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "@mui/x-date-pickers": "^5.0.13",
     "@reduxjs/toolkit": "^1.9.1",
     "axios": "^1.2.2",
+    "date-fns": "^2.30.0",
     "firebase": "^9.15.0",
     "moment": "^2.29.4",
     "notistack": "^2.0.8",

--- a/web/src/components/FormattedDateTimeWithTooltip.jsx
+++ b/web/src/components/FormattedDateTimeWithTooltip.jsx
@@ -1,0 +1,32 @@
+import { Tooltip, Typography } from "@mui/material";
+import { format } from "date-fns";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { utcStringToLocalDate } from "../utils/func";
+
+export function FormattedDateTimeWithTooltip(props) {
+  const { utcString, formatString, sx } = props;
+
+  try {
+    if (!utcString) throw new Error("empty string");
+    const localDate = utcStringToLocalDate(utcString);
+    const tipTitle = localDate.toISOString();
+    const formattedDate = format(localDate, formatString);
+    return (
+      <Tooltip title={tipTitle}>
+        <Typography sx={{ overflowWrap: "anywhere", ...sx }}>{formattedDate}</Typography>
+      </Tooltip>
+    );
+  } catch (error) {
+    return <Typography sx={{ overflowWrap: "anywhere", ...sx }}> - </Typography>;
+  }
+}
+FormattedDateTimeWithTooltip.propTypes = {
+  utcString: PropTypes.string,
+  formatString: PropTypes.string,
+  sx: PropTypes.object,
+};
+FormattedDateTimeWithTooltip.defaultProps = {
+  formatString: "PPp", // see https://date-fns.org/v3.0.0/docs/format for details
+};

--- a/web/src/components/GTeamInviteModal.jsx
+++ b/web/src/components/GTeamInviteModal.jsx
@@ -12,8 +12,8 @@ import {
   Typography,
 } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
-import moment from "moment";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { addHours, isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
@@ -30,7 +30,8 @@ export function GTeamInviteModal(props) {
   const gteamId = useSelector((state) => state.gteam.gteamId);
 
   const [open, setOpen] = useState(false);
-  const [data, setData] = useState({});
+  const [maxUses, setMaxUses] = useState(0);
+  const [expiration, setExpiration] = useState(addHours(new Date(), 1)); // Date object
   const [invitationLink, setInvitationLink] = useState(null);
 
   const { enqueueSnackbar } = useSnackbar();
@@ -39,10 +40,8 @@ export function GTeamInviteModal(props) {
     `${window.location.origin}${process.env.PUBLIC_URL}/gteam/join?token=${token}`;
   const handleReset = () => {
     setInvitationLink(null);
-    setData({
-      expiration: moment().add(1, "hours").toDate(),
-      max_uses: 0,
-    });
+    setMaxUses(0);
+    setExpiration(addHours(new Date(), 1));
   };
   const handleOpen = () => {
     handleReset();
@@ -62,15 +61,15 @@ export function GTeamInviteModal(props) {
       });
     }
     const query = {
-      expiration: data.expiration.toISOString(),
-      max_uses: data.max_uses || null,
+      expiration: expiration.toISOString(),
+      max_uses: maxUses || null,
     };
     await createGTeamInvitation(gteamId, query)
       .then((success) => onSuccess(success))
       .catch((error) => onError(error));
   };
 
-  const now = moment();
+  const now = new Date();
 
   if (!gteamId) return <></>;
 
@@ -84,7 +83,7 @@ export function GTeamInviteModal(props) {
           <Typography variant="inherit">Create New Invitation Link</Typography>
         </DialogTitle>
         <DialogContent>
-          <LocalizationProvider dateAdapter={AdapterMoment}>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
             {invitationLink ? (
               <Box display="flex" flexDirection="column">
                 <Typography>Please share the invitation link below:</Typography>
@@ -99,22 +98,20 @@ export function GTeamInviteModal(props) {
               <Grid container alignItems="center">
                 <Grid item p={1} xs={6} sm={6}>
                   <DateTimePicker
-                    inputFormat="YYYY/MM/DD HH:mm"
+                    inputFormat="yyyy/MM/dd HH:mm"
                     label="Expiration Date (future date)"
                     mask="____/__/__ __:__"
                     minDateTime={now}
-                    onChange={(moment) =>
-                      setData({ ...data, expiration: moment ? moment.toDate() : "" })
-                    }
+                    value={expiration}
+                    onChange={(newDate) => setExpiration(newDate)}
                     renderInput={(params) => (
                       <TextField fullWidth margin="dense" required {...params} />
                     )}
-                    value={data.expiration}
                   />
                 </Grid>
                 <Grid item p={1} xs={6} sm={6}>
                   <Box display="flex" flexDirection="column" justifyContent="center">
-                    <Typography>Max uses: {data.max_uses || "unlimited"}</Typography>
+                    <Typography>Max uses: {maxUses || "unlimited"}</Typography>
                     <Box mx={1}>
                       <Slider
                         step={1}
@@ -124,8 +121,8 @@ export function GTeamInviteModal(props) {
                         }))}
                         max={20}
                         min={0}
-                        onChange={(_, value) => setData({ ...data, max_uses: value })}
-                        value={data.max_uses}
+                        value={maxUses}
+                        onChange={(_, value) => setMaxUses(value)}
                         sx={{ width: "100%" }}
                       />
                     </Box>
@@ -142,7 +139,7 @@ export function GTeamInviteModal(props) {
           {!invitationLink && (
             <Button
               onClick={handleCreate}
-              disabled={!now.isBefore(data.expiration)}
+              disabled={!isBefore(now, expiration)}
               sx={modalCommonButtonStyle}
             >
               Create

--- a/web/src/components/PTeamInviteModal.jsx
+++ b/web/src/components/PTeamInviteModal.jsx
@@ -12,8 +12,8 @@ import {
   Typography,
 } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
-import moment from "moment";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { addHours, isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
@@ -30,7 +30,8 @@ export function PTeamInviteModal(props) {
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
   const [open, setOpen] = useState(false);
-  const [data, setData] = useState({});
+  const [maxUses, setMaxUses] = useState(0);
+  const [expiration, setExpiration] = useState(addHours(new Date(), 1)); // Date object
   const [invitationLink, setInvitationLink] = useState(null);
 
   const { enqueueSnackbar } = useSnackbar();
@@ -39,10 +40,8 @@ export function PTeamInviteModal(props) {
     `${window.location.origin}${process.env.PUBLIC_URL}/pteam/join?token=${token}`;
   const handleReset = () => {
     setInvitationLink(null);
-    setData({
-      expiration: moment().add(1, "hours").toDate(),
-      max_uses: 0,
-    });
+    setMaxUses(0);
+    setExpiration(addHours(new Date(), 1));
   };
   const handleOpen = () => {
     handleReset();
@@ -62,15 +61,15 @@ export function PTeamInviteModal(props) {
       });
     }
     const query = {
-      expiration: data.expiration.toISOString(),
-      max_uses: data.max_uses || null,
+      expiration: expiration.toISOString(),
+      max_uses: maxUses || null,
     };
     await createPTeamInvitation(pteamId, query)
       .then((success) => onSuccess(success))
       .catch((error) => onError(error));
   };
 
-  const now = moment();
+  const now = new Date();
 
   return (
     <>
@@ -82,7 +81,7 @@ export function PTeamInviteModal(props) {
           <Typography variant="inherit">Create New Invitation Link</Typography>
         </DialogTitle>
         <DialogContent>
-          <LocalizationProvider dateAdapter={AdapterMoment}>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
             {invitationLink ? (
               <Box display="flex" flexDirection="column">
                 <Typography>Please share the invitation link below:</Typography>
@@ -97,22 +96,20 @@ export function PTeamInviteModal(props) {
               <Grid container alignItems="center">
                 <Grid item p={1} xs={6} sm={6}>
                   <DateTimePicker
-                    inputFormat="YYYY/MM/DD HH:mm"
+                    inputFormat="yyyy/MM/dd HH:mm"
                     label="Expiration Date (future date)"
                     mask="____/__/__ __:__"
                     minDateTime={now}
-                    onChange={(moment) =>
-                      setData({ ...data, expiration: moment ? moment.toDate() : "" })
-                    }
+                    value={expiration}
+                    onChange={(newDate) => setExpiration(newDate)}
                     renderInput={(params) => (
                       <TextField fullWidth margin="dense" required {...params} />
                     )}
-                    value={data.expiration}
                   />
                 </Grid>
                 <Grid item p={1} xs={6} sm={6}>
                   <Box display="flex" flexDirection="column" justifyContent="center">
-                    <Typography>Max uses: {data.max_uses || "unlimited"}</Typography>
+                    <Typography>Max uses: {maxUses || "unlimited"}</Typography>
                     <Box mx={1}>
                       <Slider
                         step={1}
@@ -122,8 +119,8 @@ export function PTeamInviteModal(props) {
                         }))}
                         max={20}
                         min={0}
-                        onChange={(_, value) => setData({ ...data, max_uses: value })}
-                        value={data.max_uses}
+                        value={maxUses}
+                        onChange={(_, value) => setMaxUses(value)}
                         sx={{ width: "100%" }}
                       />
                     </Box>
@@ -140,7 +137,7 @@ export function PTeamInviteModal(props) {
           {!invitationLink && (
             <Button
               onClick={handleCreate}
-              disabled={!now.isBefore(data.expiration)}
+              disabled={!isBefore(now, expiration)}
               sx={modalCommonButtonStyle}
             >
               Create

--- a/web/src/components/TopicSearchModal.jsx
+++ b/web/src/components/TopicSearchModal.jsx
@@ -19,8 +19,8 @@ import {
 import { grey } from "@mui/material/colors";
 import { styled } from "@mui/material/styles";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
-import moment from "moment";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { addDays } from "date-fns";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
@@ -31,10 +31,12 @@ export function TopicSearchModal(props) {
   const [mispTags, setMispTags] = useState("");
   const [creatorIds, setCreatorIds] = useState("");
   const [topicIds, setTopicIds] = useState("");
-  const [updatedAfter, setUpdatedAfter] = useState(null); // moment object
-  const [updatedBefore, setUpdatedBefore] = useState(null); // moment object
+  const [updatedAfter, setUpdatedAfter] = useState(null); // Date object
+  const [updatedBefore, setUpdatedBefore] = useState(null); // Date object
   const [adModeChange, setAdModeChange] = useState(false);
   const [dateFormList, setDateFormList] = useState("");
+
+  const now = new Date();
 
   const advancedChange = (event) => {
     setAdModeChange(event.target.checked);
@@ -52,8 +54,8 @@ export function TopicSearchModal(props) {
       mispTags: mispTags,
       topicIds: topicIds,
       creatorIds: creatorIds,
-      updatedAfter: updatedAfter?.utc?.().toDate(),
-      updatedBefore: updatedBefore?.utc?.().toDate(),
+      updatedAfter: updatedAfter?.toISOString(),
+      updatedBefore: updatedBefore?.toISOString(),
     };
     onSearch(params);
     clearAllParams();
@@ -83,10 +85,10 @@ export function TopicSearchModal(props) {
         setUpdatedAfter(null);
         break;
       case "in24hours":
-        setUpdatedAfter(moment().add(-1, "days"));
+        setUpdatedAfter(addDays(now, -1));
         break;
       case "in7days":
-        setUpdatedAfter(moment().add(-7, "days"));
+        setUpdatedAfter(addDays(now, -7));
         break;
       default:
         break;
@@ -180,12 +182,12 @@ export function TopicSearchModal(props) {
         {(dateFormList === "since" || dateFormList === "until") && (
           <Grid item xs={5}>
             <DateTimePicker
-              inputFormat="YYYY/MM/DD HH:mm"
+              inputFormat="yyyy/MM/dd HH:mm"
               mask="____/__/__ __:__"
-              maxDateTime={moment()}
+              maxDateTime={now}
               value={dateFormList === "since" ? updatedAfter : updatedBefore}
-              onChange={(moment) =>
-                (dateFormList === "since" ? setUpdatedAfter : setUpdatedBefore)(moment)
+              onChange={(newDate) =>
+                (dateFormList === "since" ? setUpdatedAfter : setUpdatedBefore)(newDate)
               }
               renderInput={(params) => <TextField fullWidth margin="dense" required {...params} />}
             />
@@ -194,21 +196,21 @@ export function TopicSearchModal(props) {
         {dateFormList === "range" && (
           <Grid item xs={11.4} display="flex">
             <DateTimePicker
-              inputFormat="YYYY/MM/DD HH:mm"
+              inputFormat="yyyy/MM/dd HH:mm"
               mask="____/__/__ __:__"
-              maxDateTime={updatedBefore || moment()}
+              maxDateTime={updatedBefore || now}
               value={updatedAfter}
-              onChange={(moment) => setUpdatedAfter(moment)}
+              onChange={(newDate) => setUpdatedAfter(newDate)}
               renderInput={(params) => <TextField fullWidth margin="dense" required {...params} />}
             />
             <Typography sx={{ margin: "20px" }}>~</Typography>
             <DateTimePicker
-              inputFormat="YYYY/MM/DD HH:mm"
+              inputFormat="yyyy/MM/dd HH:mm"
               mask="____/__/__ __:__"
               minDateTime={updatedAfter}
-              maxDateTime={moment()}
+              maxDateTime={now}
               value={updatedBefore}
-              onChange={(moment) => setUpdatedBefore(moment)}
+              onChange={(newDate) => setUpdatedBefore(newDate)}
               renderInput={(params) => <TextField fullWidth margin="dense" required {...params} />}
             />
           </Grid>
@@ -266,7 +268,7 @@ export function TopicSearchModal(props) {
             </Box>
           </DialogTitle>
           <DialogContent>
-            <LocalizationProvider dateAdapter={AdapterMoment}>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
               <Box display="flex" flexDirection="row-reverse" sx={{ marginTop: 0 }}>
                 <FormControlLabel
                   control={<Android12Switch checked={adModeChange} onChange={advancedChange} />}

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -26,7 +26,7 @@ import {
   Typography,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import moment from "moment";
+import { format } from "date-fns";
 import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -39,7 +39,7 @@ import { AnalysisTopic } from "../components/AnalysisTopic";
 import { getATeam, getATeamAuth } from "../slices/ateam";
 import { getATeamTopics } from "../utils/api";
 import { difficulty, difficultyColors, noATeamMessage } from "../utils/const";
-import { calcTimestampDiff, errorToString } from "../utils/func";
+import { calcTimestampDiff, errorToString, utcStringToLocalDate } from "../utils/func";
 
 export function Analysis() {
   const { enqueueSnackbar } = useSnackbar();
@@ -337,10 +337,10 @@ export function Analysis() {
                             <Box display="flex" alignItems="flex-end">
                               <CalendarMonthIcon fontSize="small" sx={{ color: grey[700] }} />
                               <Typography ml={0.5} variant="caption">
-                                {moment
-                                  .utc(topic.pteams[0].statuses[0].scheduled_at)
-                                  .local()
-                                  .format("YYYY/MM/DD")}
+                                {format(
+                                  utcStringToLocalDate(topic.pteams[0].statuses[0].scheduled_at),
+                                  "yyyy/MM/dd"
+                                )}
                               </Typography>
                             </Box>
                           )}

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -26,6 +26,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { FormattedDateTimeWithTooltip } from "../components/FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "../components/TopicSearchModal";
 import { getActions, getTopic } from "../slices/topics";
 import { searchTopics } from "../utils/api";
@@ -69,8 +70,7 @@ function TopicManagementTableRow(props) {
       }}
     >
       <TableCell>
-        {/* FIXME: should arrange datetime format using moment.js or something else */}
-        <Typography sx={{ overflowWrap: "anywhere" }}>{topic.updated_at}</Typography>
+        <FormattedDateTimeWithTooltip utcString={topic.updated_at} />
       </TableCell>
       <TableCell>
         {actionList?.length > 0 ? (

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -22,12 +22,20 @@ export const calcTimestampDiff = (timestamp) => {
 };
 
 export const utcStringToLocalDate = (utcString) => {
-  const tmpDate = new Date(utcString);
-  return addMinutes(tmpDate, -tmpDate.getTimezoneOffset());
+  try {
+    const tmpDate = new Date(utcString);
+    return addMinutes(tmpDate, -tmpDate.getTimezoneOffset());
+  } catch (error) {
+    return null;
+  }
 };
 
 export const dateTimeFormat = (utcString) => {
-  return format(utcStringToLocalDate(utcString), "yyyy-MM-dd'T'HH:mm:ssxxx");
+  try {
+    return format(utcStringToLocalDate(utcString), "yyyy-MM-dd'T'HH:mm:ssxxx");
+  } catch (error) {
+    return " - ";
+  }
 };
 
 export const pickParentTagName = (tagName) => {

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import { addMinutes, format } from "date-fns";
 
 import { getZonedTeams } from "./api";
 
@@ -21,8 +21,13 @@ export const calcTimestampDiff = (timestamp) => {
   }
 };
 
-export const dateTimeFormat = (timestamp) => {
-  return moment.utc(timestamp).local().format();
+export const utcStringToLocalDate = (utcString) => {
+  const tmpDate = new Date(utcString);
+  return addMinutes(tmpDate, -tmpDate.getTimezoneOffset());
+};
+
+export const dateTimeFormat = (utcString) => {
+  return format(utcStringToLocalDate(utcString), "yyyy-MM-dd'T'HH:mm:ssxxx");
 };
 
 export const pickParentTagName = (tagName) => {


### PR DESCRIPTION
## PR の目的

- momen.js の利用を廃止し、date-fns に切り替えました

## 経緯・意図・意思決定

- これまで datetime の取り回しは string や moment オブジェクトでしたが、 Date オブジェクトで取りまわすのが楽になると思います。
- ただし、api から受け取る datetime は UTC なので、これを local TZ の Date に変換するのに一癖あります。
  - utils/func に utcStringToLocalDate() を用意したので利用してください。
- date-fns は 12/3 に 3.0.0 がリリースされていますが、本 PR では 2.30.0 を指定しています。
  - これは DateTimePicker 用の Adaper が未だ 3.x に対応していないらしく、npm が ERESOLVE 警告を出すためです。
  - 3.0 では結構な breaking changes があるようなので、↑が対応したら早急に切り替えたいところです。
  - 蛇足ですが、date-fns のマニュアルは https://date-fns.org/v3.0.0/docs/ を参照してください。
    - 2.30.0 用のページもありますが、JSON のパースエラーが出て Loading のまま止まってしまいます。:(