### PR TITLE
switch sort_key threat_impact to updated_at_desc

### DIFF
--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -119,7 +119,7 @@ export function TopicManagement() {
     const queryParams = {
       offset: perPage * (page - 1),
       limit: perPage,
-      sort_key: "threat_impact",
+      sort_key: "updated_at_desc",
       ...searchConditions,
     };
     await searchTopics(queryParams)


### PR DESCRIPTION
## PR の目的

- トピック一覧のソートキーを更新日時（降順）に変更