### PR TITLE
fix drawer menu

### DIFF
--- a/web/src/components/Drawer.jsx
+++ b/web/src/components/Drawer.jsx
@@ -1,9 +1,10 @@
 import {
   AccountCircle as AccountCircleIcon,
   Assessment as AssessmentIcon,
-  Square as SquareIcon,
+  Fence as FenceIcon,
   Groups as GroupsIcon,
   Home as HomeIcon,
+  Topic as TopicIcon,
 } from "@mui/icons-material";
 import {
   Drawer as MuiDrawer,
@@ -140,7 +141,7 @@ export function Drawer() {
               selected={location.pathname === "/zone"}
             >
               <StyledListItemIcon>
-                <SquareIcon />
+                <FenceIcon />
               </StyledListItemIcon>
               <ListItemText>Zone</ListItemText>
             </StyledListItemButton>
@@ -161,9 +162,9 @@ export function Drawer() {
           selected={location.pathname === "/topics"}
         >
           <StyledListItemIcon>
-            <>{/* FIXME */}</>
+            <TopicIcon />
           </StyledListItemIcon>
-          <ListItemText>Topic Management</ListItemText>
+          <ListItemText>Topics</ListItemText>
         </StyledListItemButton>
         {/* Account */}
         <StyledListItemButton


### PR DESCRIPTION
## PR の目的

- Drawerメニューを調整
  - Topic Management
    - 文字列を Topics に変更
    - アイコンを Topic に変更
  - GTeam
    - Zone のアイコンを Fence に変更

![drawer](https://github.com/nttcom/threatconnectome/assets/59242978/3a4a963c-caa9-4f7e-8055-bf3e0d062689)

