### PR TITLE
dateTimeFormatのエラー時の返り値の修正

### DIFF
--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -34,7 +34,7 @@ export const dateTimeFormat = (utcString) => {
   try {
     return format(utcStringToLocalDate(utcString), "yyyy-MM-dd'T'HH:mm:ssxxx");
   } catch (error) {
-    return " - ";
+    return " ";
   }
 };
 


### PR DESCRIPTION
## PR の目的

- 機能追加の場合
  - dateTimeFormatのパッチのエラー時のreturnが「-」だったのを、空文字に修正する

## 経緯・意図・意思決定
 - ハイフンのままだと、ActionのCreate/Editモーダルにそのまま表示されてしまうので、それを回避するために空文字を返すように修正した