### PR TITLE
add script to update_tags_file and wrapper of trivy + trivy_tags + up…

### DIFF
--- a/scripts/upload_tags_file.py
+++ b/scripts/upload_tags_file.py
@@ -1,0 +1,231 @@
+# !/usr/bin/env python3
+
+import argparse
+import http.client as http_client
+import os
+import sys
+from functools import partial
+from time import sleep
+from typing import Any, Callable, List, Tuple, Union
+from uuid import UUID
+
+import requests
+
+http_client.HTTPConnection.debuglevel = 0  # set 1 for detailed debug
+
+ENV_KEY_REFRESH_TOKEN = "THREATCONNECTOME_REFRESH_TOKEN"
+
+
+class APIError(Exception):
+    pass
+
+
+class ThreatconnectomeClient:
+    api_url: str
+    refresh_token: str
+    retry_max: int  # 0 for never, negative for forever
+    headers: dict
+
+    def __init__(
+        self,
+        api_url: str,
+        refresh_token: str,
+        retry_max: int = -1,
+    ):
+        self.api_url = api_url.rstrip("/")
+        self.refresh_token = refresh_token
+        self.retry_max = retry_max
+        self.headers = self.refresh_auth_token(
+            {  # headers except auth token
+                "accept": "application/json",
+                # "Content-Type": "application/json",  # oops, this causes upload_tags_file failure
+            }
+        )
+
+    def refresh_auth_token(self, headers: dict) -> dict:
+        resp = requests.post(
+            f"{self.api_url}/auth/refresh",
+            headers={"ContentType": "application/json"},
+            json={"refresh_token": self.refresh_token},
+        )
+        new_token = resp.json().get("access_token")
+        return {
+            **headers,  # keep original headers except below
+            "Authorization": f"Bearer {new_token}",
+        }
+
+    def retry_call(
+        self,
+        func: Callable[..., requests.Response],
+        *args,
+        **kwargs,
+    ) -> requests.Response:
+        # Note:
+        #   func should have kwarg "headers":
+        #     def func(*args, **kwargs, headers={}) -> Response:
+        #   self.headers is used for kwarg "headers", and auto-refreshed on 401 error.
+        _retry = self.retry_max
+        _in_auth_retry = False
+        _func = partial(func, *args, **{k: v for k, v in kwargs.items() if k != "headers"})
+
+        def _resp_to_msg(resp: requests.Response) -> str:
+            data = resp.json()
+            return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+
+        while True:
+            resp = _func(headers=self.headers)
+            if resp.status_code in {200, 204}:
+                return resp
+            if resp.status_code == 401:
+                if _in_auth_retry:
+                    raise APIError(f"ERROR: {_resp_to_msg(resp)}")
+                _in_auth_retry = True
+                self.headers = self.refresh_auth_token(self.headers)
+                continue
+            if resp.status_code < 500:
+                # unrecoverable error: raise without retry
+                raise APIError(f"ERROR: {_resp_to_msg(resp)}")
+            # maybe recoverable error
+            if _retry == 0:
+                raise APIError(f"ERROR: Exceeded retry max: {_resp_to_msg(resp)}")
+            elif _retry > 0:
+                _retry -= 1
+            sleep(3)
+
+    def upload_tags_file(self, pteam_id: Union[UUID, str], group: str, data: Any, force: bool):
+        params = {
+            "group": group,
+            "force_mode": force,
+        }
+        files = {
+            "file": ("tags_file.jsonl", data),  # filename should end with ".jsonl"
+        }
+        url = f"{self.api_url}/pteams/{pteam_id}/upload_tags_file"
+        response = self.retry_call(requests.post, url, params=params, files=files)
+        return response.json()
+
+    def remove_pteamtags_by_group(self, pteam_id: Union[UUID, str], group: str):
+        url = f"{self.api_url}/pteams/{pteam_id}/tags"
+        self.retry_call(requests.delete, url)
+
+
+ARGUMENTS: List[Tuple[str, dict]] = [
+    (
+        "pteam_id",
+        {
+            "help": "UUID of the pteam",
+        },
+    ),
+    (
+        "group",
+        {
+            "help": "Group name to apply",
+        },
+    ),
+]
+OPTIONS: List[Tuple[str, str, dict]] = [
+    (
+        "-e",
+        "--endpoint",
+        {
+            "required": True,
+            "help": "API endpoint url. (e.g. https://tc.service.org/api)",
+        },
+    ),
+    (
+        "-r",
+        "--refresh-token",
+        {
+            "required": False,
+            "default": os.environ.get(ENV_KEY_REFRESH_TOKEN),
+            "help": "Refresh token to access api server."
+            + f" default is environment variable: {ENV_KEY_REFRESH_TOKEN}.",
+        },
+    ),
+    (
+        "-i",
+        "--infile",
+        {
+            "required": False,
+            "type": argparse.FileType("r"),
+            "default": sys.stdin,
+            "help": "Input file name. default is stdin.",
+        },
+    ),
+    (
+        "-b",
+        "--block-new-tags",
+        {
+            "required": False,
+            "action": "store_true",
+            "default": False,
+            "help": "Do not give force option which allows you to create new artifact tags.",
+        },
+    ),
+    (
+        "-g",
+        "--gradual",
+        {
+            "required": False,
+            "type": int,
+            "default": 0,
+            "help": "If GURADUAL > 0, try gradual update with specified number of lines.",
+        },
+    ),
+]
+
+
+def trace_message(*args, **kwargs):
+    print(*args, **kwargs, file=sys.stderr)
+    sys.stderr.flush()
+
+
+def main(args: argparse.Namespace) -> None:
+    if args.infile == sys.stdin:
+        trace_message("reading data from STDIN...")
+    tc_client = ThreatconnectomeClient(args.endpoint, args.refresh_token, retry_max=1)
+
+    if args.gradual == 0:
+        trace_message("processing update artifact tags.")
+        lines = args.infile.read()  # process all lines at once
+        tc_client.upload_tags_file(args.pteam_id, args.group, lines, not args.block_new_tags)
+        trace_message("update completed.")
+    else:
+        trace_message("processing guradual update artifact tags.")
+        all_lines = list(args.infile)
+        all_lines_length = len(all_lines)
+        limit = args.gradual if args.gradual < all_lines_length else all_lines_length
+        trace_message(f"removing all artifact tags for {args.group}...", end="")
+        tc_client.remove_pteamtags_by_group(args.pteam_id, args.group)
+        trace_message("done")
+        while True:
+            if limit > all_lines_length:
+                limit = all_lines_length
+            trace_message(f"uploading {limit} of {all_lines_length}...", end="")
+            lines = "".join(all_lines[:limit])
+            tc_client.upload_tags_file(args.pteam_id, args.group, lines, not args.block_new_tags)
+            trace_message("done")
+            if limit >= all_lines_length:
+                break
+            limit += args.gradual
+        trace_message("guradual update completed.")
+
+
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser()
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    ARGS = PARSER.parse_args()
+
+    if not ARGS.refresh_token:
+        raise ValueError(
+            f"the argument: -r/--refresh-token or environment variable: {ENV_KEY_REFRESH_TOKEN}"
+            + " is required"
+        )
+
+    if ARGS.gradual < 0:
+        raise ValueError("error: argument -g/--gradual: expected 0 or positive integer")
+
+    main(ARGS)

--- a/scripts/upload_trivy_scaned_tags.sh
+++ b/scripts/upload_trivy_scaned_tags.sh
@@ -1,0 +1,76 @@
+#! /bin/bash -l
+
+# constants: edit below to modify
+api_endpoint="http://localhost/tcapi"
+trivy_command_path="/usr/bin/trivy"
+trivy_timeout="360m"  # give enough time to scan your target path
+
+# variables: specify by options, environment variable or hardcode below
+# priority - 1: option args, 2: environment variables, 3: defined values
+scan_path=${THREATCONNECTOME_SCAN_PATH:-""}  # e.g. /, /usr/src/metemcyber
+refresh_token=${THREATCONNECTOME_REFRESH_TOKEN:-""}  # e.g. eyJfQX......MjA3In0=
+pteam_id=${THREATCONNECTOME_PTEAM_ID:=""}  # e.g. 070fc9c8-7b53-479b-be24-211543c1eeb9
+group=${THREATCONNECTOME_GROUP:-""}  # e.g. "group alpha"
+gradual=${THREATCONNECTOME_UPDATE_GRADUAL:-"0"}  # e.g. 0, 1000, 5000
+
+
+######## DO NOT EDIT BELOW THIS LINE ########
+
+function usage() {
+    cat <<EOD >&2
+Usage: $0 [-h][-s SCAN_PATH][-r REFRESH][-p PTEAM_ID][-g GROUP][-G GRADUAL]
+  -h: Print this message and exit.
+  -s: Scan path. default: env[THREATCONNECTOME_SCAN_PATH].
+  -r: Refresh token to access api server. default: env[THREATCONNECTOME_REFRESH_TOKEN].
+  -p: UUID of the pteam. default: env[THREATCONNECTOME_PTEAM_ID].
+  -g: Group name. default: env[THREATCONNECTOME_GROUP].
+  -G: Number of gradual update, 0 for not gradual. default: env[THREATCONNECTOME_UPDATE_GRADUAL].
+EOD
+    exit
+}
+
+while getopts "hs:r:p:g:G:" OPT; do
+    case "$OPT" in
+        s) scan_path="${OPTARG}";;
+        r) refresh_token="${OPTARG}";;
+        p) pteam_id="${OPTARG}";;
+        g) group="${OPTARG}";;
+        G) gradual="${OPTARG}";;
+        *) usage;;
+    esac
+done
+shift $((${OPTIND} - 1))
+
+function giveup() {
+    echo >&2 "$*"
+    exit 255
+}
+
+[ -n "${scan_path}" ] || giveup "Missing scan path"
+[ -n "${refresh_token}" ] || giveup "Missing refresh token"
+[ -n "${pteam_id}" ] || giveup "Missing pteam_id"
+[ -n "${group}" ] || giveup "Missing group"
+[ -n "${gradual}" ] || giveup "Missing gradual"
+
+trivy_output=$(tempfile) || (echo >&2 "cannot create tempfile"; exit 255)
+tags_jsonl=$(tempfile) || (echo >&2 "cannot create tempfile"; exit 255)
+trap "rm -f -- '${trivy_output}' '${tags_jsonl}'" EXIT HUP INT QUIT TERM
+
+script_path=`dirname $0`
+trivy_cmd="${trivy_command_path} fs '${scan_path}' --list-all-pkgs --exit-code 0 --timeout '${trivy_timeout}' -f json -o '${trivy_output}' -q"
+trivy_tags_cmd="python3 ${script_path}/trivy_tags.py -i '${trivy_output}' -o '${tags_jsonl}'"
+upload_tags_cmd="python3 ${script_path}/upload_tags_file.py -e '${api_endpoint}' -r '${refresh_token}' -i '${tags_jsonl}' -g '${gradual}' '${pteam_id}' '${group}'"
+
+echo >&2 "processing trivy."
+echo >&2 "${trivy_cmd}"
+eval "${trivy_cmd}" || giveup "trivy scan failed with ret_code=$?."
+
+echo >&2 "processing trivy_tags."
+echo >&2 "${trivy_tags_cmd}"
+eval "${trivy_tags_cmd}" || giveup "trivy_tags failed."
+
+echo >&2 "processing upload_tags_file."
+echo >&2 "${upload_tags_cmd}"
+eval "${upload_tags_cmd}" || giveup "upload_tags_file failed."
+
+echo "succeeded!"


### PR DESCRIPTION
trivy でスキャンした結果を trivy_tags.py で jsonl に変換し、upload_tags_file でアップロードするスクリプトを実装

## PR の目的

- 監視対象（今回は MISP サーバを想定）の SBOM 情報を定期的に更新する機能の実装
  - cron での定期実行を想定
    - 現状の実装だと stdout, stderr にメッセージを出しているため、/dev/null に捨てた方が安全。
  - trivy および trivy_tags.py の出力に tempfile を使っているのでストレージ搭載が前提
- 既存の trivy_tags.py を含めた３スクリプトが同一ディレクトリに配置されている必要あり
  - trivy コマンドのインストール先は任意
    - upload_trivy_scaned_tags.sh 内にハードコードで設定
- 設定値は upload_trivy_scaned_tags.sh の冒頭に定義（最初に一通り確認する必要あり）。
  - 滅多に変更しない値はハードコード
    - trivy の timeout はスキャン対象により変更したいかもしれない？
    - trivy 周りの設定値は調整の余地があるが、具体的な要望が生じてからの対応としたい。
  - 可変値は、スクリプトの引数、環境変数、スクリプト内の定義値、の優先順位で適用。
    - scan path とか `/` 固定でよい場合はスクリプト内に定義してしまうのが簡単。
- upload_tags_file.py は単体でも利用可能。
  - gradual update は upload_tags_file がタイムアウトしてしまう場合の回避策（delete all した後、例えば 1000 件ずつ増やしていくような処理）。タイムアウトしないなら使わない（0 を指定する）方が（無駄な処理が不要なので）よいはず。
  - 新規タグの自動作成（foce モード）を抑止するオプションも用意してみましたが、たぶん使いどころがない...