### PR TITLE
Topic/fix status mismatch

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,3 +4,7 @@
 # The latest version X.X.X of [VULNERABLE_PACKAGE] cannot fix it.
 # - https://[reference_link1]
 # - https://[reference_link2]
+
+# Added 2024-01-24. There is no PoC exploit for this CVE yet.
+# The latest version 0.18.0 of ecdsa cannot fix it.
+CVE-2024-23342

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1544,11 +1544,11 @@ def remove_watcher_ateam(
 @router.post("/{pteam_id}/fix_status_mismatch")
 def fix_status_mismatch(
     pteam_id: UUID,
-    # current_user: models.Account = Depends(get_current_user),
+    current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
-    # check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
+    check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
 
     pteam_query = (
         select(models.CurrentPTeamTopicTagStatus).where(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1550,13 +1550,11 @@ def fix_status_mismatch(
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
 
-    pteam_query = (
-        select(models.CurrentPTeamTopicTagStatus).where(
-            models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
-            models.CurrentPTeamTopicTagStatus.topic_status.in_(
-                [models.TopicStatusType.alerted, models.TopicStatusType.acknowledged]
-            ),
-        )
+    pteam_query = select(models.CurrentPTeamTopicTagStatus).where(
+        models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
+        models.CurrentPTeamTopicTagStatus.topic_status.in_(
+            [models.TopicStatusType.alerted, models.TopicStatusType.acknowledged]
+        ),
     )
 
     rows = db.query(pteam_query.subquery()).all()

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
 from fastapi.responses import Response
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql.expression import func, true
 
@@ -1544,40 +1544,32 @@ def remove_watcher_ateam(
 @router.post("/{pteam_id}/fix_status_mismatch")
 def fix_status_mismatch(
     pteam_id: UUID,
-    current_user: models.Account = Depends(get_current_user),
+    # current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
-    check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
+    # check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
 
-    pteam_topics = (
-        db.query(models.Topic)
-        .join(
-            models.CurrentPTeamTopicTagStatus,
-            and_(
-                models.Topic.topic_id == models.CurrentPTeamTopicTagStatus.topic_id,
-                models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
-                models.CurrentPTeamTopicTagStatus.topic_status.in_(["alerted","acknowledged"]),
+    pteam_query = (
+        select(models.CurrentPTeamTopicTagStatus).where(
+            models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
+            models.CurrentPTeamTopicTagStatus.topic_status.in_(
+                [models.TopicStatusType.alerted, models.TopicStatusType.acknowledged]
             ),
         )
-        .all()
     )
 
-    pteam_tags = (
-        db.query(models.PTeamTag)
-        .join(
-            models.CurrentPTeamTopicTagStatus,
-            and_(
-                models.PTeamTag.tag_id == models.CurrentPTeamTopicTagStatus.tag_id,
-                models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
-                models.CurrentPTeamTopicTagStatus.topic_status.in_(["alerted","acknowledged"]),
-            ),
-        )
-        .all()
-    )
+    rows = db.query(pteam_query.subquery()).all()
 
-    for pteam_tag in pteam_tags:
-        for pteam_topic in pteam_topics:
-            pteamtag_try_auto_close_topic(db, pteam_tag, pteam_topic)
+    for row in rows:
+        pteam_tag = db.scalars(
+            select(models.PTeamTag).where(
+                models.PTeamTag.pteam_id == str(pteam_id), models.PTeamTag.tag_id == row.tag_id
+            )
+        ).one()
+        pteam_topic = db.scalars(
+            select(models.Topic).where(models.Topic.topic_id == row.topic_id)
+        ).one()
+        pteamtag_try_auto_close_topic(db, pteam_tag, pteam_topic)
 
     return Response(status_code=status.HTTP_200_OK)

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -6753,6 +6753,7 @@ def test_fix_mismatch(testdb: Session):
             models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam1.pteam_id),
             models.CurrentPTeamTopicTagStatus.topic_id == str(topic1.topic_id),
             models.CurrentPTeamTopicTagStatus.tag_id == str(tag1.tag_id),
+            models.CurrentPTeamTopicTagStatus.topic_status == "completed",
         )
         .one_or_none()
     )
@@ -6762,7 +6763,7 @@ def test_fix_mismatch(testdb: Session):
         .filter(
             models.PTeamTopicTagStatus.status_id == str(currentStatus.status_id),
             models.PTeamTopicTagStatus.topic_status == "completed",
-            models.PTeamTopicTagStatus.user_id == str(SYSTEM_UUID)
+            models.PTeamTopicTagStatus.user_id == str(SYSTEM_UUID),
         )
         .one_or_none()
     )
@@ -6770,8 +6771,10 @@ def test_fix_mismatch(testdb: Session):
 
     action_log = (
         testdb.query(models.ActionLog)
-        .filter(models.ActionLog.topic_id == str(currentStatus.topic_id),
-                models.ActionLog.user_id == str(SYSTEM_UUID))
+        .filter(
+            models.ActionLog.topic_id == str(currentStatus.topic_id),
+            models.ActionLog.user_id == str(SYSTEM_UUID),
+        )
         .one_or_none()
     )
     assert action_log is not None

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -6712,7 +6712,7 @@ def test_fix_status_mismatch(testdb: Session):
         )
         .one()
     )
-    currentStatus.topic_status = "alerted"
+    currentStatus.topic_status = models.TopicStatusType.alerted
     testdb.add(currentStatus)
 
     ptts = (
@@ -6723,7 +6723,7 @@ def test_fix_status_mismatch(testdb: Session):
         )
         .one()
     )
-    ptts.topic_status = "alerted"
+    ptts.topic_status = models.TopicStatusType.alerted
     testdb.add(ptts)
 
     action_log = (

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -6755,7 +6755,7 @@ def test_fix_status_mismatch(testdb: Session):
             models.CurrentPTeamTopicTagStatus.tag_id == str(tag1.tag_id),
             models.CurrentPTeamTopicTagStatus.topic_status == "completed",
         )
-        .one_or_none()
+        .one()
     )
     assert currentStatus is not None
     ptts = (
@@ -6765,7 +6765,7 @@ def test_fix_status_mismatch(testdb: Session):
             models.PTeamTopicTagStatus.topic_status == "completed",
             models.PTeamTopicTagStatus.user_id == str(SYSTEM_UUID),
         )
-        .one_or_none()
+        .one()
     )
     assert ptts is not None
 
@@ -6775,7 +6775,7 @@ def test_fix_status_mismatch(testdb: Session):
             models.ActionLog.topic_id == str(currentStatus.topic_id),
             models.ActionLog.user_id == str(SYSTEM_UUID),
         )
-        .one_or_none()
+        .one()
     )
     assert action_log is not None
 

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -6731,6 +6731,15 @@ def test_fix_mismatch(testdb: Session):
     testdb.delete(action_log)
     testdb.commit()
 
+    # set acknowledged topicstatus
+    request = {"topic_status": models.TopicStatusType.acknowledged}
+    response = client.post(
+        f"/pteams/{pteam1.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
+        headers=headers(USER1),
+        json=request,
+    )
+    assert response.status_code == 200
+
     # call fix_status_mimatch API
     response = client.post(
         f"/pteams/{pteam1.pteam_id}/fix_status_mismatch",

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -6617,7 +6617,7 @@ def test_remove_watcher():
     assert len(data) == 0
 
 
-def test_fix_mismatch(testdb: Session):
+def test_fix_status_mismatch(testdb: Session):
     create_user(USER1)
     pteam1 = create_pteam(USER1, {**PTEAM1, "tags": []})
     tag1 = create_tag(USER1, "test:tag:alpha")


### PR DESCRIPTION
## PR の目的
- 問題が起きているタグのオートクローズ実行用APIを作成(api/app/routers/pteams.py)
- 作成したAPIについてのテストを作成(api/app/tests/medium/routers/test_pteams.py)

## 経緯・意図・意思決定
オートクローズ実行用API（鶴田担当）
- CurrentPTeamTopicTagStatusテーブルでstatusがalerted、acknowledgedのものを取ってきています。(1553~1560行目)
scheduled_at が過去なものを取ってくる部分については未実装です。
- 取ってきたtag_idとtopic_idを使用しpteamtag_try_auto_close_topic()の引数に必要なTeamTagとTopicテーブルの情報を取ってきています。またpteamtag_try_auto_close_topic()を実行しています。(1564~1573行目)
- レスポンスは200番を返すようにしています。

テスト（小島担当）
- 上記のAPIに対してテストケースを追加しました。
- クローズされた状態から、DBを直接操作して、currentStatus, status, actionlogを削除して、クローズ前の状態を作っています。その状態から上記APIを呼び、再度クローズされるかを検証しています。

trivyignore
https://avd.aquasec.com/nvd/2024/cve-2024-23342/ をtrivyignoreに追加
