### PR TITLE
early return if topicActions not yet loaded

### DIFF
--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -84,7 +84,7 @@ export function ReportCompletedActions(props) {
     }
   };
 
-  if (!pteamId || !topicId || !topics[topicId]) return <></>;
+  if (!pteamId || !topicId || !topics[topicId] || !topicActions) return <></>;
 
   const handleClose = () => {
     setShow(false);


### PR DESCRIPTION
## PR の目的

- UI でアーティファクト表示時にホワイトアウトすることがある不具合を修正

topicActions のロードが完了する前に参照してしまうと発生していた模様。
ロード未完な場合にはブランクを返すことで対応。