### PR TITLE
add scheduled_at

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1550,14 +1550,33 @@ def fix_status_mismatch(
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
 
-    pteam_query = select(models.CurrentPTeamTopicTagStatus).where(
-        models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
-        models.CurrentPTeamTopicTagStatus.topic_status.in_(
-            [models.TopicStatusType.alerted, models.TopicStatusType.acknowledged]
-        ),
+    pteam_query = (
+        select(models.CurrentPTeamTopicTagStatus, models.PTeamTopicTagStatus)
+        .where(
+            models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
+            or_(
+                models.CurrentPTeamTopicTagStatus.topic_status.in_(
+                    [
+                        models.TopicStatusType.alerted,
+                        models.TopicStatusType.acknowledged,
+                    ]
+                ),
+                and_(
+                    models.PTeamTopicTagStatus.topic_status == models.TopicStatusType.scheduled,
+                    models.PTeamTopicTagStatus.scheduled_at < datetime.now(),
+                ),
+            ),
+        )
+        .join(
+            models.PTeamTopicTagStatus,
+            and_(
+                models.PTeamTopicTagStatus.status_id == models.CurrentPTeamTopicTagStatus.status_id,
+            ),
+        )
+        .subquery()
     )
 
-    rows = db.query(pteam_query.subquery()).all()
+    rows = db.query(pteam_query).all()
 
     for row in rows:
         pteam_tag = db.scalars(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1573,10 +1573,9 @@ def fix_status_mismatch(
                 models.PTeamTopicTagStatus.status_id == models.CurrentPTeamTopicTagStatus.status_id,
             ),
         )
-        .subquery()
     )
 
-    rows = db.query(pteam_query).all()
+    rows = db.scalars(pteam_query).all()
 
     for row in rows:
         pteam_tag = db.scalars(


### PR DESCRIPTION
## PR の目的
- 問題が起きているタグのオートクローズ実行用APIを作成(api/app/routers/pteams.py)
- 下記のpull requestで未実装だった部分を追加しました。
https://github.com/nttcom/threatconnectome/pull/54

## 経緯・意図・意思決定

- scheduled_at が過去なものについてにオートクローズするように実装しました。(1557~1576行目)
- PTeamTopicTagStatusテーブルをjoinし、scheduled_atの値を取ってくるようにしました。