### PR TITLE
fix key error

### DIFF
--- a/scripts/cdx_tags.py
+++ b/scripts/cdx_tags.py
@@ -128,7 +128,7 @@ class CDXComponents:
                 }
                 for (tag, refs) in self.components.items()
             ],
-            key=lambda x: x["tag"],
+            key=lambda x: x["tag_name"],
         )
 
 


### PR DESCRIPTION
## PR の目的

- key error が発生するので修正
  - models の "tag" を "tag_name" に変更した際の対応漏れ
