### PR TITLE
Refactoring/common create topicstatus function on test

### DIFF
--- a/api/app/tests/medium/routers/test_achievements.py
+++ b/api/app/tests/medium/routers/test_achievements.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
 
-from app import models, schemas
+from app import models
 from app.main import app
 from app.tests.medium.constants import (
     ACTION1,
@@ -27,6 +27,7 @@ from app.tests.medium.utils import (
     create_badge,
     create_pteam,
     create_topic,
+    create_topicstatus,
     create_user,
     headers,
     invite_to_pteam,
@@ -109,13 +110,7 @@ def test_create_secbadge_with_status_id():
     request1 = {
         "topic_status": "scheduled",
     }
-
-    response1 = client.post(
-        f"/pteams/{pteam.pteam_id}/topicstatus/{topic.topic_id}/{tag.tag_id}",
-        headers=headers(USER1),
-        json=request1,
-    )
-    topic_status = schemas.TopicStatusResponse(**response1.json())
+    topic_status = create_topicstatus(USER1, pteam.pteam_id, topic.topic_id, tag.tag_id, request1)
 
     metadata = {
         "name": f"he reason of {topic.title} has been found!",
@@ -336,12 +331,7 @@ def test_get_secbadges():
     request1 = {
         "topic_status": "scheduled",
     }
-    response1 = client.post(
-        f"/pteams/{pteam.pteam_id}/topicstatus/{topic.topic_id}/{tag.tag_id}",
-        headers=headers(USER1),
-        json=request1,
-    )
-    topic_status = schemas.TopicStatusResponse(**response1.json())
+    topic_status = create_topicstatus(USER1, pteam.pteam_id, topic.topic_id, tag.tag_id, request1)
 
     metadata2 = {
         "image": "",

--- a/api/app/tests/medium/routers/test_ateams.py
+++ b/api/app/tests/medium/routers/test_ateams.py
@@ -40,6 +40,7 @@ from app.tests.medium.utils import (
     create_pteam,
     create_tag,
     create_topic,
+    create_topicstatus,
     create_user,
     create_watching_request,
     create_zone,
@@ -1543,13 +1544,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.acknowledged,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam1.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam1.pteam_id, topic1.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1578,13 +1573,7 @@ def test_get_topic_status():
         "scheduled_at": str(datetime(3000, 1, 1)),
         "assignees": list(map(str, [user1.user_id, user2.user_id])),
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam1.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam1.pteam_id, topic1.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1612,13 +1601,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.completed,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam1.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam1.pteam_id, topic1.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 0
@@ -1695,13 +1678,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.completed,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic1.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1736,13 +1713,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.acknowledged,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic2.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic2.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1780,13 +1751,7 @@ def test_get_topic_status():
         "topic_status": models.TopicStatusType.scheduled,
         "scheduled_at": str(datetime(3000, 1, 1)),
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic2.topic_id}/{tag2.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic2.topic_id, tag2.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1828,13 +1793,7 @@ def test_get_topic_status():
         "topic_status": models.TopicStatusType.scheduled,
         "scheduled_at": str(datetime(3000, 12, 31)),
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam1.pteam_id}/topicstatus/{topic2.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam1.pteam_id, topic2.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1874,13 +1833,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.completed,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic2.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic2.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1911,13 +1864,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.completed,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic2.topic_id}/{tag2.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic2.topic_id, tag2.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1
@@ -1939,13 +1886,7 @@ def test_get_topic_status():
     request = {
         "topic_status": models.TopicStatusType.acknowledged,
     }
-    assert_200(
-        client.post(
-            f"/pteams/{pteam2.pteam_id}/topicstatus/{topic2.topic_id}/{tag1.tag_id}",
-            headers=headers(USER1),
-            json=request,
-        )
-    )
+    create_topicstatus(USER1, pteam2.pteam_id, topic2.topic_id, tag1.tag_id, request)
 
     data = assert_200(client.get(f"/ateams/{ateam1.ateam_id}/topicstatus", headers=headers(USER1)))
     assert data["num_topics"] == 1

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -51,6 +51,7 @@ from app.tests.medium.utils import (
     create_pteam,
     create_tag,
     create_topic,
+    create_topicstatus,
     create_user,
     create_watching_request,
     create_zone,
@@ -448,12 +449,7 @@ def test_delete_topic(testdb: Session):
         "assignees": [str(user1.user_id)],
         "scheduled_at": str(datetime(2023, 6, 1)),
     }
-    response = client.post(
-        f"/pteams/{pteam1.pteam_id}/topicstatus/{topic1.topic_id}/{tag1.tag_id}",
-        headers=headers(USER1),
-        json=json_data,
-    )
-    assert response.status_code == 200
+    create_topicstatus(USER1, pteam1.pteam_id, topic1.topic_id, tag1.tag_id, json_data)
 
     # delete topic
     response = client.delete(f"/topics/{TOPIC1['topic_id']}", headers=headers(USER1))

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -352,6 +352,19 @@ def create_badge(
     return schemas.SecBadgeBody(**response.json())
 
 
+def create_topicstatus(
+    user: dict, pteam_id: UUID, topic_id: UUID, tag_id: UUID, json: dict
+) -> schemas.TopicStatusResponse:
+    response = assert_200(
+        client.post(
+            f"/pteams/{pteam_id}/topicstatus/{topic_id}/{tag_id}",
+            headers=headers(user),
+            json=json,
+        )
+    )
+    return schemas.TopicStatusResponse(**response)
+
+
 def common_put(user: dict, api_path: str, **kwargs) -> dict:
     response = client.put(api_path, headers=headers(user), json=kwargs)
     if response.status_code != 200:


### PR DESCRIPTION
## PR の目的
apiテストで、create_topicstatus の共通関数を呼ぶようにしました。

## 経緯・意図・意思決定
共通関数を作成し、テストのコード行数の削減、可読性の向上を狙いました。
今後も時間あるときに、同様の共通関数を作ろうと思います。

## 参考文献
