### PR TITLE
add option to speed up scanning

### DIFF
--- a/scripts/upload_trivy_scaned_tags.sh
+++ b/scripts/upload_trivy_scaned_tags.sh
@@ -60,7 +60,7 @@ trap "rm -f -- '${trivy_output}' '${tags_jsonl}'" EXIT HUP INT QUIT TERM
 script_path=$(dirname "$0")
 
 echo >&2 "processing trivy."
-trivy_cmd="${trivy_command_path} fs '${scan_path}' --list-all-pkgs --exit-code 0 --timeout '${trivy_timeout}' -f json -o '${trivy_output}' -q"
+trivy_cmd="${trivy_command_path} fs '${scan_path}' --list-all-pkgs --scanners vuln --exit-code 0 --timeout '${trivy_timeout}' -f json -o '${trivy_output}' -q"
 echo >&2 "${trivy_cmd}"
 eval "${trivy_cmd}" || giveup "trivy scan failed with ret_code=$?."
 


### PR DESCRIPTION
## PR の目的

TrivyのFilesystemスキャン結果をSBOMとして登録するスクリプト(`upload_trivy_scaned_tags.sh`)の高速化

## 経緯・意図・意思決定

取得する必要のない情報を収集していたので、高速化のためにTrivyコマンドオプションを追加しました。

## 参考文献
https://aquasecurity.github.io/trivy/v0.48/docs/configuration/others/#enabledisable-scanners