### PR TITLE
Auto Closeボタンの追加

### DIFF
--- a/web/src/components/PTeamAutoClose.jsx
+++ b/web/src/components/PTeamAutoClose.jsx
@@ -1,0 +1,26 @@
+import { Box, Button, Typography } from "@mui/material";
+import { useSnackbar } from "notistack";
+import React from "react";
+
+import { commonButtonStyle } from "../utils/const";
+
+export function PTeamAutoClose() {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleSave = async () => {
+    enqueueSnackbar("Auto Close Accepted", { variant: "success" });
+  };
+
+  return (
+    <Box>
+      <Box display="flex" flexDirection="row" alignItems="center">
+        <Typography variant="body2" mb={1} mr={2}>
+          Close only Alerted tags.
+        </Typography>
+        <Button onClick={handleSave} sx={{ ...commonButtonStyle, mb: 1 }}>
+          Done
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -19,6 +19,7 @@ import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
 import { a11yProps } from "../utils/func.js";
 
 import { PTeamAuthEditor } from "./PTeamAuthEditor";
+import { PTeamAutoClose } from "./PTeamAutoClose";
 import { PTeamGeneralSetting } from "./PTeamGeneralSetting";
 import { SBOMDropArea } from "./SBOMDropArea";
 import { TagMonitoring } from "./TagMonitoring";
@@ -59,6 +60,7 @@ export function PTeamSettingsModal(props) {
             <Tab label="Monitor" {...a11yProps(1)} />
             <Tab label="Authorities" {...a11yProps(2)} />
             <Tab label="Upload" {...a11yProps(3)} />
+            <Tab label="Auto Close" {...a11yProps(3)} />
           </Tabs>
         </Box>
         <TabPanel index={0} value={tab}>
@@ -72,6 +74,7 @@ export function PTeamSettingsModal(props) {
         </TabPanel>
         <TabPanel index={3} value={tab}>
           <SBOMDropArea pteamId={pteamId} onUploaded={handleSBOMUploaded} />
+          <PTeamAutoClose />
         </TabPanel>
       </DialogContent>
     </Dialog>

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -26,6 +26,7 @@ export function PTeamTagAutoClose(props) {
         dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
         dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
         dispatch(getPTeamTagsSummary(pteamId));
+        // TODO: topic.status is changed when a autocolse button is pressed.
       })
       .catch((error) => {
         const resp = error.response;

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -1,22 +1,30 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
+import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { getPTeamTagsSummary } from "../slices/pteam";
-import { autoClose } from "../utils/api";
+import {
+  getPTeamSolvedTaggedTopicIds,
+  getPTeamUnsolvedTaggedTopicIds,
+  getPTeamTagsSummary,
+} from "../slices/pteam";
+import { autoCloseTag } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
-export function PTeamAutoClose() {
+export function PTeamTagAutoClose(props) {
+  const { tagId } = props;
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
   const handleSave = async () => {
-    await autoClose(pteamId)
+    await autoCloseTag(pteamId, tagId)
       .then(() => {
         enqueueSnackbar("Auto Close Accepted", { variant: "success" });
+        dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
+        dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
         dispatch(getPTeamTagsSummary(pteamId));
       })
       .catch((error) => {
@@ -41,3 +49,7 @@ export function PTeamAutoClose() {
     </Box>
   );
 }
+
+PTeamTagAutoClose.propTypes = {
+  tagId: PropTypes.string.isRequired,
+};

--- a/web/src/components/PTeamTagLabel.jsx
+++ b/web/src/components/PTeamTagLabel.jsx
@@ -1,10 +1,12 @@
 import { Settings as SettingsIcon } from "@mui/icons-material";
 import { Box, IconButton } from "@mui/material";
+import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import { PTeamTagSettingsModal } from "./PTeamTagSettingsModal";
 
-export function PTeamTagLabel() {
+export function PTeamTagLabel(props) {
+  const { tagId } = props;
   const [pteamTagSettingsModalOpen, setPTeamTagSettingsModalOpen] = useState(false);
 
   return (
@@ -19,7 +21,12 @@ export function PTeamTagLabel() {
       <PTeamTagSettingsModal
         setShow={setPTeamTagSettingsModalOpen}
         show={pteamTagSettingsModalOpen}
+        tagId={tagId}
       />
     </>
   );
 }
+
+PTeamTagLabel.propTypes = {
+  tagId: PropTypes.string.isRequired,
+};

--- a/web/src/components/PTeamTagLabel.jsx
+++ b/web/src/components/PTeamTagLabel.jsx
@@ -1,0 +1,25 @@
+import { Settings as SettingsIcon } from "@mui/icons-material";
+import { Box, IconButton } from "@mui/material";
+import React, { useState } from "react";
+
+import { PTeamTagSettingsModal } from "./PTeamTagSettingsModal";
+
+export function PTeamTagLabel() {
+  const [pteamTagSettingsModalOpen, setPTeamTagSettingsModalOpen] = useState(false);
+
+  return (
+    <>
+      <Box display="flex" flexDirection="column">
+        <Box display="flex" alignItems="center">
+          <IconButton onClick={() => setPTeamTagSettingsModalOpen(true)}>
+            <SettingsIcon />
+          </IconButton>
+        </Box>
+      </Box>
+      <PTeamTagSettingsModal
+        setShow={setPTeamTagSettingsModalOpen}
+        show={pteamTagSettingsModalOpen}
+      />
+    </>
+  );
+}

--- a/web/src/components/PTeamTagSettingsModal.jsx
+++ b/web/src/components/PTeamTagSettingsModal.jsx
@@ -4,10 +4,10 @@ import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { PTeamAutoClose } from "./PTeamAutoClose";
+import { PTeamTagAutoClose } from "./PTeamTagAutoClose";
 
 export function PTeamTagSettingsModal(props) {
-  const { setShow, show } = props;
+  const { setShow, show, tagId } = props;
 
   const handleClose = () => setShow(false);
 
@@ -24,7 +24,7 @@ export function PTeamTagSettingsModal(props) {
         </Box>
       </DialogTitle>
       <DialogContent>
-        <PTeamAutoClose />
+        <PTeamTagAutoClose tagId={tagId} />
       </DialogContent>
     </Dialog>
   );
@@ -32,4 +32,5 @@ export function PTeamTagSettingsModal(props) {
 PTeamTagSettingsModal.propTypes = {
   setShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
+  tagId: PropTypes.string.isRequired,
 };

--- a/web/src/components/PTeamTagSettingsModal.jsx
+++ b/web/src/components/PTeamTagSettingsModal.jsx
@@ -1,0 +1,35 @@
+import { Close as CloseIcon } from "@mui/icons-material";
+import { Box, Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { PTeamAutoClose } from "./PTeamAutoClose";
+
+export function PTeamTagSettingsModal(props) {
+  const { setShow, show } = props;
+
+  const handleClose = () => setShow(false);
+
+  return (
+    <Dialog fullWidth onClose={handleClose} open={show}>
+      <DialogTitle>
+        <Box alignItems="center" display="flex" flexDirection="row">
+          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+            Tag Close
+          </Typography>
+          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <PTeamAutoClose />
+      </DialogContent>
+    </Dialog>
+  );
+}
+PTeamTagSettingsModal.propTypes = {
+  setShow: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
+};

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -109,7 +109,7 @@ export function Tag() {
             <Typography variant="h4" sx={{ fontWeight: 900 }}>
               {tagDict.tag_name}
             </Typography>
-            <PTeamTagLabel />
+            <PTeamTagLabel tagId={tagId} />
           </Box>
           <UUIDTypography>{tagId}</UUIDTypography>
           <Typography mt={1} mr={1} mb={1} variant="caption">

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { PTeamTagLabel } from "../components/PTeamTagLabel.jsx";
 import { PTeamTaggedTopics } from "../components/PTeamTaggedTopics";
 import { TabPanel } from "../components/TabPanel";
 import { TagReferences } from "../components/TagReferences";
@@ -104,9 +105,12 @@ export function Tag() {
     <>
       <Box alignItems="center" display="flex" flexDirection="row" mt={3} mb={3}>
         <Box display="flex" flexDirection="column" flexGrow={1}>
-          <Typography variant="h4" sx={{ fontWeight: 900 }}>
-            {tagDict.tag_name}
-          </Typography>
+          <Box display="flex" alignItems="center">
+            <Typography variant="h4" sx={{ fontWeight: 900 }}>
+              {tagDict.tag_name}
+            </Typography>
+            <PTeamTagLabel />
+          </Box>
           <UUIDTypography>{tagId}</UUIDTypography>
           <Typography mt={1} mr={1} mb={1} variant="caption">
             {`Updated ${calcTimestampDiff(pteamtag.last_updated_at)}`}

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -98,6 +98,11 @@ export const uploadSBOMFile = async (pteamId, group, file, forceMode = true) => 
   });
 };
 
+export const autoClose = async (pteamId) => axios.post(`/pteams/${pteamId}/fix_status_mismatch`);
+
+export const autoCloseTag = async (pteamId, tagId) =>
+  axios.post(`/pteams/${pteamId}/tags/${tagId}/fix_status_mismatch`);
+
 // ateams
 export const updateATeam = async (ateamId, data) => axios.put(`/ateams/${ateamId}`, data);
 


### PR DESCRIPTION
## PR の目的
- 画面上でAutoCloseを実施するためにStatusとTagsの歯車アイコン内モーダルにボタンを追加する

## 経緯・意図・意思決定
- 使用頻度がそんなに高くないので、設定内に収めた
- Tagsは歯車アイコンを新設した
