### PR TITLE
[UI] Upload SBOM File

### DIFF
--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -12,21 +12,33 @@ import {
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import { TabPanel } from "../components/TabPanel";
+import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
 import { a11yProps } from "../utils/func.js";
 
 import { PTeamAuthEditor } from "./PTeamAuthEditor";
 import { PTeamGeneralSetting } from "./PTeamGeneralSetting";
+import { SBOMDropArea } from "./SBOMDropArea";
 import { TagMonitoring } from "./TagMonitoring";
 
 export function PTeamSettingsModal(props) {
+  const dispatch = useDispatch();
+
   const { setShow, show, defaultTabIndex } = props;
   const [tab, setTab] = useState(defaultTabIndex ?? 0);
 
   const handleClose = () => setShow(false);
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
+
+  const pteamId = useSelector((state) => state.pteam.pteamId); // dispatched by App or PTeamSelector
+
+  const handleSBOMUploaded = () => {
+    dispatch(getPTeamTagsSummary(pteamId));
+    dispatch(getPTeamGroups(pteamId));
+  };
 
   return (
     <Dialog fullWidth onClose={handleClose} open={show} maxWidth="md">
@@ -46,6 +58,7 @@ export function PTeamSettingsModal(props) {
             <Tab label="General" {...a11yProps(0)} />
             <Tab label="Monitor" {...a11yProps(1)} />
             <Tab label="Authorities" {...a11yProps(2)} />
+            <Tab label="Upload" {...a11yProps(3)} />
           </Tabs>
         </Box>
         <TabPanel index={0} value={tab}>
@@ -56,6 +69,9 @@ export function PTeamSettingsModal(props) {
         </TabPanel>
         <TabPanel index={2} value={tab}>
           <PTeamAuthEditor />
+        </TabPanel>
+        <TabPanel index={3} value={tab}>
+          <SBOMDropArea pteamId={pteamId} onUploaded={handleSBOMUploaded} />
         </TabPanel>
       </DialogContent>
     </Dialog>

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -1,0 +1,149 @@
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useSnackbar } from "notistack";
+import PropTypes from "prop-types";
+import React, { useEffect, useRef, useState } from "react";
+
+import { uploadSBOMFile } from "../utils/api";
+import { errorToString } from "../utils/func";
+
+function PreUploadModal(props) {
+  const { sbomFile, open, setOpen, onCompleted } = props;
+  const [groupName, setGroupName] = useState("");
+
+  const handleClose = () => {
+    setGroupName("");
+    setOpen(false);
+  };
+  const handleUpload = () => {
+    onCompleted(groupName); // parent will close me
+    setGroupName(""); // reset for next open
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>
+        <Box display="flex">
+          <Typography>Upload SBOM file</Typography>
+          <Box flexGrow={1} />
+          <IconButton onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <Typography>Selected file: {sbomFile?.name}</Typography>
+      <DialogContent>
+        <TextField
+          label="Group name"
+          value={groupName}
+          onChange={(event) => setGroupName(event.target.value)}
+          required
+          error={!groupName}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleUpload} disabled={!groupName}>
+          Upload
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+PreUploadModal.propTypes = {
+  sbomFile: PropTypes.object.isRequired,
+  open: PropTypes.bool.isRequired,
+  setOpen: PropTypes.func.isRequired,
+  onCompleted: PropTypes.func.isRequired,
+};
+
+export function SBOMDropArea(props) {
+  const { pteamId, onUploaded } = props;
+  const dropRef = useRef(null);
+  const { enqueueSnackbar } = useSnackbar();
+  const [sbomFile, setSbomFile] = useState(null);
+  const [preModalOpen, setPreModalOpen] = useState(false);
+
+  useEffect(() => {
+    dropRef.current.addEventListener("dragover", handleDragOver);
+    dropRef.current.addEventListener("drop", handleDrop);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleDragOver = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    /* nothing to do */
+  };
+
+  const handleDrop = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const { files } = event.dataTransfer;
+    if (files && files.length) {
+      if (files.length > 1) {
+        alert("Please drop only 1 file");
+        return;
+      }
+      if (!files[0].name.endsWith(".json")) {
+        alert("Only *.json is supported");
+        return;
+      }
+      setSbomFile(files[0]);
+      setPreModalOpen(true);
+    }
+  };
+  const handlePreUploadCompleted = (group) => {
+    setPreModalOpen(false);
+    processUploadSBOM(sbomFile, group);
+  };
+
+  const processUploadSBOM = (file, group) => {
+    if (!file || !group) {
+      alert("Something went wrong: missing file or group.");
+      return;
+    }
+    enqueueSnackbar(`Uploading SBOM file: ${file.name}`, { variant: "info" });
+    uploadSBOMFile(pteamId, group, file)
+      .then((response) => {
+        enqueueSnackbar("Upload SBOM succeeded", { variant: "success" });
+        onUploaded();
+      })
+      .catch((error) => {
+        const msg = errorToString(error);
+        enqueueSnackbar(`Operation failed: ${msg}`, { variant: "error" });
+      })
+      .finally(() => {
+        setSbomFile(null);
+      });
+  };
+
+  if (!pteamId) return <></>;
+
+  return (
+    <>
+      <Box ref={dropRef} sx={{ width: 300, height: 100, border: 1 }}>
+        <Typography>Upload SBOM file here!</Typography>
+      </Box>
+      <PreUploadModal
+        sbomFile={sbomFile}
+        open={preModalOpen}
+        setOpen={setPreModalOpen}
+        onCompleted={(group) => handlePreUploadCompleted(group)}
+      />
+    </>
+  );
+}
+SBOMDropArea.propTypes = {
+  pteamId: PropTypes.string.isRequired,
+  onUploaded: PropTypes.func.isRequired,
+};

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -1,4 +1,7 @@
-import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Close as CloseIcon,
+  UploadFile as UploadFileIcon
+} from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -10,11 +13,13 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useRef, useState } from "react";
 
 import { uploadSBOMFile } from "../utils/api";
+import { modalCommonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 function PreUploadModal(props) {
@@ -31,36 +36,47 @@ function PreUploadModal(props) {
   };
 
   return (
-    <Dialog open={open} onClose={handleClose}>
+    <Dialog fullWidth open={open} onClose={handleClose}>
       <DialogTitle>
-        <Box display="flex">
-          <Typography>Upload SBOM file</Typography>
-          <Box flexGrow={1} />
-          <IconButton onClick={handleClose}>
+        <Box alignItems="center" display="flex" flexDirection="row">
+          <Typography flexGrow={1} variant="inherit">
+            Upload SBOM File
+          </Typography>
+          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
             <CloseIcon />
           </IconButton>
         </Box>
       </DialogTitle>
-      <Typography>Selected file: {sbomFile?.name}</Typography>
       <DialogContent>
-        <TextField
-          label="Group name"
-          value={groupName}
-          onChange={(event) => setGroupName(event.target.value)}
-          required
-          error={!groupName}
-        />
+        <Box display="flex" flexDirection="column">
+          <TextField
+            label="Group name"
+            size="small"
+            value={groupName}
+            onChange={(event) => setGroupName(event.target.value)}
+            required
+            error={!groupName}
+            sx={{ mt: 2 }}
+          />
+          <Box display="flex" flexDirection="row" sx={{ mt: 1, ml: 1 }}>
+            <Typography sx={{ fontWeight: "bold" }}>Selected file: </Typography>
+            <Typography>{sbomFile?.name}</Typography>
+          </Box>
+        </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleUpload} disabled={!groupName}>
-          Upload
-        </Button>
+        <Box sx={{ display: "flex", flexDirection: "row", mr: 1, mb: 1 }}>
+          <Box sx={{ flex: "1 1 auto" }} />
+          <Button onClick={handleUpload} disabled={!groupName} sx={modalCommonButtonStyle}>
+            Upload
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   );
 }
 PreUploadModal.propTypes = {
-  sbomFile: PropTypes.object.isRequired,
+  sbomFile: PropTypes.object,
   open: PropTypes.bool.isRequired,
   setOpen: PropTypes.func.isRequired,
   onCompleted: PropTypes.func.isRequired,
@@ -131,8 +147,16 @@ export function SBOMDropArea(props) {
 
   return (
     <>
-      <Box ref={dropRef} sx={{ width: 300, height: 100, border: 1 }}>
-        <Typography>Upload SBOM file here!</Typography>
+      <Box
+        alignItems="center"
+        justifyContent="center"
+        display="flex"
+        flexDirection="column"
+        ref={dropRef}
+        sx={{ width: "100%", minHeight: "300px", border: "4px dotted #888" }}
+      >
+        <UploadFileIcon sx={{ fontSize: 50, mb: 3 }} />
+        <Typography>Drop SBOM file here</Typography>
       </Box>
       <PreUploadModal
         sbomFile={sbomFile}

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -1,7 +1,4 @@
-import {
-  Close as CloseIcon,
-  UploadFile as UploadFileIcon
-} from "@mui/icons-material";
+import { Close as CloseIcon, UploadFile as UploadFileIcon } from "@mui/icons-material";
 import {
   Box,
   Button,

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -6,7 +6,6 @@ import {
 } from "@mui/icons-material";
 import {
   Box,
-  Button,
   Chip,
   IconButton,
   InputAdornment,
@@ -36,7 +35,6 @@ import { PTeamStatusCard } from "../components/PTeamStatusCard";
 import { SBOMDropArea } from "../components/SBOMDropArea";
 import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
 import {
-  commonButtonStyle,
   noPTeamMessage,
   threatImpactName,
   threatImpactProps,
@@ -136,23 +134,6 @@ export function Status() {
   }
   const targetTags = filteredTags.slice(perPage * (page - 1), perPage * page);
 
-  const notRegistered = (
-    <>
-      <Box display="flex" alignItems="flex-start" flexDirection="column">
-        <Typography variant="body1">
-          No artifact tags have been registered yet. Please register first.
-        </Typography>
-        <Button
-          sx={commonButtonStyle}
-          target="_blank"
-          href="https://docs.google.com/document/d/1QWkH21pnuTD4S1bHY9RD-qH5I3bzvyJnJr72itSP87w/edit?usp=sharing"
-        >
-          Open Docs
-        </Button>
-      </Box>
-    </>
-  );
-
   const filterRow = (
     <Box display="flex" alignItems="center" sx={{ mt: 1 }}>
       <Pagination
@@ -247,8 +228,8 @@ export function Status() {
                       ? "0"
                       : "1"
                     : iFilter[val] // keep current
-                    ? "1"
-                    : "0"),
+                      ? "1"
+                      : "0"),
                 ""
               )
             );
@@ -286,19 +267,13 @@ export function Status() {
 
   return (
     <>
-      {summary.tags?.length > 0 || (
-        <SBOMDropArea pteamId={pteamId} onUploaded={handleSBOMUploaded} />
-      )}
       <Box display="flex" flexDirection="row">
         <PTeamLabel defaultTabIndex={1} />
         <Box flexGrow={1} />
       </Box>
       <PTeamGroupChip />
       {summary.tags.length === 0 ? (
-        <Box display="flex">
-          {notRegistered}
-          <Box flexGrow={1} />
-        </Box>
+        <SBOMDropArea pteamId={pteamId} onUploaded={handleSBOMUploaded} />
       ) : (
         <>
           <Box display="flex" mt={2}>

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -34,11 +34,7 @@ import { PTeamLabel } from "../components/PTeamLabel";
 import { PTeamStatusCard } from "../components/PTeamStatusCard";
 import { SBOMDropArea } from "../components/SBOMDropArea";
 import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
-import {
-  noPTeamMessage,
-  threatImpactName,
-  threatImpactProps,
-} from "../utils/const";
+import { noPTeamMessage, threatImpactName, threatImpactProps } from "../utils/const";
 const threatImpactCountMax = 99999;
 
 function SearchField(props) {
@@ -228,8 +224,8 @@ export function Status() {
                       ? "0"
                       : "1"
                     : iFilter[val] // keep current
-                      ? "1"
-                      : "0"),
+                    ? "1"
+                    : "0"),
                 ""
               )
             );

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -27,12 +27,14 @@ import {
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
 import { PTeamGroupChip } from "../components/PTeamGroupChip";
 import { PTeamLabel } from "../components/PTeamLabel";
 import { PTeamStatusCard } from "../components/PTeamStatusCard";
+import { SBOMDropArea } from "../components/SBOMDropArea";
+import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
 import {
   commonButtonStyle,
   noPTeamMessage,
@@ -87,6 +89,7 @@ SearchField.propTypes = {
 export function Status() {
   const location = useLocation();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const params = new URLSearchParams(location.search);
   const searchWord = params.get("word")?.trim().toLowerCase() ?? "";
@@ -101,6 +104,11 @@ export function Status() {
 
   if (!pteamId) return <>{noPTeamMessage}</>;
   else if (!user || !summary) return <>Now loading...</>;
+
+  const handleSBOMUploaded = () => {
+    dispatch(getPTeamTagsSummary(pteamId));
+    dispatch(getPTeamGroups(pteamId));
+  };
 
   const iFilter = [0, 1, 2, 3].reduce(
     (ret, idx) => ({
@@ -278,6 +286,9 @@ export function Status() {
 
   return (
     <>
+      {summary.tags?.length > 0 || (
+        <SBOMDropArea pteamId={pteamId} onUploaded={handleSBOMUploaded} />
+      )}
       <Box display="flex" flexDirection="row">
         <PTeamLabel defaultTabIndex={1} />
         <Box flexGrow={1} />

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -85,6 +85,19 @@ export const removeWatcherATeam = async (pteamId, ateamId) =>
 
 export const getPTeamGroups = async (pteamId) => axios.get(`/pteams/${pteamId}/groups`);
 
+export const uploadSBOMFile = async (pteamId, group, file, forceMode = true) => {
+  const formData = new FormData();
+  formData.append("file", file);
+  const paramData = {
+    group: group,
+    force_mode: forceMode,
+  };
+  return axios.post(`/pteams/${pteamId}/upload_sbom_file`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+    params: paramData,
+  });
+};
+
 // ateams
 export const updateATeam = async (ateamId, data) => axios.put(`/ateams/${ateamId}`, data);
 


### PR DESCRIPTION
## PR の目的

- SBOM ファイルを Drag＆Drop で PTeam に登録できる UI を実装

## 経緯・意図・意思決定

- D&D を実現するライブラリは存在するが、開発が止まっていたりして手頃なのが見つからなかった。今回の用途では非常に単純な処理だけなので、自前で実装している。

- デザイン部分については現在はDrag&Dropのみ対応。（クリックでエクスプローラー立ち上げは非対応）
- １つもTagがない場合は、以前Docksへのリンクがあった部分に差し替え
- 既存のTagに新たに追加する場合は、SettingsからUploadする
- Setting内のタブの数に注意（AutoCloseが入ります）