### PR TITLE
use rootfs scan

### DIFF
--- a/scripts/upload_trivy_scaned_tags.sh
+++ b/scripts/upload_trivy_scaned_tags.sh
@@ -60,7 +60,7 @@ trap "rm -f -- '${trivy_output}' '${tags_jsonl}'" EXIT HUP INT QUIT TERM
 script_path=$(dirname "$0")
 
 echo >&2 "processing trivy."
-trivy_cmd="${trivy_command_path} fs '${scan_path}' --list-all-pkgs --scanners vuln --exit-code 0 --timeout '${trivy_timeout}' -f json -o '${trivy_output}' -q"
+trivy_cmd="${trivy_command_path} rootfs '${scan_path}' --list-all-pkgs --scanners vuln --exit-code 0 --timeout '${trivy_timeout}' -f json -o '${trivy_output}' -q"
 echo >&2 "${trivy_cmd}"
 eval "${trivy_cmd}" || giveup "trivy scan failed with ret_code=$?."
 


### PR DESCRIPTION
## PR の目的

upload_trivy_scanned_tags.shはサーバ内で想定することを想定しているため、trivyのrootfs scanを使うように変更


## 経緯・意図・意思決定


## 参考文献
https://aquasecurity.github.io/trivy/v0.48/docs/target/rootfs/