### PR TITLE
Topic/fix status mismatch tag

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1664,6 +1664,7 @@ def fix_status_mismatch_tag(
 ):
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
+    pteam_tag = validate_pteamtag(db, pteam_id, tag_id, on_error=status.HTTP_404_NOT_FOUND)
 
     pteam_query = (
         select(models.CurrentPTeamTopicTagStatus, models.PTeamTopicTagStatus)
@@ -1692,11 +1693,6 @@ def fix_status_mismatch_tag(
     )
 
     rows = db.scalars(pteam_query).all()
-    pteam_tag = db.scalars(
-        select(models.PTeamTag).where(
-            models.PTeamTag.pteam_id == str(pteam_id), models.PTeamTag.tag_id == str(tag_id)
-        )
-    ).one()
 
     for row in rows:
         pteam_topic = db.scalars(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1653,3 +1653,55 @@ def fix_status_mismatch(
         pteamtag_try_auto_close_topic(db, pteam_tag, pteam_topic)
 
     return Response(status_code=status.HTTP_200_OK)
+
+
+@router.post("/{pteam_id}/tags/{tag_id}/fix_status_mismatch")
+def fix_status_mismatch_tag(
+    pteam_id: UUID,
+    tag_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
+    check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
+
+    pteam_query = (
+        select(models.CurrentPTeamTopicTagStatus, models.PTeamTopicTagStatus)
+        .where(
+            models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
+            models.CurrentPTeamTopicTagStatus.tag_id == str(tag_id),
+            or_(
+                models.CurrentPTeamTopicTagStatus.topic_status.in_(
+                    [
+                        models.TopicStatusType.alerted,
+                        models.TopicStatusType.acknowledged,
+                    ]
+                ),
+                and_(
+                    models.PTeamTopicTagStatus.topic_status == models.TopicStatusType.scheduled,
+                    models.PTeamTopicTagStatus.scheduled_at < datetime.now(),
+                ),
+            ),
+        )
+        .join(
+            models.PTeamTopicTagStatus,
+            and_(
+                models.PTeamTopicTagStatus.status_id == models.CurrentPTeamTopicTagStatus.status_id,
+            ),
+        )
+    )
+
+    rows = db.scalars(pteam_query).all()
+    pteam_tag = db.scalars(
+            select(models.PTeamTag).where(
+                models.PTeamTag.pteam_id == str(pteam_id), models.PTeamTag.tag_id == str(tag_id)
+            )
+        ).one()
+
+    for row in rows:
+        pteam_topic = db.scalars(
+            select(models.Topic).where(models.Topic.topic_id == row.topic_id)
+        ).one()
+        pteamtag_try_auto_close_topic(db, pteam_tag, pteam_topic)
+
+    return Response(status_code=status.HTTP_200_OK)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1665,6 +1665,7 @@ def fix_status_mismatch_tag(
     validate_pteam(db, pteam_id, on_error=status.HTTP_404_NOT_FOUND)
     check_pteam_membership(db, pteam_id, current_user.user_id, on_error=status.HTTP_403_FORBIDDEN)
     pteam_tag = validate_pteamtag(db, pteam_id, tag_id, on_error=status.HTTP_404_NOT_FOUND)
+    assert pteam_tag
 
     pteam_query = (
         select(models.CurrentPTeamTopicTagStatus, models.PTeamTopicTagStatus)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1693,10 +1693,10 @@ def fix_status_mismatch_tag(
 
     rows = db.scalars(pteam_query).all()
     pteam_tag = db.scalars(
-            select(models.PTeamTag).where(
-                models.PTeamTag.pteam_id == str(pteam_id), models.PTeamTag.tag_id == str(tag_id)
-            )
-        ).one()
+        select(models.PTeamTag).where(
+            models.PTeamTag.pteam_id == str(pteam_id), models.PTeamTag.tag_id == str(tag_id)
+        )
+    ).one()
 
     for row in rows:
         pteam_topic = db.scalars(


### PR DESCRIPTION
## PR の目的
- 問題が起きているタグを指定してオートクローズ実行するAPIを作成(api/app/routers/pteams.py)

## 経緯・意図・意思決定
- pteam_idとtag_idを指定し、オートクローズするように実装しました。
- CurrentPTeamTopicTagStatusテーブルでstatusがalerted、acknowledged、scheduled_at が過去なものを取ってきています。(1670~1683行目)
- データベースから取ってきたtopic_idを使用しpteamtag_try_auto_close_topic()の引数に必要なTeamTagとTopicテーブルの情報を取ってきています。またpteamtag_try_auto_close_topic()を実行しています。(1695~1705行目)
- レスポンスは200番を返すようにしています。
- テストに関しては別のPRで追加するつもりです。
