### PR TITLE
call outerjoin instead of join

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1631,7 +1631,7 @@ def fix_status_mismatch(
                 ),
             ),
         )
-        .join(
+        .outerjoin(
             models.PTeamTopicTagStatus,
             and_(
                 models.PTeamTopicTagStatus.status_id == models.CurrentPTeamTopicTagStatus.status_id,
@@ -1685,7 +1685,7 @@ def fix_status_mismatch_tag(
                 ),
             ),
         )
-        .join(
+        .outerjoin(
             models.PTeamTopicTagStatus,
             and_(
                 models.PTeamTopicTagStatus.status_id == models.CurrentPTeamTopicTagStatus.status_id,


### PR DESCRIPTION
## PR の目的

- fix status mismatch が alerted な対象に対して機能していなかった不具合を修正

