### PR TITLE
update vscode settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,8 @@
         "charliermarsh.ruff", // Ruff for linting
         "ms-python.python",// python
         "esbenp.prettier-vscode", //prettier
+        "ms-python.pylint", //pylint
+        "ms-python.mypy-type-checker", //mypy
+        "ms-python.black-formatter" //black
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
         "charliermarsh.ruff", // Ruff for linting
         "ms-python.python",// python
         "esbenp.prettier-vscode", //prettier
-        "ms-python.pylint", //pylint
         "ms-python.mypy-type-checker", //mypy
         "ms-python.black-formatter" //black
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,34 +2,23 @@
     "[javascriptreact]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.codeActionsOnSave": {
-            "source.organizeImports": false
+            "source.organizeImports": "never"
         }
     },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[python]": {
-        "editor.defaultFormatter": "ms-python.python",
+        "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.codeActionsOnSave": {
-            "source.fixAll": true,
-            // disable isort because it conflicts with ruff
-            "source.organizeImports": false
+            "source.fixAll": "explicit",
+            "source.organizeImports": "never"
         }
     },
     "python.languageServer": "Pylance",
-    "python.linting.lintOnSave": true,
-    "python.linting.pylintEnabled": false,
-    "python.linting.mypyEnabled": true,
-    "python.formatting.provider": "black",
-    "python.formatting.blackPath": "black",
-    "python.formatting.blackArgs": [
-        "--config",
-        "api/pyproject.toml",
-    ],
-    "ruff.args": [
-        "--config",
-        "api/pyproject.toml",
-    ],
+
+    "black-formatter.args": ["--config", "api/pyproject.toml"],
+    "ruff.lint.args": ["--config", "api/pyproject.toml"],
     //"ruff.fixAll": true,
     "files.insertFinalNewline": true,
     "editor.formatOnSave": true


### PR DESCRIPTION
## PR の目的

vscodeでdeprecatedになっていた設定を修正しました。
pythonのblack, mypyはblackを利用する方式に変更してあります

## 経緯・意図・意思決定
pythonツールの移行についての説明
https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions

pythonのデフォルトフォーマッターは従来通りblackとしていますが、ruffにblack同様のフォーマッター機能が追加されているので、ruffに変更しても良いかもしれません



## 参考文献
