### PR TITLE
use distro as pkg_info if have

### DIFF
--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -315,7 +315,12 @@ class SyftCDXParser(SBOMParser):
                 return None
             name_pref = f"{self.purl.namespace}/" if self.purl.namespace else ""
             pkg_name = name_pref + self.purl.name
-            pkg_info = self.purl.type
+            distro = (
+                self.purl.qualifiers.get("distro")
+                if self.purl and isinstance(self.purl.qualifiers, dict)
+                else None
+            )
+            pkg_info = distro if distro else self.purl.type
             pkg_mgr = self.mgr_info.name if self.mgr_info else ""
 
             return f"{pkg_name}:{pkg_info}:{pkg_mgr}"


### PR DESCRIPTION
## PR の目的

- syft 出力の CycloneDX から生成したアーティファクトタグの pkg_info を修正
  - purl から distro が取れる場合には distro を、取れない場合には purl.type を適用する（前者の追加）。
