### PR TITLE
delete pteam slack url

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1069,6 +1069,8 @@ def update_pteam(
     if data.slack_webhook_url:
         validate_slack_webhook_url(data.slack_webhook_url)
         pteam.slack_webhook_url = data.slack_webhook_url
+    elif data.slack_webhook_url == "":
+        pteam.slack_webhook_url = data.slack_webhook_url
 
     need_auto_close = (data.disabled is False and pteam.disabled is True) or (
         data.zone_names and set(data.zone_names) - {z.zone_name for z in pteam.zones}

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -338,6 +338,26 @@ def test_update_pteam__by_not_admin():
     assert response.reason_phrase == "Forbidden"
 
 
+def test_update_pteam_empty_data():
+    create_user(USER1)
+    pteam1 = create_pteam(USER1, PTEAM1)
+
+    empty_data = {
+        "pteam_name": "",
+        "contact_info": "",
+        "slack_webhook_url": "",
+    }
+
+    request = schemas.PTeamUpdateRequest(**{**empty_data}).model_dump()
+    response = client.put(f"/pteams/{pteam1.pteam_id}", headers=headers(USER1), json=request)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["pteam_name"] == ""
+    assert data["contact_info"] == ""
+    assert data["slack_webhook_url"] == ""
+    assert data["alert_threat_impact"] == 3
+
+
 def test_get_pteam_groups():
     create_user(USER1)
     pteam2 = create_pteam(USER1, PTEAM2)


### PR DESCRIPTION
## PR の目的
- Pteam設定モーダルで、Slackの通知URLを削除できなかった問題について対応

## 経緯・意図・意思決定
- 削除できなかった原因はバックエンド側のバグで空文字が受け付けられないようになっていました。
- if data.slack_webhook_url:としており空文字とNoneが受け付けられないようになっていたので、elifを用いて空文字を追加できるようにしました。 (api/app/routers/pteams.py 1072,1073行目)
- 元々登録してあるデータを空文字で上書きできるかを検証するテストを作成しました。(api/app/tests/medium/routers/test_pteams.py)
- create()用いてデータを登録し、update_pteam apiを使用し、空文字のデータを再登録しました。
