### PR TITLE
Fix/namespace on artifact tag name

### DIFF
--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -123,8 +123,7 @@ class TrivyCDXParser(SBOMParser):
         def to_tag(self, components_map: Dict[str, Any]) -> Optional[str]:
             if not self.purl:
                 return None
-            name_pref = f"{self.purl.namespace}/" if self.purl.namespace else ""
-            pkg_name = name_pref + self.purl.name
+            pkg_name = self.purl.name
             pkg_info = self.purl.type
             pkg_mgr = ""
             if self.targets:
@@ -313,8 +312,7 @@ class SyftCDXParser(SBOMParser):
         def to_tag(self) -> Optional[str]:
             if not self.purl:
                 return None
-            name_pref = f"{self.purl.namespace}/" if self.purl.namespace else ""
-            pkg_name = name_pref + self.purl.name
+            pkg_name = self.purl.name
             distro = (
                 self.purl.qualifiers.get("distro")
                 if self.purl and isinstance(self.purl.qualifiers, dict)

--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -123,7 +123,7 @@ class TrivyCDXParser(SBOMParser):
         def to_tag(self, components_map: Dict[str, Any]) -> Optional[str]:
             if not self.purl:
                 return None
-            pkg_name = self.purl.name
+            pkg_name = self.name  # given by trivy. may include namespace in some case.
             pkg_info = self.purl.type
             pkg_mgr = ""
             if self.targets:
@@ -312,7 +312,7 @@ class SyftCDXParser(SBOMParser):
         def to_tag(self) -> Optional[str]:
             if not self.purl:
                 return None
-            pkg_name = self.purl.name
+            pkg_name = self.name  # given by syft. may include namespace in some case.
             distro = (
                 self.purl.qualifiers.get("distro")
                 if self.purl and isinstance(self.purl.qualifiers, dict)


### PR DESCRIPTION
## PR の目的

- artifact tag の pkg_name 部に component.name を適用するように改修
  - namespace, subpath の扱いをツール側に任せることで、trivy_db2tc.py で自動生成されるトピックとの整合性を確保
  - trivy 以外のツールで生成した SBOM だと命名規則が異なる可能性があり、対応を検討する余地がある