### PR TITLE
change the order of api

### DIFF
--- a/api/app/routers/achievements.py
+++ b/api/app/routers/achievements.py
@@ -20,6 +20,22 @@ from app.schemas import BadgeRequest, SecBadgeBody
 router = APIRouter(prefix="/achievements", tags=["achievements"])
 
 
+@router.post("", response_model=SecBadgeBody)
+def create_secbadge(
+    data: BadgeRequest,
+    current_user: Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Issue a security badge for the given userID and badge's metadata.
+
+    `priority` is optional, the default is `100`.
+
+    `difficulty` is optional, the default is `low`.
+    """
+    return create_secbadge_internal(data, current_user, db)
+
+
 @router.post("/metadata", status_code=status.HTTP_204_NO_CONTENT)
 def validate_secbadge_metadata(metadata: Dict[str, Any], db: Session = Depends(get_db)):
     return validate_secbadge_metadata_internal(metadata, db)
@@ -41,22 +57,6 @@ def get_secbadges(
         .order_by(desc(SecBadge.created_at))
         .all()
     )
-
-
-@router.post("", response_model=SecBadgeBody)
-def create_secbadge(
-    data: BadgeRequest,
-    current_user: Account = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    Issue a security badge for the given userID and badge's metadata.
-
-    `priority` is optional, the default is `100`.
-
-    `difficulty` is optional, the default is `low`.
-    """
-    return create_secbadge_internal(data, current_user, db)
 
 
 @router.delete("/{badge_id}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## PR の目的
- 意図しないバグやエラーを防ぐため、app/routersディレクトリ内にあるapiの関数の順番を入れ替えました。
- 定義した順（上から順）にパターンマッチが試行されるため、例えば/users/meが/users/{user_id}より下にある場合、"/me" は"/{user_id}" の user_id = "me"と解釈されエラーになってしまう。

下記のURLは公式ドキュメントで順序問題について書かれている部分です。
https://fastapi.tiangolo.com/ja/tutorial/path-params/#_7

## 経緯・意図・意思決定
- 並べ替えについてpteam.py以外のファイルについて実施しました。
### 並べ替えた順番について
- apiのパスでパスパラメータを使っているもの({}をつけているもの)を下の方にし、パスパラメータを使っていないもの({}がついていないもの)を上の方にしました。
- パスの数が少ないものがなるべく上の方に来るようにしました。
- パスの数が多くても似たような機能でかたまって書かれていた場合、そのままにしています。
