### PR TITLE
Topic/waiting modal

### DIFF
--- a/web/src/components/PTeamAutoClose.jsx
+++ b/web/src/components/PTeamAutoClose.jsx
@@ -1,19 +1,22 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { WaitingModal } from "../components/WaitingModal";
 import { getPTeamTagsSummary } from "../slices/pteam";
 import { autoClose } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
 export function PTeamAutoClose() {
+  const [isOpenWaitingModal, setIsOpenWaitingModal] = useState(false);
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
   const handleSave = async () => {
+    setIsOpenWaitingModal(true);
     await autoClose(pteamId)
       .then(() => {
         enqueueSnackbar("Auto Close Accepted", { variant: "success" });
@@ -25,6 +28,9 @@ export function PTeamAutoClose() {
           `Operation failed: ${resp.status} ${resp.statusText} - ${resp.data?.detail}`,
           { variant: "error" }
         );
+      })
+      .finally(() => {
+        setIsOpenWaitingModal(false);
       });
   };
 
@@ -38,6 +44,7 @@ export function PTeamAutoClose() {
           Run
         </Button>
       </Box>
+      <WaitingModal isOpen={isOpenWaitingModal} text="Trying auto close" />
     </Box>
   );
 }

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -1,9 +1,10 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { WaitingModal } from "../components/WaitingModal";
 import {
   getPTeamSolvedTaggedTopicIds,
   getPTeamUnsolvedTaggedTopicIds,
@@ -14,12 +15,14 @@ import { commonButtonStyle } from "../utils/const";
 
 export function PTeamTagAutoClose(props) {
   const { tagId } = props;
+  const [isOpenWaitingModal, setIsOpenWaitingModal] = useState(false);
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
   const handleSave = async () => {
+    setIsOpenWaitingModal(true);
     await autoCloseTag(pteamId, tagId)
       .then(() => {
         enqueueSnackbar("Auto Close Accepted", { variant: "success" });
@@ -34,6 +37,9 @@ export function PTeamTagAutoClose(props) {
           `Operation failed: ${resp.status} ${resp.statusText} - ${resp.data?.detail}`,
           { variant: "error" }
         );
+      })
+      .finally(() => {
+        setIsOpenWaitingModal(false);
       });
   };
 
@@ -47,6 +53,7 @@ export function PTeamTagAutoClose(props) {
           Done
         </Button>
       </Box>
+      <WaitingModal isOpen={isOpenWaitingModal} text="Trying auto close" />
     </Box>
   );
 }

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -15,6 +15,7 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useRef, useState } from "react";
 
+import { WaitingModal } from "../components/WaitingModal";
 import { uploadSBOMFile } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
@@ -85,6 +86,7 @@ export function SBOMDropArea(props) {
   const { enqueueSnackbar } = useSnackbar();
   const [sbomFile, setSbomFile] = useState(null);
   const [preModalOpen, setPreModalOpen] = useState(false);
+  const [isOpenWaitingModal, setIsOpenWaitingModal] = useState(false);
 
   useEffect(() => {
     dropRef.current.addEventListener("dragover", handleDragOver);
@@ -125,6 +127,7 @@ export function SBOMDropArea(props) {
       alert("Something went wrong: missing file or group.");
       return;
     }
+    setIsOpenWaitingModal(true);
     enqueueSnackbar(`Uploading SBOM file: ${file.name}`, { variant: "info" });
     uploadSBOMFile(pteamId, group, file)
       .then((response) => {
@@ -137,6 +140,7 @@ export function SBOMDropArea(props) {
       })
       .finally(() => {
         setSbomFile(null);
+        setIsOpenWaitingModal(false);
       });
   };
 
@@ -161,6 +165,7 @@ export function SBOMDropArea(props) {
         setOpen={setPreModalOpen}
         onCompleted={(group) => handlePreUploadCompleted(group)}
       />
+      <WaitingModal isOpen={isOpenWaitingModal} text="Uploading SBOM file" />
     </>
   );
 }

--- a/web/src/components/WaitingModal.jsx
+++ b/web/src/components/WaitingModal.jsx
@@ -1,0 +1,32 @@
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+  CircularProgress,
+} from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+
+export function WaitingModal(props) {
+  const { isOpen, text } = props;
+
+  return (
+    <Dialog fullWidth open={isOpen}>
+      <DialogTitle>
+        <Box alignItems="center" display="flex" flexDirection="row">
+          <Typography flexGrow={1} variant="inherit">
+            {text} is in progress. Please wait.
+          </Typography>
+          <CircularProgress />
+        </Box>
+      </DialogTitle>
+      <DialogContent></DialogContent>
+    </Dialog>
+  );
+}
+WaitingModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  text: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
## PR の目的
SBOMファイルアップロード時とオートクローズ試行時に、ユーザに操作させないよう、待機用モーダルを表示するようにする。


## 経緯・意図・意思決定
- waiting modal コンポーネントの実装
- SBOMファイルアップロード時に、waiting modalを表示
- オートクローズ試行時に、waiting modalを表示

![image](https://github.com/nttcom/threatconnectome/assets/92132688/5a239ec8-08de-47f6-a5f1-5e343188f68c)


## 参考文献
