### PR TITLE
rename variables in jsx files

### DIFF
--- a/web/src/components/ATeamCreateModal.jsx
+++ b/web/src/components/ATeamCreateModal.jsx
@@ -21,7 +21,7 @@ import { createATeam } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamCreateModal(props) {
-  const { open, setOpen, closeTeamSelector } = props;
+  const { open, onOpen, onCloseTeamSelector } = props;
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
@@ -30,7 +30,7 @@ export function ATeamCreateModal(props) {
   const [contactInfo, setContactInfo] = useState("");
 
   useEffect(() => {
-    closeTeamSelector();
+    onCloseTeamSelector();
     setATeamName(null);
     setContactInfo("");
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
@@ -44,7 +44,7 @@ export function ATeamCreateModal(props) {
     await createATeam(data)
       .then(async (response) => {
         enqueueSnackbar("create ateam succeeded", { variant: "success" });
-        setOpen(false);
+        onOpen(false);
         // fix user.ateams before navigating, to avoid overwriting ateamId by pages/App.jsx.
         await dispatch(getUser());
         const newParams = new URLSearchParams();
@@ -62,12 +62,12 @@ export function ATeamCreateModal(props) {
 
   return (
     <>
-      <Dialog fullWidth open={open} onClose={() => setOpen(false)}>
+      <Dialog fullWidth open={open} onClose={() => onOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
             <Typography variant="h5">Create ATeam</Typography>
             <Box flexGrow={1} />
-            <IconButton onClick={() => setOpen(false)}>
+            <IconButton onClick={() => onOpen(false)}>
               <CloseIcon />
             </IconButton>
           </Box>
@@ -100,6 +100,6 @@ export function ATeamCreateModal(props) {
 
 ATeamCreateModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
-  closeTeamSelector: PropTypes.func.isRequired,
+  onOpen: PropTypes.func.isRequired,
+  onCloseTeamSelector: PropTypes.func.isRequired,
 };

--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -203,7 +203,7 @@ export function ATeamGeneralSetting(props) {
               }
             />
           </FormControl>
-          <CheckButton handleClick={handleCheckSlack} isLoading={checkSlack} />
+          <CheckButton onHandleClick={handleCheckSlack} isLoading={checkSlack} />
         </Box>
         <Box mt={1}>{slackMessage}</Box>
       </Box>
@@ -216,7 +216,7 @@ export function ATeamGeneralSetting(props) {
           <Typography sx={{ color: grey[700], minWidth: "720px" }} mr={1} mb={1}>
             {flashsenseUrl}
           </Typography>
-          <CheckButton handleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
+          <CheckButton onHandleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
         </Box>
       </Box>
       <Box mb={4}>{flashsenseMessage}</Box>

--- a/web/src/components/ATeamLabel.jsx
+++ b/web/src/components/ATeamLabel.jsx
@@ -25,7 +25,7 @@ export function ATeamLabel(props) {
         <UUIDTypography>{ateam.ateam_id}</UUIDTypography>
       </Box>
       <ATeamSettingsModal
-        setShow={setATeamSettingsModalOpen}
+        onSetShow={setATeamSettingsModalOpen}
         show={ateamSettingsModalOpen}
         ateam={ateam}
       />

--- a/web/src/components/ATeamSettingsModal.jsx
+++ b/web/src/components/ATeamSettingsModal.jsx
@@ -20,10 +20,10 @@ import { ATeamAuthEditor } from "./ATeamAuthEditor";
 import { ATeamGeneralSetting } from "./ATeamGeneralSetting";
 
 export function ATeamSettingsModal(props) {
-  const { setShow, show, defaultTabIndex } = props;
+  const { onSetShow, show, defaultTabIndex } = props;
   const [tab, setTab] = useState(defaultTabIndex ?? 0);
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
@@ -57,7 +57,7 @@ export function ATeamSettingsModal(props) {
   );
 }
 ATeamSettingsModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   defaultTabIndex: PropTypes.number,
 };

--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -44,7 +44,7 @@ import { ZoneSelectorModal } from "./ZoneSelectorModal";
 const steps = ["Threat, Vulnerability, and Risk", "Dissemination", "Response planning"];
 
 export function ATeamTopicCreateModal(props) {
-  const { open, setOpen } = props;
+  const { open, onSetOpen } = props;
 
   const [activeStep, setActiveStep] = useState(0);
   const [topicId, setTopicId] = useState(uuid.v4());
@@ -183,7 +183,7 @@ export function ATeamTopicCreateModal(props) {
       })
       .catch((error) => operationError(error));
     resetParams();
-    setOpen(false);
+    onSetOpen(false);
   };
 
   const handleNext = () => setActiveStep(activeStep + 1);
@@ -194,7 +194,7 @@ export function ATeamTopicCreateModal(props) {
 
   const handleClose = () => {
     resetParams();
-    setOpen(false);
+    onSetOpen(false);
   };
 
   function ActionGeneratorModal() {
@@ -251,7 +251,7 @@ export function ATeamTopicCreateModal(props) {
         open={open === true}
         onClose={(event, reason) => {
           if (reason === "backdropClick") return;
-          setOpen(false);
+          onSetOpen(false);
         }}
         maxWidth="md"
         fullWidth
@@ -518,5 +518,5 @@ export function ATeamTopicCreateModal(props) {
 
 ATeamTopicCreateModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
 };

--- a/web/src/components/ATeamTopicMenu.jsx
+++ b/web/src/components/ATeamTopicMenu.jsx
@@ -19,7 +19,7 @@ export function ATeamTopicMenu() {
         >
           New Topic
         </Button>
-        <ATeamTopicCreateModal open={modalOpen} setOpen={setModalOpen} />
+        <ATeamTopicCreateModal open={modalOpen} onSetOpen={setModalOpen} />
       </Box>
     </>
   );

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -77,7 +77,7 @@ export function AnalysisTopic(props) {
   };
 
   useEffect(() => {
-    reloadComments(targetTopic.topic_id);
+    handleReloadComments(targetTopic.topic_id);
     if (topics?.[targetTopic.topic_id] === undefined) dispatch(getTopic(targetTopic.topic_id));
     if (actions?.[targetTopic.topic_id] === undefined) dispatch(getActions(targetTopic.topic_id));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -129,7 +129,7 @@ export function AnalysisTopic(props) {
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
-  const reloadComments = async (topicId) => {
+  const handleReloadComments = async (topicId) => {
     await apiGetATeamTopicComments(ateam.ateam_id, topicId)
       .then((response) => setComments(response.data))
       .catch((error) => operationError(error));
@@ -144,7 +144,7 @@ export function AnalysisTopic(props) {
       comment: newComment.trim(),
     })
       .then(() => {
-        reloadComments(targetTopic.topic_id);
+        handleReloadComments(targetTopic.topic_id);
         setNewComment("");
       })
       .catch((error) => operationError(error));
@@ -159,7 +159,7 @@ export function AnalysisTopic(props) {
       comment: editComment.trim(),
     })
       .then(() => {
-        reloadComments(targetTopic.topic_id);
+        handleReloadComments(targetTopic.topic_id);
         setEditComment("");
         setEditable(false);
       })
@@ -681,7 +681,7 @@ export function AnalysisTopic(props) {
         comment={deleteComment}
         onClose={() => {
           setDeleteComment(null);
-          reloadComments(targetTopic.topic_id);
+          handleReloadComments(targetTopic.topic_id);
         }}
       />
     </>

--- a/web/src/components/CheckButton.jsx
+++ b/web/src/components/CheckButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export function CheckButton(props) {
-  const { handleClick, isLoading } = props;
+  const { onHandleClick, isLoading } = props;
 
   return (
     <Button
@@ -12,7 +12,7 @@ export function CheckButton(props) {
         textTransform: "none",
         marginRight: "10px",
       }}
-      onClick={handleClick}
+      onClick={onHandleClick}
     >
       {isLoading ? <CircularProgress size="1.6rem" sx={{ color: "#fff" }} /> : "Check"}
     </Button>
@@ -20,6 +20,6 @@ export function CheckButton(props) {
 }
 
 CheckButton.propTypes = {
-  handleClick: PropTypes.func.isRequired,
+  onHandleClick: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
 };

--- a/web/src/components/GTeamCreateModal.jsx
+++ b/web/src/components/GTeamCreateModal.jsx
@@ -21,7 +21,7 @@ import { createGTeam } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
 export function GTeamCreateModal(props) {
-  const { open, setOpen, closeTeamSelector } = props;
+  const { open, onSetOpen, onCloseTeamSelector } = props;
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
@@ -30,7 +30,7 @@ export function GTeamCreateModal(props) {
   const [contactInfo, setContactInfo] = useState("");
 
   useEffect(() => {
-    closeTeamSelector();
+    onCloseTeamSelector();
     setGTeamName(null);
     setContactInfo("");
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
@@ -44,7 +44,7 @@ export function GTeamCreateModal(props) {
     await createGTeam(data)
       .then(async (response) => {
         enqueueSnackbar("create gteam succeeded", { variant: "success" });
-        setOpen(false);
+        onSetOpen(false);
         // fix user.gteams before navigating, to avoid overwriting gteamId by pages/App.jsx.
         await dispatch(getUser());
         const newParams = new URLSearchParams();
@@ -62,12 +62,12 @@ export function GTeamCreateModal(props) {
 
   return (
     <>
-      <Dialog fullWidth open={open} onClose={() => setOpen(false)}>
+      <Dialog fullWidth open={open} onClose={() => onSetOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
             <Typography variant="h5">Create GTeam</Typography>
             <Box flexGrow={1} />
-            <IconButton onClick={() => setOpen(false)}>
+            <IconButton onClick={() => onSetOpen(false)}>
               <CloseIcon />
             </IconButton>
           </Box>
@@ -100,6 +100,6 @@ export function GTeamCreateModal(props) {
 
 GTeamCreateModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
-  closeTeamSelector: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
+  onCloseTeamSelector: PropTypes.func.isRequired,
 };

--- a/web/src/components/GTeamGeneralSetting.jsx
+++ b/web/src/components/GTeamGeneralSetting.jsx
@@ -133,7 +133,7 @@ export function GTeamGeneralSetting(props) {
           <Typography sx={{ color: grey[700], minWidth: "720px" }} mr={1} mb={1}>
             {flashsenseUrl}
           </Typography>
-          <CheckButton handleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
+          <CheckButton onHandleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
         </Box>
       </Box>
       <Box mb={4}>{flashsenseMessage}</Box>

--- a/web/src/components/GTeamLabel.jsx
+++ b/web/src/components/GTeamLabel.jsx
@@ -25,7 +25,7 @@ export function GTeamLabel(props) {
         <UUIDTypography>{gteam.gteam_id}</UUIDTypography>
       </Box>
       <GTeamSettingsModal
-        setShow={setGTeamSettingsModalOpen}
+        onSetShow={setGTeamSettingsModalOpen}
         show={gteamSettingsModalOpen}
         gteam={gteam}
       />

--- a/web/src/components/GTeamSettingsModal.jsx
+++ b/web/src/components/GTeamSettingsModal.jsx
@@ -20,10 +20,10 @@ import { GTeamAuthEditor } from "./GTeamAuthEditor";
 import { GTeamGeneralSetting } from "./GTeamGeneralSetting";
 
 export function GTeamSettingsModal(props) {
-  const { setShow, show, defaultTabIndex } = props;
+  const { onSetShow, show, defaultTabIndex } = props;
   const [tab, setTab] = useState(defaultTabIndex ?? 0);
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
@@ -57,7 +57,7 @@ export function GTeamSettingsModal(props) {
   );
 }
 GTeamSettingsModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   defaultTabIndex: PropTypes.number,
 };

--- a/web/src/components/PTeamCreateModal.jsx
+++ b/web/src/components/PTeamCreateModal.jsx
@@ -21,7 +21,7 @@ import { createPTeam } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
 export function PTeamCreateModal(props) {
-  const { open, setOpen, closeTeamSelector } = props;
+  const { open, onSetOpen, onCloseTeamSelector } = props;
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { enqueueSnackbar } = useSnackbar();
@@ -31,7 +31,7 @@ export function PTeamCreateModal(props) {
   const [slackUrl, setSlackUrl] = useState("");
 
   useEffect(() => {
-    closeTeamSelector();
+    onCloseTeamSelector();
     setPTeamName(null);
     setContactInfo("");
     setSlackUrl("");
@@ -47,7 +47,7 @@ export function PTeamCreateModal(props) {
     await createPTeam(data)
       .then(async (response) => {
         enqueueSnackbar("create pteam succeeded", { variant: "success" });
-        setOpen(false);
+        onSetOpen(false);
         // fix user.pteams before navigating, to avoid overwriting pteamId by pages/App.jsx.
         await dispatch(getUser());
         const newParams = new URLSearchParams();
@@ -65,12 +65,12 @@ export function PTeamCreateModal(props) {
 
   return (
     <>
-      <Dialog fullWidth open={open} onClose={() => setOpen(false)}>
+      <Dialog fullWidth open={open} onClose={() => onSetOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
             <Typography variant="h5">Create PTeam</Typography>
             <Box flexGrow={1} />
-            <IconButton onClick={() => setOpen(false)}>
+            <IconButton onClick={() => onSetOpen(false)}>
               <CloseIcon />
             </IconButton>
           </Box>
@@ -108,6 +108,6 @@ export function PTeamCreateModal(props) {
 
 PTeamCreateModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
-  closeTeamSelector: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
+  onCloseTeamSelector: PropTypes.func.isRequired,
 };

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -39,7 +39,7 @@ import { ActionItem } from "./ActionItem";
 export function PTeamEditAction(props) {
   const {
     open,
-    setOpen,
+    onSetOpen,
     presetTopicId,
     presetTagId,
     presetParentTagId,
@@ -180,7 +180,7 @@ export function PTeamEditAction(props) {
         { variant: "warning" }
       );
       reloadTopicAfterAPI();
-      setOpen(false);
+      onSetOpen(false);
       return;
     }
 
@@ -196,13 +196,13 @@ export function PTeamEditAction(props) {
       .then(async () => {
         enqueueSnackbar("Update topic succeeded", { variant: "success" });
         reloadTopicAfterAPI();
-        setOpen(false);
+        onSetOpen(false);
       })
       .catch((error) => operationError(error));
   };
 
   const handleClose = () => {
-    setOpen(false);
+    onSetOpen(false);
   };
 
   function ActionGeneratorModal() {
@@ -376,7 +376,7 @@ export function PTeamEditAction(props) {
 
 PTeamEditAction.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
   presetTopicId: PropTypes.string,
   presetTagId: PropTypes.string,
   presetParentTagId: PropTypes.string,

--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -211,7 +211,7 @@ export function PTeamGeneralSetting(props) {
               }
             />
           </FormControl>
-          <CheckButton handleClick={handleCheckSlack} isLoading={checkSlack} />
+          <CheckButton onHandleClick={handleCheckSlack} isLoading={checkSlack} />
         </Box>
         <Box mt={1}>{slackMessage}</Box>
       </Box>
@@ -239,7 +239,7 @@ export function PTeamGeneralSetting(props) {
           <Typography sx={{ color: grey[700], minWidth: "720px" }} mr={1} mb={1}>
             {flashsenseUrl}
           </Typography>
-          <CheckButton handleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
+          <CheckButton onHandleClick={handleCheckFlashsense} isLoading={checkFlashsense} />
         </Box>
       </Box>
       <Box mb={4}>{flashsenseMessage}</Box>

--- a/web/src/components/PTeamLabel.jsx
+++ b/web/src/components/PTeamLabel.jsx
@@ -30,7 +30,7 @@ export function PTeamLabel(props) {
         <UUIDTypography>{pteamId}</UUIDTypography>
       </Box>
       <PTeamSettingsModal
-        setShow={setPTeamSettingsModalOpen}
+        onSetShow={setPTeamSettingsModalOpen}
         show={pteamSettingsModalOpen}
         defaultTabIndex={defaultTabIndex}
       />

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -27,10 +27,10 @@ import { TagMonitoring } from "./TagMonitoring";
 export function PTeamSettingsModal(props) {
   const dispatch = useDispatch();
 
-  const { setShow, show, defaultTabIndex } = props;
+  const { onSetShow, show, defaultTabIndex } = props;
   const [tab, setTab] = useState(defaultTabIndex ?? 0);
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
@@ -83,7 +83,7 @@ export function PTeamSettingsModal(props) {
   );
 }
 PTeamSettingsModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   defaultTabIndex: PropTypes.number,
 };

--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -168,7 +168,7 @@ GroupChips.propTypes = {
 };
 
 export function PTeamStatusCard(props) {
-  const { handleClick, tag } = props;
+  const { onHandleClick, tag } = props;
 
   const CommentTooltip = styled(({ className, ...props }) => (
     <Tooltip {...props} classes={{ popper: className }} />
@@ -184,7 +184,7 @@ export function PTeamStatusCard(props) {
 
   return (
     <TableRow
-      onClick={handleClick}
+      onClick={onHandleClick}
       sx={{
         cursor: "pointer",
         "&:last-child td, &:last-child th": { border: 0 },
@@ -225,7 +225,7 @@ export function PTeamStatusCard(props) {
 }
 
 PTeamStatusCard.propTypes = {
-  handleClick: PropTypes.func.isRequired,
+  onHandleClick: PropTypes.func.isRequired,
   tag: PropTypes.shape({
     tag_name: PropTypes.string,
     tag_id: PropTypes.string,

--- a/web/src/components/PTeamStatusMenu.jsx
+++ b/web/src/components/PTeamStatusMenu.jsx
@@ -68,7 +68,7 @@ export function PTeamStatusMenu(props) {
       </Menu>
       <TopicModal
         open={modalOpen}
-        setOpen={setModalOpen}
+        onSetOpen={setModalOpen}
         presetTagId={presetTagId}
         presetParentTagId={presetParentTagId}
       />

--- a/web/src/components/PTeamTagLabel.jsx
+++ b/web/src/components/PTeamTagLabel.jsx
@@ -19,7 +19,7 @@ export function PTeamTagLabel(props) {
         </Box>
       </Box>
       <PTeamTagSettingsModal
-        setShow={setPTeamTagSettingsModalOpen}
+        onSetShow={setPTeamTagSettingsModalOpen}
         show={pteamTagSettingsModalOpen}
         tagId={tagId}
       />

--- a/web/src/components/PTeamTagSettingsModal.jsx
+++ b/web/src/components/PTeamTagSettingsModal.jsx
@@ -7,9 +7,9 @@ import React from "react";
 import { PTeamTagAutoClose } from "./PTeamTagAutoClose";
 
 export function PTeamTagSettingsModal(props) {
-  const { setShow, show, tagId } = props;
+  const { onSetShow, show, tagId } = props;
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   return (
     <Dialog fullWidth onClose={handleClose} open={show}>
@@ -30,7 +30,7 @@ export function PTeamTagSettingsModal(props) {
   );
 }
 PTeamTagSettingsModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   tagId: PropTypes.string.isRequired,
 };

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -34,7 +34,7 @@ import { RecommendedStar } from "./RecommendedStar";
 import { UUIDTypography } from "./UUIDTypography";
 
 export function ReportCompletedActions(props) {
-  const { handleConfirm, setShow, show, topicId, topicActions } = props;
+  const { onConfirm, onSetShow, show, topicId, topicActions } = props;
 
   const [note, setNote] = useState("");
   const [selectedAction, setSelectedAction] = useState([]);
@@ -72,7 +72,7 @@ export function ReportCompletedActions(props) {
         note: note.trim() || null,
       });
       handleClose();
-      handleConfirm();
+      onConfirm();
       setNote("");
       dispatch(getPTeamTagsSummary(pteamId));
       dispatch(getPTeamTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
@@ -87,7 +87,7 @@ export function ReportCompletedActions(props) {
   if (!pteamId || !topicId || !topics[topicId] || !topicActions) return <></>;
 
   const handleClose = () => {
-    setShow(false);
+    onSetShow(false);
   };
 
   const handleSelectAction = async (actionId) => {
@@ -245,8 +245,8 @@ export function ReportCompletedActions(props) {
 }
 
 ReportCompletedActions.propTypes = {
-  handleConfirm: PropTypes.func.isRequired,
-  setShow: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   topicId: PropTypes.string.isRequired,
   topicActions: PropTypes.array.isRequired,

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -21,12 +21,12 @@ import { modalCommonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 function PreUploadModal(props) {
-  const { sbomFile, open, setOpen, onCompleted } = props;
+  const { sbomFile, open, onSetOpen, onCompleted } = props;
   const [groupName, setGroupName] = useState("");
 
   const handleClose = () => {
     setGroupName("");
-    setOpen(false);
+    onSetOpen(false);
   };
   const handleUpload = () => {
     onCompleted(groupName); // parent will close me
@@ -76,7 +76,7 @@ function PreUploadModal(props) {
 PreUploadModal.propTypes = {
   sbomFile: PropTypes.object,
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
   onCompleted: PropTypes.func.isRequired,
 };
 
@@ -162,7 +162,7 @@ export function SBOMDropArea(props) {
       <PreUploadModal
         sbomFile={sbomFile}
         open={preModalOpen}
-        setOpen={setPreModalOpen}
+        onSetOpen={setPreModalOpen}
         onCompleted={(group) => handlePreUploadCompleted(group)}
       />
       <WaitingModal isOpen={isOpenWaitingModal} text="Uploading SBOM file" />

--- a/web/src/components/TeamSelector.jsx
+++ b/web/src/components/TeamSelector.jsx
@@ -197,18 +197,18 @@ export function TeamSelector() {
         </Menu>
         <PTeamCreateModal
           open={openPTeamCreationModal}
-          setOpen={setOpenPTeamCreationModal}
-          closeTeamSelector={handleClose}
+          onSetOpen={setOpenPTeamCreationModal}
+          onCloseTeamSelector={handleClose}
         />
         <ATeamCreateModal
           open={openATeamCreationModal}
-          setOpen={setOpenATeamCreationModal}
-          closeTeamSelector={handleClose}
+          onOpen={setOpenATeamCreationModal}
+          onCloseTeamSelector={handleClose}
         />
         <GTeamCreateModal
           open={openGTeamCreationModal}
-          setOpen={setOpenGTeamCreationModal}
-          closeTeamSelector={handleClose}
+          onSetOpen={setOpenGTeamCreationModal}
+          onCloseTeamSelector={handleClose}
         />
       </Box>
     </>

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -249,7 +249,7 @@ export function TopicCard(props) {
         </Box>
         <TopicModal
           open={topicModalOpen}
-          setOpen={setTopicModalOpen}
+          onSetOpen={setTopicModalOpen}
           presetTopicId={topicId}
           presetTagId={currentTagId}
           presetParentTagId={currentTagDict.parent_id}
@@ -493,15 +493,15 @@ export function TopicCard(props) {
             )}
           </CardActions>
           <ReportCompletedActions
-            handleConfirm={handleActionMenuClose}
-            setShow={setActionModalOpen}
+            onConfirm={handleActionMenuClose}
+            onSetShow={setActionModalOpen}
             show={actionModalOpen}
             topicId={topicId}
             topicActions={topicActions}
           />
           <PTeamEditAction
             open={pteamActionModalOpen}
-            setOpen={setPteamActionModalOpen}
+            onSetOpen={setPteamActionModalOpen}
             presetTopicId={topicId}
             presetTagId={currentTagId}
             presetParentTagId={currentTagDict.parent_id}

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -10,7 +10,7 @@ import { deleteTopic } from "../utils/api";
 import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
 
 export function TopicDeleteModal(props) {
-  const { topicId, setOpenTopicModal, onDelete } = props;
+  const { topicId, onSetOpenTopicModal, onDelete } = props;
   const [open, setOpen] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
@@ -35,7 +35,7 @@ export function TopicDeleteModal(props) {
         ]);
       })
       .catch((error) => operationError(error));
-    setOpenTopicModal(false);
+    onSetOpenTopicModal(false);
   }
 
   return (
@@ -85,6 +85,6 @@ export function TopicDeleteModal(props) {
 
 TopicDeleteModal.propTypes = {
   topicId: PropTypes.string.isRequired,
-  setOpenTopicModal: PropTypes.func.isRequired,
+  onSetOpenTopicModal: PropTypes.func.isRequired,
   onDelete: PropTypes.func,
 };

--- a/web/src/components/TopicEditModal.jsx
+++ b/web/src/components/TopicEditModal.jsx
@@ -50,7 +50,7 @@ import { TopicTagSelector } from "./TopicTagSelector";
 import { ZoneSelectorModal } from "./ZoneSelectorModal";
 
 export function TopicEditModal(props) {
-  const { open, setOpen, currentTopic, currentActions } = props;
+  const { open, onSetOpen, currentTopic, currentActions } = props;
 
   const [topicId, setTopicId] = useState("");
   const [title, setTitle] = useState("");
@@ -125,7 +125,7 @@ export function TopicEditModal(props) {
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
-  const handleClose = () => setOpen(false);
+  const handleClose = () => onSetOpen(false);
 
   const handleUpdate = async () => {
     setUpdating(true);
@@ -203,7 +203,7 @@ export function TopicEditModal(props) {
       // Note: params are kept on failed values
     } finally {
       setUpdating(false);
-      setOpen(false);
+      onSetOpen(false);
     }
   };
 
@@ -586,7 +586,7 @@ export function TopicEditModal(props) {
 
 TopicEditModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
   currentTopic: PropTypes.object.isRequired,
   currentActions: PropTypes.array.isRequired,
 };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -54,7 +54,7 @@ import { ZoneSelectorModal } from "./ZoneSelectorModal";
 const steps = ["Import Flashsense", "Create topic"];
 
 export function TopicModal(props) {
-  const { open, setOpen, presetTopicId, presetTagId, presetParentTagId, presetActions } = props;
+  const { open, onSetOpen, presetTopicId, presetTagId, presetParentTagId, presetActions } = props;
 
   const [errors, setErrors] = useState([]);
   const [activeStep, setActiveStep] = useState(0);
@@ -194,7 +194,7 @@ export function TopicModal(props) {
       .then(async () => {
         enqueueSnackbar("Create topic succeeded", { variant: "success" });
         reloadTopicAfterAPI();
-        setOpen(false);
+        onSetOpen(false);
       })
       .catch((error) => operationError(error));
   };
@@ -230,7 +230,7 @@ export function TopicModal(props) {
         { variant: "warning" }
       );
       reloadTopicAfterAPI();
-      setOpen(false);
+      onSetOpen(false);
       return;
     }
 
@@ -246,7 +246,7 @@ export function TopicModal(props) {
       .then(async () => {
         enqueueSnackbar("Update topic succeeded", { variant: "success" });
         reloadTopicAfterAPI();
-        setOpen(false);
+        onSetOpen(false);
       })
       .catch((error) => operationError(error));
   };
@@ -322,10 +322,10 @@ export function TopicModal(props) {
 
   const handleClose = () => {
     setActiveStep(presetTopicId ? 1 : 0);
-    setOpen(false);
+    onSetOpen(false);
   };
 
-  const onDeleteTopic = () => {
+  const handleDeleteTopic = () => {
     if (presetTagId) {
       dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId }));
       dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId }));
@@ -391,7 +391,7 @@ export function TopicModal(props) {
         open={open === true}
         onClose={(event, reason) => {
           if (reason && reason === "backdropClick") return;
-          setOpen(false);
+          onSetOpen(false);
         }}
         maxWidth="md"
         fullWidth
@@ -658,8 +658,8 @@ export function TopicModal(props) {
                   </Typography>
                   <TopicDeleteModal
                     topicId={presetTopicId}
-                    setOpenTopicModal={setOpen}
-                    onDelete={onDeleteTopic}
+                    onSetOpenTopicModal={onSetOpen}
+                    onDelete={handleDeleteTopic}
                   />
                 </Box>
               </Box>
@@ -687,7 +687,7 @@ export function TopicModal(props) {
 
 TopicModal.propTypes = {
   open: PropTypes.bool.isRequired,
-  setOpen: PropTypes.func.isRequired,
+  onSetOpen: PropTypes.func.isRequired,
   presetTopicId: PropTypes.string,
   presetTagId: PropTypes.string,
   presetParentTagId: PropTypes.string,

--- a/web/src/components/ZoneItemDeleteModal.jsx
+++ b/web/src/components/ZoneItemDeleteModal.jsx
@@ -16,7 +16,7 @@ import {
 import { modalCommonButtonStyle } from "../utils/const";
 
 export function ZoneItemDeleteModal(props) {
-  const { setShow, show, zone, itemType, itemId } = props;
+  const { onSetShow, show, zone, itemType, itemId } = props;
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
@@ -26,7 +26,7 @@ export function ZoneItemDeleteModal(props) {
     return <></>;
   }
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   const itemProp =
     itemType === "topic"
@@ -112,7 +112,7 @@ export function ZoneItemDeleteModal(props) {
           dispatch(getGTeamZonesSummary(zone.gteam_id)),
           enqueueSnackbar(succeededMessage, { variant: "success" }),
         ]);
-        setShow(false);
+        onSetShow(false);
       })
       .catch((error) => {
         const resp = error.response ?? { status: "???", statusText: error.toString() };
@@ -139,7 +139,7 @@ export function ZoneItemDeleteModal(props) {
               {confirmMessage}
               <Box display="flex">
                 <Box flexGrow={1} />
-                <Button onClick={() => setShow(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
+                <Button onClick={() => onSetShow(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
                   Cancel
                 </Button>
                 <Button
@@ -157,7 +157,7 @@ export function ZoneItemDeleteModal(props) {
   );
 }
 ZoneItemDeleteModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   zone: PropTypes.object.isRequired,
   itemType: PropTypes.string.isRequired,

--- a/web/src/components/ZoneMarkItemTab.jsx
+++ b/web/src/components/ZoneMarkItemTab.jsx
@@ -140,7 +140,7 @@ export function ZoneMarkItemTab(props) {
         </TabPanel>
       </Box>
       <ZoneItemDeleteModal
-        setShow={setItemDeleteOpen}
+        onSetShow={setItemDeleteOpen}
         show={itemDeleteOpen}
         zone={zone}
         itemType={itemType}

--- a/web/src/components/ZoneSettingsModal.jsx
+++ b/web/src/components/ZoneSettingsModal.jsx
@@ -18,7 +18,7 @@ import { updateZone } from "../utils/api";
 import { modalCommonButtonStyle } from "../utils/const";
 
 export function ZoneSettingsModal(props) {
-  const { setShow, show, gteamId, zoneName, currentZoneInfo } = props;
+  const { onSetShow, show, gteamId, zoneName, currentZoneInfo } = props;
 
   const [zoneInfo, setZoneInfo] = useState(currentZoneInfo);
   const { enqueueSnackbar } = useSnackbar();
@@ -28,7 +28,7 @@ export function ZoneSettingsModal(props) {
     setZoneInfo(currentZoneInfo);
   }, [show, currentZoneInfo]);
 
-  const handleClose = () => setShow(false);
+  const handleClose = () => onSetShow(false);
 
   const operationError = (error) => {
     const resp = error.response;
@@ -80,7 +80,7 @@ export function ZoneSettingsModal(props) {
           />
           <Box display="flex">
             <Box flexGrow={1} />
-            <Button onClick={() => setShow(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
+            <Button onClick={() => onSetShow(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
               Cancel
             </Button>
             <Button
@@ -100,7 +100,7 @@ export function ZoneSettingsModal(props) {
   );
 }
 ZoneSettingsModal.propTypes = {
-  setShow: PropTypes.func.isRequired,
+  onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   gteamId: PropTypes.string.isRequired,
   zoneName: PropTypes.string.isRequired,

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -297,7 +297,7 @@ export function Status() {
                 {targetTags.map((tag) => (
                   <PTeamStatusCard
                     key={tag.tag_id}
-                    handleClick={() => handleNavigateTag(tag.tag_id)}
+                    onHandleClick={() => handleNavigateTag(tag.tag_id)}
                     tag={tag}
                   />
                 ))}

--- a/web/src/pages/ZoneEdit.jsx
+++ b/web/src/pages/ZoneEdit.jsx
@@ -134,7 +134,7 @@ export function ZoneEdit() {
         </TableContainer>
       </Box>
       <ZoneSettingsModal
-        setShow={setZoneSettingsModalOpen}
+        onSetShow={setZoneSettingsModalOpen}
         show={zoneSettingsModalOpen}
         gteamId={gteamId}
         zoneName={zoneName}


### PR DESCRIPTION
## PR の目的
- React でイベントを表す props には onSomething 、それらのイベントを処理するハンドラ関数の定義には handleSomething という名前になるように変更しました。

## 経緯・意図・意思決定
- 公式ドキュメントでは props には onSomething、ハンドラ関数の定義には handleSomethingを使用するのが推奨されているためそれに合わせる形で変数名を変更しました。
以下のURLは公式ドキュメントでonSomething、handleSomethingが書かれている部分です。
https://ja.react.dev/learn/tutorial-tic-tac-toe#:~:text=%E3%81%93%E3%81%A8%E3%81%AB%E3%81%AA%E3%82%8A%E3%81%BE%E3%81%99%E3%80%82-,%E8%A3%9C%E8%B6%B3,-DOM%20%E3%81%AE%20%3Cbutton
