### PR TITLE
flush deletion to avoid unique constraint violation

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1033,6 +1033,7 @@ def apply_group_tags(
             models.PTeamTagReference.group == group,
         )
     )
+    db.flush()
     db.add_all(
         [
             models.PTeamTagReference(


### PR DESCRIPTION
## PR の目的

- ユニークキー制約違反の回避

PTR(PTeamTagReference) をグループ指定で一括削除した後に add_all で刷新している。
この処理において、PTR の主キーは reference_id であるため削除がマークされたオブジェクトと刷新用に生成されるオブジェクトは別物となる。pteam_id, tag_id, group, target, version が全て一致する場合、削除より先に追加が実行されるとユニークキー制約違反が発生する（と思われる）。

これを回避するため、暫定処置として delete 後に flush する。
抜本的な解決としては、主キーを 5要素の複合キーに替える（reference_id 廃止）か、削除・更新・新設を正確に分類して処理する必要がある。