### PR TITLE
Topic/add group in SBOM parsing

### DIFF
--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -124,8 +124,9 @@ class TrivyCDXParser(SBOMParser):
         def to_tag(self, components_map: Dict[str, Any]) -> Optional[str]:
             if not self.purl:
                 return None
-            pkg_name = self.name  # given by trivy. may include namespace in some case.
-            pkg_group = self.group
+            pkg_name = (
+                self.group + ":" + self.name if self.group else self.name
+            )  # given by trivy. may include namespace in some case.
             pkg_info = self.purl.type
             pkg_mgr = ""
             if self.targets:
@@ -141,12 +142,7 @@ class TrivyCDXParser(SBOMParser):
                     pkg_info = self._fix_distro(distro) if distro else ""
                 else:
                     pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
-
-            return (
-                f"{pkg_group}:{pkg_name}:{pkg_info}:{pkg_mgr}"
-                if pkg_group
-                else f"{pkg_name}:{pkg_info}:{pkg_mgr}"
-            )
+            return f"{pkg_name}:{pkg_info}:{pkg_mgr}"
 
     @classmethod
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> List[Artifact]:
@@ -321,21 +317,18 @@ class SyftCDXParser(SBOMParser):
         def to_tag(self) -> Optional[str]:
             if not self.purl:
                 return None
-            pkg_name = self.name  # given by syft. may include namespace in some case.
+            pkg_name = (
+                self.group + ":" + self.name if self.group else self.name
+            )  # given by syft. may include namespace in some case.
             distro = (
                 self.purl.qualifiers.get("distro")
                 if self.purl and isinstance(self.purl.qualifiers, dict)
                 else None
             )
-            pkg_group = self.group
             pkg_info = distro if distro else self.purl.type
             pkg_mgr = self.mgr_info.name if self.mgr_info else ""
 
-            return (
-                f"{pkg_group}:{pkg_name}:{pkg_info}:{pkg_mgr}"
-                if pkg_group
-                else f"{pkg_name}:{pkg_info}:{pkg_mgr}"
-            )
+            return f"{pkg_name}:{pkg_info}:{pkg_mgr}"
 
     @classmethod
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> List[Artifact]:

--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -142,10 +142,11 @@ class TrivyCDXParser(SBOMParser):
                 else:
                     pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
 
-            if not pkg_group:
-                return f"{pkg_name}:{pkg_info}:{pkg_mgr}"
-
-            return f"{pkg_name}:{pkg_group}:{pkg_info}:{pkg_mgr}"
+            return (
+                f"{pkg_group}:{pkg_name}:{pkg_info}:{pkg_mgr}"
+                if pkg_group
+                else f"{pkg_name}:{pkg_info}:{pkg_mgr}"
+            )
 
     @classmethod
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> List[Artifact]:
@@ -253,6 +254,7 @@ class SyftCDXParser(SBOMParser):
 
         bom_ref: str
         type: str
+        group: str
         name: str
         version: str
         raw_purl: Optional[str]
@@ -325,10 +327,15 @@ class SyftCDXParser(SBOMParser):
                 if self.purl and isinstance(self.purl.qualifiers, dict)
                 else None
             )
+            pkg_group = self.group
             pkg_info = distro if distro else self.purl.type
             pkg_mgr = self.mgr_info.name if self.mgr_info else ""
 
-            return f"{pkg_name}:{pkg_info}:{pkg_mgr}"
+            return (
+                f"{pkg_group}:{pkg_name}:{pkg_info}:{pkg_mgr}"
+                if pkg_group
+                else f"{pkg_name}:{pkg_info}:{pkg_mgr}"
+            )
 
     @classmethod
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> List[Artifact]:
@@ -360,6 +367,7 @@ class SyftCDXParser(SBOMParser):
                 components_map[data["bom-ref"]] = SyftCDXParser.CDXComponent(
                     bom_ref=data.get("bom-ref"),
                     type=data.get("type"),
+                    group=data.get("group"),
                     name=data.get("name"),
                     version=data.get("version"),
                     raw_purl=data.get("purl"),

--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -231,9 +231,6 @@ class TrivyCDXParser(SBOMParser):
                 continue  # maybe directory or image
             if not (tag := component.to_tag(components_map)):
                 continue  # omit not packages
-            print(tag)
-            # print(Artifact(tag=tag))
-            # print(artifacts_map)
             artifact = artifacts_map.get(tag, Artifact(tag=tag))
             artifacts_map[tag] = artifact
             for _target_ref, target_name in component.targets:


### PR DESCRIPTION
## PR の目的
- Trivyの最新バージョン(0.49.1)でCycloneDXの構造が変化したため追従しました。
- group属性が追加されたため、groupの情報をパースできるようにsbom.pyを変更しました。

## 経緯・意図・意思決定
Trivy
- groupの情報をパースできるように、groupの要素を追加しました。(75行目, 128行目, 179行目)
- groupの情報をnameの隣に表示されるように変更しました。
~~(pkg_name}:{pkg_group}:{pkg_info}:{pkg_mgr}~~   
(pkg_group}:{pkg_name}:{pkg_info}:{pkg_mgr}(148行目)
- jsonファイルをパースしてgroupが存在しなかったとき、以前と同様{pkg_name}:{pkg_info}:{pkg_mgr}の形でtagが出力されるようにしました。(145行目, 146行目)

Syft
- trivyの時と同様に、syftで作成されたsbomファイルをパースする際にgroupの情報を考慮するように修正しました。(257、330~338, 370行目)