### PR TITLE
Fix/settings modal

### DIFF
--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -187,7 +187,7 @@ export function ATeamGeneralSetting(props) {
             <OutlinedInput
               id="outlined-adornment-password"
               type={edittingSlackUrl ? "text" : "password"}
-              autocomplete="new-password" // to avoid autocomplete by browser
+              autoComplete="new-password" // to avoid autocomplete by browser
               value={slackUrl}
               onChange={(event) => setSlackUrl(event.target.value)}
               endAdornment={

--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -147,7 +147,7 @@ export function ATeamGeneralSetting(props) {
           ATeam name
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="ateam-name-field"
           size="small"
           value={ateamName}
           onChange={(event) => setATeamName(event.target.value)}
@@ -160,7 +160,7 @@ export function ATeamGeneralSetting(props) {
           Contact Info
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="contact-info-field"
           size="small"
           value={contactInfo}
           onChange={(event) => setContactInfo(event.target.value)}

--- a/web/src/components/GTeamGeneralSetting.jsx
+++ b/web/src/components/GTeamGeneralSetting.jsx
@@ -104,7 +104,7 @@ export function GTeamGeneralSetting(props) {
           GTeam name
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="gteam-name-field"
           size="small"
           value={gteamName}
           onChange={(event) => setGTeamName(event.target.value)}
@@ -117,7 +117,7 @@ export function GTeamGeneralSetting(props) {
           Contact Info
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="contact-info-field"
           size="small"
           value={contactInfo}
           onChange={(event) => setContactInfo(event.target.value)}

--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -195,7 +195,7 @@ export function PTeamGeneralSetting(props) {
             <OutlinedInput
               id="outlined-adornment-password"
               type={edittingSlackUrl ? "text" : "password"}
-              autocomplete="new-password" // to avoid autocomplete by browser
+              autoComplete="new-password" // to avoid autocomplete by browser
               value={slackUrl}
               onChange={(event) => setSlackUrl(event.target.value)}
               endAdornment={

--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -156,7 +156,7 @@ export function PTeamGeneralSetting(props) {
           PTeam name
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="pteam-name-field"
           size="small"
           value={pteamName}
           onChange={(event) => setPTeamName(event.target.value)}
@@ -169,7 +169,7 @@ export function PTeamGeneralSetting(props) {
           Contact Info
         </Typography>
         <TextField
-          id="outlined-basic"
+          id="contact-info-field"
           size="small"
           value={contactInfo}
           onChange={(event) => setContactInfo(event.target.value)}

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -264,7 +264,7 @@ export function Status() {
   return (
     <>
       <Box display="flex" flexDirection="row">
-        <PTeamLabel defaultTabIndex={1} />
+        <PTeamLabel defaultTabIndex={0} />
         <Box flexGrow={1} />
       </Box>
       <PTeamGroupChip />


### PR DESCRIPTION
## PR の目的
設定モーダルまわりの修正

## 経緯・意図・意思決定
- status画面から、歯車ボタンを押した際にデフォルトで表示するタブを、「AUTHORITIES」から「GENERAL」に変更
- GENERALタブの、autocomplete をautoCompleteに修正。おそらくMaterialUIのパラメータ名が変わった。これにより、パスワードのオートコンプリートが、されないようになりました。
- GENERALタブの、フィールドのID被りのWarningを修正。
  ![image](https://github.com/nttcom/threatconnectome/assets/92132688/f24a8661-ab03-49c0-a4bb-22a4e77f77a4)


## 参考文献
