### PR TITLE
Topic/change default mail enable

### DIFF
--- a/api/app/alembic/versions/982664e26b3d_add_mail_tables.py
+++ b/api/app/alembic/versions/982664e26b3d_add_mail_tables.py
@@ -20,7 +20,7 @@ depends_on = None
 def insert_rows_into_ateam_mail(connection: Connection):
     query = """
         INSERT INTO ateammail (ateam_id, enable, address)
-          SELECT ateam_id, false, '' FROM ateam
+          SELECT ateam_id, true, '' FROM ateam
         """
     connection.exec_driver_sql(query)
 
@@ -28,7 +28,7 @@ def insert_rows_into_ateam_mail(connection: Connection):
 def insert_rows_into_pteam_mail(connection: Connection):
     query = """
         INSERT INTO pteammail (pteam_id, enable, address)
-          SELECT pteam_id, false, '' FROM pteam
+          SELECT pteam_id, true, '' FROM pteam
         """
     connection.exec_driver_sql(query)
 

--- a/api/app/routers/ateams.py
+++ b/api/app/routers/ateams.py
@@ -107,7 +107,7 @@ def create_ateam(
     )
     ateam.alert_mail = models.ATeamMail(
         ateam_id=ateam.ateam_id,
-        enable=data.alert_mail.enable if data.alert_mail else False,
+        enable=data.alert_mail.enable if data.alert_mail else True,
         address=data.alert_mail.address if data.alert_mail else "",
     )
     current_user.ateams.append(ateam)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -471,7 +471,7 @@ def create_pteam(
     )
     pteam.alert_mail = models.PTeamMail(
         pteam_id=pteam.pteam_id,
-        enable=data.alert_mail.enable if data.alert_mail else False,
+        enable=data.alert_mail.enable if data.alert_mail else True,
         address=data.alert_mail.address if data.alert_mail else "",
     )
     pteam.zones = update_zones(db, current_user.user_id, True, [], data.zone_names)

--- a/api/app/tests/medium/routers/test_pteams.py
+++ b/api/app/tests/medium/routers/test_pteams.py
@@ -247,7 +247,7 @@ def test_create_pteam__by_default():
     assert pteam1.contact_info == ""
     assert pteam1.slack_webhook_url == ""
     assert pteam1.alert_threat_impact == DEFAULT_ALERT_THREAT_IMPACT
-    assert pteam1.alert_mail.enable is False
+    assert pteam1.alert_mail.enable is True
     assert pteam1.alert_mail.address == ""
 
 


### PR DESCRIPTION
## PR の目的
- mailのenableのデフォルト設定をTrueにする

## 経緯・意図・意思決定

- mailのenableのデフォルト設定をTrueにする
- migration scriptのmail enable をtrueに変更



※DBマイグレーションは、一度、982664e26b3d_add_mail_tables.pyの一個前にdowngradeし、再度upgradeしてください。
※ #101 よりさきにマージしてください。

## 参考文献
