### PR TITLE
Fix/test sendgrid

### DIFF
--- a/api/app/routers/external.py
+++ b/api/app/routers/external.py
@@ -44,8 +44,6 @@ def check_email(data: EmailCheckRequest, current_user: Account = Depends(get_cur
     )
     if response is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    if response.status_code != 200:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=response.body)
 
 
 @router.post("/flashsense/check")

--- a/api/app/routers/external.py
+++ b/api/app/routers/external.py
@@ -8,7 +8,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from app.auth import get_current_user, token_scheme
 from app.models import Account
 from app.schemas import EmailCheckRequest, FsServerInfo, SlackCheckRequest
-from app.sendgrid import send_email
+from app.sendgrid import SendgridFailStatusError, SendgridHttpError, send_email
 from app.slack import post_message, validate_slack_webhook_url
 
 router = APIRouter(prefix="/external", tags=["external"])
@@ -38,12 +38,24 @@ def check_email(data: EmailCheckRequest, current_user: Account = Depends(get_cur
     """
     Send test email with sendgrid
     """
+    try:
+        send_email(
+            data.email, "test message from Threatconnectome", "test message from Threatconnectome"
+        )
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(err))
+    except SendgridFailStatusError as err:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"sendgrid fail status error: {str(err)}",
+        )
+    except SendgridHttpError as err:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"sendgrid http error: {str(err)}",
+        )
 
-    response = send_email(
-        data.email, "test message from Threatconnectome", "test message from Threatconnectome"
-    )
-    if response is None:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return Response(status_code=status.HTTP_200_OK, content="OK")
 
 
 @router.post("/flashsense/check")

--- a/api/app/sendgrid.py
+++ b/api/app/sendgrid.py
@@ -11,7 +11,12 @@ def send_email(to_email: str, subject: str, content: str):
         from_email = Email(os.environ.get("SYSTEM_EMAIL"))
 
         mail = Mail(from_email, To(to_email), subject, Content("text/plain", content))
-        return sg.client.mail.send.post(request_body=mail.get())
+        response = sg.client.mail.send.post(request_body=mail.get())
+        if response.status_code != 202:
+            print("failed response to send email with sendgrid")
+            print(response.body)
+            return None
+        return response
     except exceptions.HTTPError as e:
         print("failed to send email with sendgrid")
         print(e)

--- a/api/app/sendgrid.py
+++ b/api/app/sendgrid.py
@@ -5,19 +5,32 @@ from python_http_client import exceptions
 from sendgrid.helpers.mail import Content, Email, Mail, To
 
 
-def send_email(to_email: str, subject: str, content: str):
-    try:
-        sg = sendgrid.SendGridAPIClient(api_key=os.environ.get("SENDGRID_API_KEY"))
-        from_email = Email(os.environ.get("SYSTEM_EMAIL"))
+class SendgridFailStatusError(Exception):
+    pass
 
-        mail = Mail(from_email, To(to_email), subject, Content("text/plain", content))
+
+class SendgridHttpError(Exception):
+    pass
+
+
+def send_email(to_email: str, subject: str, content: str):
+    SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY")
+    if SENDGRID_API_KEY is None:
+        raise ValueError("SENDGRID_API_KEY is not set")
+
+    SYSTEM_EMAIL = os.environ.get("SYSTEM_EMAIL")
+    if SYSTEM_EMAIL is None:
+        raise ValueError("SYSTEM_EMAIL is not set")
+
+    try:
+        sg = sendgrid.SendGridAPIClient(api_key=SENDGRID_API_KEY)
+        mail = Mail(Email(SYSTEM_EMAIL), To(to_email), subject, Content("text/plain", content))
+
         response = sg.client.mail.send.post(request_body=mail.get())
         if response.status_code != 202:
-            print("failed response to send email with sendgrid")
             print(response.body)
-            return None
+            raise SendgridFailStatusError(response.body)
         return response
-    except exceptions.HTTPError as e:
-        print("failed to send email with sendgrid")
-        print(e)
-        return None
+    except exceptions.HTTPError as err:
+        print(err)
+        raise SendgridHttpError(err)


### PR DESCRIPTION
## PR の目的

https://github.com/nttcom/threatconnectome/pull/102 の修正

## 経緯・意図・意思決定

- sendgrid apiの実行成功時、result.status_code のレスポンスは 200→202に変更
- from アドレスやAPIキーがセットされていない場合に、その旨のエラーメッセージを返す
- `sendgrid.py` で例外を出し、`/email/check `で例外をキャッチしてレスポンスを作成するように変更

## 参考文献
