### PR TITLE
Change variable name

### DIFF
--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.expression import func
 from app import models
 from app.constants import SYSTEM_EMAIL
 from app.sendgrid import ready_to_send_email, send_email
-from app.slack import create_slack_pteam_alert_blocks_for_new_topic, post_message
+from app.slack import create_slack_pteam_alert_blocks_for_new_topic, send_slack
 
 
 def _ready_alert_by_email() -> bool:
@@ -100,7 +100,7 @@ def alert_new_topic(db: Session, topic_id: UUID | str) -> None:
                     row.topic.threat_impact,
                     groups,
                 )
-                post_message(row.pteam.alert_slack.webhook_url, slack_message_blocks)
+                send_slack(row.pteam.alert_slack.webhook_url, slack_message_blocks)
             except Exception:
                 pass
 

--- a/api/app/routers/external.py
+++ b/api/app/routers/external.py
@@ -11,7 +11,7 @@ from app.constants import SYSTEM_EMAIL
 from app.models import Account
 from app.schemas import EmailCheckRequest, FsServerInfo, SlackCheckRequest
 from app.sendgrid import SendgridFailStatusError, SendgridHttpError, ready_to_send_email, send_email
-from app.slack import post_message, validate_slack_webhook_url
+from app.slack import send_slack, validate_slack_webhook_url
 
 router = APIRouter(prefix="/external", tags=["external"])
 
@@ -28,7 +28,7 @@ def check_webhook_url(data: SlackCheckRequest, current_user: Account = Depends(g
             "text": {"type": "mrkdwn", "text": "test message from Threatconnectome"},
         }
     ]
-    response = post_message(data.slack_webhook_url, blocks)
+    response = send_slack(data.slack_webhook_url, blocks)
     if response is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
     if response.status_code != 200:

--- a/api/app/slack.py
+++ b/api/app/slack.py
@@ -43,7 +43,7 @@ def _block_header(text: str):
     ]
 
 
-def post_message(url: str, blocks: Sequence[Dict]):
+def send_slack(url: str, blocks: Sequence[Dict]):
     try:
         webhook = WebhookClient(url)
         return webhook.send(text=blocks[0]["text"]["text"], blocks=blocks)
@@ -181,4 +181,4 @@ def alert_to_ateam(db: Session, action: models.TopicAction):
             action=action.action,
             action_type=action.action_type,
         )
-        post_message(webhook_url, blocks)
+        send_slack(webhook_url, blocks)


### PR DESCRIPTION
## PR の目的
- slack.pyにあるpost_message関数の名前をsend_slackに変更しました。

## 経緯・意図・意思決定
- メール通知機能が追加されpost_messagの名前だとどこに通知しているのか分かりずらいと思ったため、send_slackに変更しました。
- メールへ通知を行っている部分の関数の名前がsend_emailなので、それに合わせる形でsend_slackにしました。

## 参考文献
