### PR TITLE
unmask mail address for notification

### DIFF
--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -36,7 +36,6 @@ import { CheckButton } from "./CheckButton";
 export function ATeamNotificationSetting(props) {
   const { show } = props;
   const [edittingSlackUrl, setEdittingSlackUrl] = useState(false);
-  const [edittingEmail, setEdittingEmail] = useState(false);
   const [slackUrl, setSlackUrl] = useState("");
   const [slackEnable, setSlackEnable] = useState(false);
   const [mailAddress, setMailAddress] = useState("");
@@ -61,7 +60,6 @@ export function ATeamNotificationSetting(props) {
       setMailEnable(ateam.alert_mail.enable);
     }
     setEdittingSlackUrl(false);
-    setEdittingEmail(false);
     setCheckSlack(false);
     setSlackMessage();
   }, [show, ateam]);
@@ -198,21 +196,10 @@ export function ATeamNotificationSetting(props) {
           >
             <OutlinedInput
               id="ateam-mail-address-field"
-              type={edittingEmail ? "text" : "password"}
+              type="text"
               autoComplete="new-password" // to avoid autocomplete by browser
               value={mailAddress}
               onChange={(event) => setMailAddress(event.target.value)}
-              endAdornment={
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={() => setEdittingEmail(!edittingEmail)}
-                    edge="end"
-                  >
-                    {edittingEmail ? <VisibilityOffIcon /> : <VisibilityIcon />}
-                  </IconButton>
-                </InputAdornment>
-              }
             />
           </FormControl>
           <CheckButton onHandleClick={handleCheckMail} isLoading={checkEmail} />

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -38,7 +38,6 @@ import { CheckButton } from "./CheckButton";
 export function PTeamNotificationSetting(props) {
   const { show } = props;
   const [edittingSlackUrl, setEdittingSlackUrl] = useState(false);
-  const [edittingEmail, setEdittingEmail] = useState(false);
   const [slackUrl, setSlackUrl] = useState("");
   const [slackEnable, setSlackEnable] = useState(false);
   const [mailAddress, setMailAddress] = useState("");
@@ -65,7 +64,6 @@ export function PTeamNotificationSetting(props) {
       setAlertImpact(pteam.alert_threat_impact);
     }
     setEdittingSlackUrl(false);
-    setEdittingEmail(false);
     setCheckSlack(false);
     setSlackMessage();
   }, [show, pteam]);
@@ -202,21 +200,10 @@ export function PTeamNotificationSetting(props) {
           >
             <OutlinedInput
               id="pteam-mail-address-field"
-              type={edittingEmail ? "text" : "password"}
+              type="text"
               autoComplete="new-password" // to avoid autocomplete by browser
               value={mailAddress}
               onChange={(event) => setMailAddress(event.target.value)}
-              endAdornment={
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={() => setEdittingEmail(!edittingEmail)}
-                    edge="end"
-                  >
-                    {edittingEmail ? <VisibilityOffIcon /> : <VisibilityIcon />}
-                  </IconButton>
-                </InputAdornment>
-              }
             />
           </FormControl>
           <CheckButton onHandleClick={handleCheckMail} isLoading={checkEmail} />


### PR DESCRIPTION
## PR の目的
通知設定画面のメールアドレスのマスクをしないようにしました。

## 経緯・意図・意思決定
pteamは以下。ateamも同様。

![image](https://github.com/nttcom/threatconnectome/assets/92132688/b9575385-3769-455d-aa99-421ea2949d29)


## 参考文献
