### PR TITLE
Change the title on the API screen

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -20,7 +20,7 @@ from app.routers import (
 
 
 def create_app():
-    app = FastAPI()
+    app = FastAPI(title="Threatconnectome")
     origins = [
         "http://localhost:3000",  # dev
         "http://localhost:8080",  # dev


### PR DESCRIPTION
## PR の目的
- API画面で出てくるサービス名を "Threatconnectome" に変更しました。


![スクリーンショット 2024-03-08 10 28 12（2）](https://github.com/nttcom/threatconnectome/assets/142189177/30821346-0376-4fe6-83b5-d852f4521c54)
