### PR TITLE
Add query parameter to url on topic screen

### DIFF
--- a/web/src/components/Drawer.jsx
+++ b/web/src/components/Drawer.jsx
@@ -158,7 +158,7 @@ export function Drawer() {
         )}
         {/* Topics */}
         <StyledListItemButton
-          onClick={() => navigate("/topics")}
+          onClick={() => navigate("/topics?" + queryParams)}
           selected={location.pathname === "/topics"}
         >
           <StyledListItemIcon>


### PR DESCRIPTION
## PR の目的
- PTeamでTopics画面を開くとデフォルトのpteam に戻ってしまうバグを修正しました

## 経緯・意図・意思決定
- Drawer.jsxで/topicsだけクエリパラメータの記述がないことがバグの原因でした。そのため/topicsにクエリパラメータを追加しました。