### PR TITLE
Change alert mail to html

### DIFF
--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -149,7 +149,7 @@ def create_mail_alert_for_new_topic(
         4: "None",
     }.get(threat_impact) or "WrongThreatImpact"
     subject = f"[Tc Alert] {threat_impact_label}: {topic_title}"
-    body = "\n".join(
+    body = "<br>".join(
         [
             "A new topic created.",
             "",
@@ -160,7 +160,7 @@ def create_mail_alert_for_new_topic(
             f"Groups: {', '.join(groups)}",
             f"Artifact: {tag_name}",
             "",
-            f"Link to Artifact page: {_pteam_tag_page_link(pteam_id, tag_id)}",
+            f"<a href={_pteam_tag_page_link(pteam_id, tag_id)}>Link to Artifact page</a>",
         ]
     )
     return subject, body

--- a/api/app/sendgrid.py
+++ b/api/app/sendgrid.py
@@ -36,7 +36,7 @@ def send_email(to_email: str, from_email: str, subject: str, content: str):
 
     try:
         sg = sendgrid.SendGridAPIClient(api_key=SENDGRID_API_KEY)
-        mail = Mail(Email(from_email), To(to_email), subject, Content("text/plain", content))
+        mail = Mail(Email(from_email), To(to_email), subject, Content("text/html", content))
 
         response = sg.client.mail.send.post(request_body=mail.get())
         if response.status_code != 202:


### PR DESCRIPTION
## PR の目的

通知メールの文字化け対策として、ContentTypeを`text/html`に変更する

## 経緯・意図・意思決定

- 通知メールのContentTypeを`text/html`に変更しました
- メールの本文をHTML仕様に変更しました。改行にbrタグ、リンクにaタグを使用。

メール本文
![image](https://github.com/nttcom/threatconnectome/assets/92132688/4f80bd12-5b5e-4ac2-a76b-bccbc4f6abc0)


## 参考文献
