### PR TITLE
add `restart` to firebase container

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -94,3 +94,4 @@ services:
     working_dir: /opt/workspace
     command: "firebase emulators:start --import=./data --export-on-exit"
     tty: true
+    restart: always


### PR DESCRIPTION
## PR の目的

docker-compose-local.yml 内で、firebase continerのみ、`restart`が記述されていなかったので、追加しました。
これにより、contanier立ち上げた状態で、マシンを再起動した際、containerがすべて起動します。


## 参考文献
