### PR TITLE
Modified to add child tag

### DIFF
--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -115,6 +115,7 @@ export function PTeamEditAction(props) {
   const validateActionTags = () => {
     const validTagNames = new Set();
     const presetTag = allTags.find((tag) => tag.tag_id === presetTagId);
+    validTagNames.add(presetTag.tag_name);
 
     allTags
       .filter((tag) => tagIds.includes(tag.tag_id))
@@ -122,11 +123,6 @@ export function PTeamEditAction(props) {
         validTagNames.add(tag.tag_name);
         if (tag.parent_name && tag.parent_name !== tag.tag_name) {
           validTagNames.add(tag.parent_name);
-        }
-
-        // When only the parent tag is registered in a topic, child tags can also be selected.
-        if (tag.tag_id !== presetTagId && tag.tag_id === presetParentTagId) {
-          validTagNames.add(presetTag.tag_name);
         }
       });
     for (let action of actions) {

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -114,6 +114,8 @@ export function PTeamEditAction(props) {
 
   const validateActionTags = () => {
     const validTagNames = new Set();
+    const presetTag = allTags.find((tag) => tag.tag_id === presetTagId);
+
     allTags
       .filter((tag) => tagIds.includes(tag.tag_id))
       .forEach((tag) => {
@@ -124,8 +126,7 @@ export function PTeamEditAction(props) {
 
         // When only the parent tag is registered in a topic, child tags can also be selected.
         if (tag.tag_id !== presetTagId && tag.tag_id === presetParentTagId) {
-          const tag = allTags.filter((tag) => tag.tag_id === presetTagId);
-          validTagNames.add(tag[0].tag_name);
+          validTagNames.add(presetTag.tag_name);
         }
       });
     for (let action of actions) {

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -125,7 +125,6 @@ export function PTeamEditAction(props) {
         // When only the parent tag is registered in a topic, child tags can also be selected.
         if (tag.tag_id !== presetTagId && tag.tag_id === presetParentTagId) {
           const tag = allTags.filter((tag) => tag.tag_id === presetTagId);
-          console.log(tag[0].tag_name);
           validTagNames.add(tag[0].tag_name);
         }
       });

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -121,6 +121,13 @@ export function PTeamEditAction(props) {
         if (tag.parent_name && tag.parent_name !== tag.tag_name) {
           validTagNames.add(tag.parent_name);
         }
+
+        // When only the parent tag is registered in a topic, child tags can also be selected.
+        if (tag.tag_id !== presetTagId && tag.tag_id === presetParentTagId) {
+          const tag = allTags.filter((tag) => tag.tag_id === presetTagId);
+          console.log(tag[0].tag_name);
+          validTagNames.add(tag[0].tag_name);
+        }
       });
     for (let action of actions) {
       if (action.ext?.tags && !action.ext.tags.every((tag) => validTagNames.has(tag))) {

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -137,6 +137,9 @@ export function TopicModal(props) {
 
   const validateActionTags = () => {
     const validTagNames = new Set();
+    const presetTag = allTags.find((tag) => tag.tag_id === presetTagId);
+    validTagNames.add(presetTag.tag_name);
+
     allTags
       .filter((tag) => tagIds.includes(tag.tag_id))
       .forEach((tag) => {


### PR DESCRIPTION
## PR の目的
- pteamの画面でアクションを作成する際に、Topictagが親タグの場合その子供のタグが選択できないバグを修正しました。

## 経緯・意図・意思決定
- Topictagに親タグのみ選択されていても、アクション作成時に親と子供のタグ両方を登録できるようにしました。
- 条件分岐を行いvalidTagNamesに子供のタグを追加できるようにしました。
