### PR TITLE
ボタンに関するCSSの作成

### DIFF
--- a/web/src/components/ATeamInviteModal.jsx
+++ b/web/src/components/ATeamInviteModal.jsx
@@ -19,8 +19,9 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
+import styles from "../cssModule/button.module.css";
 import { createATeamInvitation } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle } from "../utils/const";
 
 import { CopiedIcon } from "./CopiedIcon";
 
@@ -75,7 +76,7 @@ export function ATeamInviteModal(props) {
 
   return (
     <>
-      <Button onClick={handleOpen} sx={commonButtonStyle}>
+      <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
       <Dialog open={open} fullWidth>

--- a/web/src/components/ATeamRequestModal.jsx
+++ b/web/src/components/ATeamRequestModal.jsx
@@ -21,8 +21,9 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
+import styles from "../cssModule/button.module.css";
 import { createATeamWatchingRequest } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamRequestModal(props) {
   const { text } = props;
@@ -74,7 +75,7 @@ export function ATeamRequestModal(props) {
 
   return (
     <>
-      <Button onClick={handleOpen} sx={commonButtonStyle}>
+      <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
       <Dialog open={open} fullWidth>

--- a/web/src/components/ATeamTopicMenu.jsx
+++ b/web/src/components/ATeamTopicMenu.jsx
@@ -1,7 +1,7 @@
 import { Button, Box } from "@mui/material";
 import React, { useState } from "react";
 
-import { commonButtonStyle } from "../utils/const";
+import styles from "../cssModule/button.module.css";
 
 import { ATeamTopicCreateModal } from "./ATeamTopicCreateModal";
 
@@ -12,10 +12,11 @@ export function ATeamTopicMenu() {
     <>
       <Box display="flex" justifyContent="flex-end" mb={2}>
         <Button
+          className={styles.prominent_btn}
           onClick={() => {
             setModalOpen(true);
           }}
-          sx={{ ...commonButtonStyle, width: "100px" }}
+          sx={{ width: "100px" }}
         >
           New Topic
         </Button>

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -40,6 +40,7 @@ import { ThreatImpactChip } from "../components/ThreatImpactChip";
 import { TopicEditModal } from "../components/TopicEditModal";
 import { UUIDTypography } from "../components/UUIDTypography";
 import { WarningTooltip } from "../components/WarningTooltip";
+import styles from "../cssModule/button.module.css";
 import { getActions, getTopic } from "../slices/topics";
 import {
   createATeamTopicComment as apiCreateATeamTopicComment,
@@ -300,12 +301,10 @@ export function AnalysisTopic(props) {
                 onChange={(event) => setNewComment(event.target.value)}
               />
               <Button
+                className={styles.check_btn}
                 onClick={handleCreateComment}
-                variant="outlined"
-                color="success"
                 sx={{
                   margin: "10px 0 30px auto",
-                  textTransform: "none",
                 }}
               >
                 Comment

--- a/web/src/components/CheckButton.jsx
+++ b/web/src/components/CheckButton.jsx
@@ -2,18 +2,13 @@ import { Button, CircularProgress } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
+import styles from "../cssModule/button.module.css";
+
 export function CheckButton(props) {
   const { onHandleClick, isLoading } = props;
 
   return (
-    <Button
-      variant="outlined"
-      sx={{
-        textTransform: "none",
-        marginRight: "10px",
-      }}
-      onClick={onHandleClick}
-    >
+    <Button className={styles.check_btn} onClick={onHandleClick}>
       {isLoading ? <CircularProgress size="1.6rem" sx={{ color: "#fff" }} /> : "Check"}
     </Button>
   );

--- a/web/src/components/GTeamInviteModal.jsx
+++ b/web/src/components/GTeamInviteModal.jsx
@@ -19,8 +19,9 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
+import styles from "../cssModule/button.module.css";
 import { createGTeamInvitation } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle } from "../utils/const";
 
 import { CopiedIcon } from "./CopiedIcon";
 
@@ -75,7 +76,7 @@ export function GTeamInviteModal(props) {
 
   return (
     <>
-      <Button onClick={handleOpen} sx={commonButtonStyle}>
+      <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
       <Dialog open={open} fullWidth>

--- a/web/src/components/PTeamInviteModal.jsx
+++ b/web/src/components/PTeamInviteModal.jsx
@@ -19,8 +19,9 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
+import styles from "../cssModule/button.module.css";
 import { createPTeamInvitation } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle } from "../utils/const";
 
 import { CopiedIcon } from "./CopiedIcon";
 
@@ -73,7 +74,7 @@ export function PTeamInviteModal(props) {
 
   return (
     <>
-      <Button onClick={handleOpen} sx={commonButtonStyle}>
+      <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
       <Dialog open={open} fullWidth>

--- a/web/src/components/ZoneCreateModal.jsx
+++ b/web/src/components/ZoneCreateModal.jsx
@@ -12,10 +12,11 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
+import styles from "../cssModule/button.module.css";
 import { getGTeamZonesSummary } from "../slices/gteam";
 import { getAuthorizedZones } from "../slices/user";
 import { createGTeamZone } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle } from "../utils/const";
 
 export function ZoneCreateModal(props) {
   const { gteamId } = props;
@@ -53,7 +54,7 @@ export function ZoneCreateModal(props) {
 
   return (
     <>
-      <Button onClick={() => setOpen(true)} sx={{ ...commonButtonStyle }}>
+      <Button className={styles.prominent_btn} onClick={() => setOpen(true)}>
         Create Zone
       </Button>
       <Dialog open={open} onClose={() => setOpen(false)} fullWidth>

--- a/web/src/cssModule/button.module.css
+++ b/web/src/cssModule/button.module.css
@@ -1,0 +1,15 @@
+.prominent_btn.prominent_btn {
+    background-color: green;
+    color: white;
+    text-transform: none;
+    &:hover {
+        background-color: darkgreen;
+    }
+} 
+
+.check_btn.check_btn {
+    text-transform: none;
+    border: 1px solid;
+    padding-left: 13px;
+    padding-right: 13px
+}

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -29,6 +29,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { FormattedDateTimeWithTooltip } from "../components/FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "../components/TopicSearchModal";
+import styles from "../cssModule/button.module.css";
 import { getActions, getTopic } from "../slices/topics";
 import { searchTopics } from "../utils/api";
 import { difficulty, difficultyColors } from "../utils/const";
@@ -200,9 +201,7 @@ export function TopicManagement() {
         <Box flexGrow={1} />
         <Box mb={0.5}>
           <Button
-            variant="contained"
-            color="success"
-            sx={{ textTransform: "none" }}
+            className={styles.prominent_btn}
             onClick={() => {
               setSearchMenuOpen(true);
             }}


### PR DESCRIPTION
## PR の目的

- これまでjsx内に直接書かれていたボタンのデザインについて、新たにmodule.cssを作成し、共通のデザインを反映させる

## 経緯・意図・意思決定

- 複数回使われている登録系の緑のボタンとoutlineの水色のボタンについてcssを作成し、反映させた
- 1箇所しか使用されていないボタンをcssに切り出すかは要検討
- モーダル内のボタンについては後日作成予定のmodal.module.cssで実装予定

