### PR TITLE
Change group to service

### DIFF
--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -48,7 +48,7 @@ function PreUploadModal(props) {
       <DialogContent>
         <Box display="flex" flexDirection="column">
           <TextField
-            label="Group name"
+            label="Service name"
             size="small"
             value={groupName}
             onChange={(event) => setGroupName(event.target.value)}

--- a/web/src/components/TagReferences.jsx
+++ b/web/src/components/TagReferences.jsx
@@ -40,7 +40,7 @@ export function TagReferences(props) {
                 <TableRow>
                   <TableCell sx={{ fontWeight: 900 }}>target</TableCell>
                   <TableCell sx={{ fontWeight: 900 }}>version</TableCell>
-                  <TableCell sx={{ fontWeight: 900 }}>group</TableCell>
+                  <TableCell sx={{ fontWeight: 900 }}>Service</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>


### PR DESCRIPTION
## PR の目的
-UI上で 「Group」という表示だったのを「Service」に変更しました

## 経緯・意図・意思決定
- sbomファイルをアップロードするモーダルで「Group name」と表示されていたところを「Service name」に変更しました。(web/src/components/SBOMDropArea.jsx)
- tagのreferencesで「Group」と表示されていたところを「Service」に変更しました。(web/src/components/TagReferences.jsx)
