### PR TITLE
Topicの表示行の切り替え

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -220,6 +220,7 @@ def search_topics_internal(
     updated_after: datetime | None = None,
     updated_before: datetime | None = None,
     pteam_id: UUID | None = None,
+    ateam_id: UUID | None = None,
 ) -> dict:
     # search conditions
     search_by_threat_impacts_stmt = (
@@ -320,17 +321,60 @@ def search_topics_internal(
     search_by_pteam_id = (
         true()
         if pteam_id is None
-        else models.Topic.topic_id.in_(
-            select(models.Topic.topic_id)
-            .join(models.TopicTag)
-            .where(
-                models.TopicTag.tag_id.in_(
-                    select(models.Tag.tag_id)
-                    .join(models.Dependency)
-                    .join(models.Service)
-                    .where(models.Service.pteam_id == str(pteam_id))
+        else or_(
+            models.TopicTag.tag_id.in_(
+                select(models.Tag.tag_id)
+                .join(models.Dependency)
+                .join(
+                    models.Service,
+                    and_(
+                        models.Service.service_id == models.Dependency.service_id,
+                        models.Service.pteam_id == str(pteam_id),
+                    ),
                 )
-            )
+            ),
+            models.TopicTag.tag_id.in_(
+                select(models.Tag.parent_id)
+                .join(models.Dependency)
+                .join(
+                    models.Service,
+                    and_(
+                        models.Service.service_id == models.Dependency.service_id,
+                        models.Service.pteam_id == str(pteam_id),
+                    ),
+                )
+            ),
+        )
+    )
+
+    search_by_ateam_id = (
+        true()
+        if ateam_id is None
+        else or_(
+            models.TopicTag.tag_id.in_(
+                select(models.Tag.tag_id)
+                .join(models.Dependency)
+                .join(models.Service)
+                .join(
+                    models.ATeamPTeam,
+                    and_(
+                        models.ATeamPTeam.pteam_id == models.Service.pteam_id,
+                        models.ATeamPTeam.ateam_id == str(ateam_id),
+                    ),
+                )
+            ),
+            models.TopicTag.tag_id.in_(
+                select(models.Tag.parent_id)
+                .join(models.Dependency)
+                .join(models.Service)
+                .join(
+                    models.ATeamPTeam,
+                    and_(
+                        models.ATeamPTeam.pteam_id == models.Service.pteam_id,
+                        models.ATeamPTeam.ateam_id == str(ateam_id),
+                    ),
+                )
+            ),
         )
     )
 
@@ -347,6 +391,7 @@ def search_topics_internal(
         search_by_updated_before_stmt,
         search_by_updated_after_stmt,
         search_by_pteam_id,
+        search_by_ateam_id,
     ]
     filter_topics_stmt = and_(
         true(),
@@ -357,7 +402,7 @@ def search_topics_internal(
     # join tables only if required
     select_topics_stmt = select(models.Topic)
     select_count_stmt = select(func.count(models.Topic.topic_id.distinct()))
-    if tag_ids is not None:
+    if tag_ids is not None or pteam_id or ateam_id:
         select_topics_stmt = select_topics_stmt.outerjoin(models.TopicTag)
         select_count_stmt = select_count_stmt.outerjoin(models.TopicTag)
     if misp_tag_ids is not None:

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -63,6 +63,7 @@ def search_topics(
     created_before: datetime | None = Query(None),
     updated_after: datetime | None = Query(None),
     updated_before: datetime | None = Query(None),
+    pteam_id: UUID | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -174,6 +175,7 @@ def search_topics(
         created_before=created_before,
         updated_after=updated_after,
         updated_before=updated_before,
+        pteam_id=pteam_id,
     )
 
 

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -98,6 +98,12 @@ def search_topics(
     """
     keyword_for_empty = ""
 
+    if pteam_id and ateam_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot specify both pteam_id and ateam_id",
+        )
+
     fixed_tag_ids: set[str | None] = set()
     if tag_names is not None:
         for tag_name in tag_names:

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -64,6 +64,7 @@ def search_topics(
     updated_after: datetime | None = Query(None),
     updated_before: datetime | None = Query(None),
     pteam_id: UUID | None = Query(None),
+    ateam_id: UUID | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -176,6 +177,7 @@ def search_topics(
         updated_after=updated_after,
         updated_before=updated_before,
         pteam_id=pteam_id,
+        ateam_id=ateam_id,
     )
 
 

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -1193,7 +1193,6 @@ class TestSearchTopics:
                 / "upload_test"
                 / "tag.jsonl"
             )
-            print(sbom_file)
             with open(sbom_file, "rb") as tags:
                 response_upload_sbom_file = client.post(
                     f"/pteams/{self.pteam1.pteam_id}/upload_tags_file",

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -8,7 +8,9 @@ import {
   Box,
   Button,
   Chip,
+  FormControlLabel,
   Select,
+  Switch,
   Table,
   TableBody,
   TableCell,
@@ -22,6 +24,7 @@ import {
   Paper,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
+import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
@@ -60,6 +63,8 @@ function TopicManagementTableRow(props) {
     );
   }
 
+  const relatedTopic = true;
+
   return (
     <TableRow
       key={topic.topic_id}
@@ -74,7 +79,14 @@ function TopicManagementTableRow(props) {
       <TableCell>
         <FormattedDateTimeWithTooltip utcString={topic.updated_at} />
       </TableCell>
-      <TableCell>
+      <TableCell align="center">
+        {relatedTopic ? (
+          <CheckCircleOutlineIcon color="success" />
+        ) : (
+          <HorizontalRuleIcon sx={{ color: grey[500] }} />
+        )}
+      </TableCell>
+      <TableCell align="center">
         {actionList?.length > 0 ? (
           <CheckCircleOutlineIcon color="success" />
         ) : (
@@ -190,6 +202,39 @@ export function TopicManagement() {
     </Box>
   );
 
+  const Android12Switch = styled(Switch)(({ theme }) => ({
+    padding: 8,
+    "& .MuiSwitch-track": {
+      borderRadius: 22 / 2,
+      "&:before, &:after": {
+        content: "''",
+        position: "absolute",
+        top: "50%",
+        transform: "translateY(-50%)",
+        width: 16,
+        height: 16,
+      },
+      "&:before": {
+        backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24"><path fill="${encodeURIComponent(
+          theme.palette.getContrastText(theme.palette.primary.main),
+        )}" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/></svg>")`,
+        left: 12,
+      },
+      "&:after": {
+        backgroundImage: `url("data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24"><path fill="${encodeURIComponent(
+          theme.palette.getContrastText(theme.palette.primary.main),
+        )}" d="M19,13H5V11H19V13Z" /></svg>")`,
+        right: 12,
+      },
+    },
+    "& .MuiSwitch-thumb": {
+      boxShadow: "none",
+      width: 16,
+      height: 16,
+      margin: 2,
+    },
+  }));
+
   const topics = searchResult?.topics;
 
   if (!topics) return <>Loading...</>;
@@ -197,7 +242,7 @@ export function TopicManagement() {
   return (
     <>
       <Box display="flex" mt={2}>
-        {filterRow}
+        <FormControlLabel sx={{ ml: -1 }} control={<Android12Switch />} label="Related topics" />
         <Box flexGrow={1} />
         <Box mb={0.5}>
           <Button
@@ -221,17 +266,20 @@ export function TopicManagement() {
         <Table sx={{ minWidth: 650 }}>
           <TableHead>
             <TableRow>
-              <TableCell style={{ width: "10%" }} display="flex">
+              <TableCell style={{ width: "20%" }} display="flex">
                 <Box display="flex" flexDirection="row">
-                  <Typography variant="body2">Last Update</Typography>
+                  <Typography variant="body2" sx={{ fontWeight: 900 }}>
+                    Last Update
+                  </Typography>
                   <Tooltip title="Timezone is local time">
                     <InfoIcon sx={{ color: grey[600], ml: 1 }} />
                   </Tooltip>
                 </Box>
               </TableCell>
-              <TableCell style={{ width: "3%" }}>Action</TableCell>
-              <TableCell style={{ width: "25%" }}>Title</TableCell>
-              <TableCell style={{ width: "35%" }}>MISP Tag</TableCell>
+              <TableCell style={{ width: "3%", fontWeight: 900 }}>Affected</TableCell>
+              <TableCell style={{ width: "3%", fontWeight: 900 }}>Action</TableCell>
+              <TableCell style={{ width: "25%", fontWeight: 900 }}>Title</TableCell>
+              <TableCell style={{ width: "35%", fontWeight: 900 }}>MISP Tag</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -111,7 +111,8 @@ export function TopicManagement() {
   const perPageItems = [10, 20, 50, 100];
 
   const [searchMenuOpen, setSearchMenuOpen] = useState(false);
-  const [checked, setChecked] = useState(true);
+  const [checkedPteam, setCheckedPteam] = useState(true);
+  const [checkedAteam, setCheckedAteam] = useState(false);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(perPageItems[0]);
   const [searchConditions, setSearchConditions] = useState({});
@@ -124,15 +125,24 @@ export function TopicManagement() {
 
   const params = new URLSearchParams(useLocation().search);
   const pteamId = params.get("pteamId");
+  const ateamId = params.get("ateamId");
 
   const evalSearchTopics = async () => {
     let queryParams = {};
-    if (checked === true) {
+    if (checkedPteam === true && pteamId) {
       queryParams = {
         offset: perPage * (page - 1),
         limit: perPage,
         sort_key: "updated_at_desc",
         pteam_id: pteamId,
+        ...searchConditions,
+      };
+    } else if (checkedAteam === true && ateamId) {
+      queryParams = {
+        offset: perPage * (page - 1),
+        limit: perPage,
+        sort_key: "updated_at_desc",
+        ateam_id: ateamId,
         ...searchConditions,
       };
     } else {
@@ -156,7 +166,7 @@ export function TopicManagement() {
     if (!user?.user_id) return;
     evalSearchTopics();
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [page, perPage, searchConditions, user, checked]);
+  }, [page, perPage, searchConditions, user, checkedPteam, checkedAteam]);
 
   const paramsToSearchQuery = (params) => {
     const delimiter = "|";
@@ -181,7 +191,11 @@ export function TopicManagement() {
   };
 
   const handleChangeSwitch = () => {
-    setChecked(!checked);
+    if (pteamId) {
+      setCheckedPteam(!checkedPteam);
+    } else if (ateamId) {
+      setCheckedAteam(!checkedAteam);
+    }
   };
 
   const filterRow = (
@@ -253,11 +267,20 @@ export function TopicManagement() {
   return (
     <>
       <Box display="flex" mt={2}>
-        <FormControlLabel
-          sx={{ ml: -1 }}
-          control={<Android12Switch checked={checked} onChange={handleChangeSwitch} />}
-          label="Related topics"
-        />
+        {pteamId ? (
+          <FormControlLabel
+            sx={{ ml: -1 }}
+            control={<Android12Switch checked={checkedPteam} onChange={handleChangeSwitch} />}
+            label="Related topics"
+          />
+        ) : (
+          <FormControlLabel
+            sx={{ ml: -1 }}
+            control={<Android12Switch checked={checkedAteam} onChange={handleChangeSwitch} />}
+            label="Related topics"
+          />
+        )}
+
         <Box flexGrow={1} />
         <Box mb={0.5}>
           <Button

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -29,8 +29,8 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
 import { useNavigate } from "react-router";
+import { useLocation } from "react-router-dom";
 
 import { FormattedDateTimeWithTooltip } from "../components/FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "../components/TopicSearchModal";


### PR DESCRIPTION
## PR の目的

- Topic内のリストを、PTeamは自身の関係のあるTopicのみ表示／ATeamは全件表示をデフォルトにし、切り替えるボタンを設置する

## 経緯・意図・意思決定
- 切り替えたことがわかるよう、リスト自体に「Affected」項目を追加した
- 現在は画面モックのみ


## 参考文献
