### PR TITLE
Topic/api searching tags dismiss tsquery

### DIFF
--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app import models
@@ -416,14 +416,6 @@ def create_tag(db: Session, tag: models.Tag) -> None:
     db.flush()
 
 
-def search_tags_by_name(db: Session, words: Sequence[str]) -> Sequence[models.Tag]:
-    return db.scalars(
-        select(models.Tag).where(
-            models.Tag.tag_name.bool_op("@@")(func.to_tsquery("|".join(words)))
-        )
-    ).all()
-
-
 def delete_tag(db: Session, tag: models.Tag):
     db.delete(tag)
     db.flush()
@@ -445,14 +437,6 @@ def get_misp_tag_by_name(db: Session, tag_name: str) -> models.MispTag | None:
 def create_misp_tag(db: Session, misptag: models.MispTag) -> None:
     db.add(misptag)
     db.flush()
-
-
-def search_misp_tags_by_name(db: Session, words: Sequence[str]) -> Sequence[models.MispTag]:
-    return db.scalars(
-        select(models.MispTag).where(
-            models.MispTag.tag_name.bool_op("@@")(func.to_tsquery("|".join(words)))
-        )
-    ).all()
 
 
 ### Topic

--- a/api/app/routers/misptags.py
+++ b/api/app/routers/misptags.py
@@ -51,9 +51,12 @@ def search_misp_tags(
     Search misp tags.
     If given a list of words, return all misp tags that match any of the words.
     """
+    all_misp_tags = persistence.get_all_misp_tags(db)
     # If no words were provided, return all misp tags.
     if words is None:
-        return persistence.get_all_misp_tags(db)
+        return all_misp_tags
 
     # Otherwise, search for tags that match the provided words.
-    return persistence.search_misp_tags_by_name(db, words)
+    return filter(
+        lambda x: any(word.lower() in x.tag_name.lower() for word in words), all_misp_tags
+    )

--- a/api/app/routers/tags.py
+++ b/api/app/routers/tags.py
@@ -53,12 +53,13 @@ def search_tags(
     Search tags.
     If given a list of words, return all tags that match any of the words.
     """
+    all_tags = persistence.get_all_tags(db)
     # If no words were provided, return all tags.
     if words is None:
-        return persistence.get_all_tags(db)
+        return all_tags
 
     # Otherwise, search for tags that match the provided words.
-    return persistence.search_tags_by_name(db, words)
+    return filter(lambda x: any(word.lower() in x.tag_name.lower() for word in words), all_tags)
 
 
 @router.delete("/{tag_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tests/medium/routers/test_tags.py
+++ b/api/app/tests/medium/routers/test_tags.py
@@ -143,20 +143,31 @@ def test_delete_tag():
     assert len(data) == 0
 
 
-@pytest.mark.skip(reason='TODO: need fix syntax error in query at searching with ":"')
 def test_search_tag():
     create_user(USER1)
 
-    # tag_1 = create_tag(USER1, 'a1:a2:')
-    # tag_11 = create_tag(USER1, 'a1:a2:a3-1')
-    # tag_12 = create_tag(USER1, 'a1:a2:a3-2')
-    # tag_1 = create_tag(USER1, 'b1:b2:')
-    # tag_11 = create_tag(USER1, 'b1:b2:b3-1')
-    # tag_12 = create_tag(USER1, 'b1:b2:b3-2')
-    # tag_x = create_tag(USER1, 'a2')
+    tag_1 = create_tag(USER1, "a1:a2:")
+    tag_11 = create_tag(USER1, "a1:a2:a3-1")
+    tag_12 = create_tag(USER1, "a1:a2:a3-2")
+    create_tag(USER1, "b1:b2:")
+    tag_21 = create_tag(USER1, "b1:b2:b3-1")
+    create_tag(USER1, "b1:b2:b3-2")
+    create_tag(USER1, "a2")
 
-    # params = {"words": ["a1:a2:a3-1"]}
-    # data = assert_200(client.get("/tags/search", headers=headers(USER1), params=params))
-    # assert len(data) == 1
-    # assert data[0] == schema_to_dict(tag_11)
-    # # TODO: check more
+    params = {"words": ["a3-1"]}
+    data = assert_200(client.get("/tags/search", headers=headers(USER1), params=params))
+    assert len(data) == 1
+    assert schema_to_dict(tag_11) in data
+
+    params = {"words": ["3-1"]}
+    data = assert_200(client.get("/tags/search", headers=headers(USER1), params=params))
+    assert len(data) == 2
+    assert schema_to_dict(tag_11) in data
+    assert schema_to_dict(tag_21) in data
+
+    params = {"words": [":A2"]}
+    data = assert_200(client.get("/tags/search", headers=headers(USER1), params=params))
+    assert len(data) == 3
+    assert schema_to_dict(tag_1) in data
+    assert schema_to_dict(tag_11) in data
+    assert schema_to_dict(tag_12) in data


### PR DESCRIPTION
## PR の目的

- tag, misp_tag の検索apiで、tsqueryでの単語検索を止め、文字列検索で判定するように改修
  - 検索処理をDB側でなくPython（ORM）側で行っている


#### 付記
- case insensitive
- コロン（:）を含む検索でInternal Server Errorが発生していた問題も解消
- テストは既存（スキップしていた内容）を少し手直ししただけのもの。抜本的な整理が必要だが、別タスクとしたい。