### PR TITLE
モーダルのデザイン統一とCSS化

### DIFF
--- a/web/src/components/ATeamAuthEditor.jsx
+++ b/web/src/components/ATeamAuthEditor.jsx
@@ -2,11 +2,12 @@ import {
   CheckBox as CheckedIcon,
   CheckBoxOutlineBlank as UnCheckedIcon,
   CheckBoxOutlined as CheckedOutlinedIcon,
+  Close as CloseIcon,
 } from "@mui/icons-material";
 import {
   Box,
   Button,
-  Divider,
+  IconButton,
   Table,
   TableBody,
   TableCell,
@@ -20,9 +21,9 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getATeamAuth, getATeamAuthInfo } from "../slices/ateam";
 import { updateATeamAuth } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamAuthEditor(props) {
   const { userId, userEmail, onClose } = props;
@@ -203,8 +204,17 @@ export function ATeamAuthEditor(props) {
 
   return userMe && newAuth.user && authInfo && authorities && ateamAuth ? (
     <>
-      <Typography variant="h5">Authority: {pseudoEdit ? "member & others" : userEmail}</Typography>
-      <Divider sx={{ my: 1 }} />
+      <Box display="flex" flexDirection="row">
+        <Typography className={dialogStyle.dialog_title}>
+          Authority: {pseudoEdit ? "member & others" : userEmail}
+        </Typography>
+        <Box flexGrow={1} />
+        {onClose && (
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        )}
+      </Box>
       <TableContainer>
         <Table sx={{ minWidth: 650 }}>
           <TableHead>
@@ -223,22 +233,13 @@ export function ATeamAuthEditor(props) {
       </TableContainer>
       <Box display="flex" mt={2}>
         {editable && userId && (
-          <Button onClick={switchPseudoEdit} sx={modalCommonButtonStyle}>
+          <Button onClick={switchPseudoEdit} className={dialogStyle.submit_btn}>
             {pseudoEdit ? `Edit ${userEmail}` : "Edit Pseudo"}
           </Button>
         )}
         <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            {editable && updated() ? "Cancel" : "Close"}
-          </Button>
-        )}
         {editable && (
-          <Button
-            onClick={handleSave}
-            disabled={!updated()}
-            sx={{ ...modalCommonButtonStyle, ml: 1 }}
-          >
+          <Button onClick={handleSave} disabled={!updated()} className={dialogStyle.submit_btn}>
             Update
           </Button>
         )}

--- a/web/src/components/ATeamCreateModal.jsx
+++ b/web/src/components/ATeamCreateModal.jsx
@@ -16,9 +16,9 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getUser } from "../slices/user";
 import { createATeam } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamCreateModal(props) {
   const { open, onOpen, onCloseTeamSelector } = props;
@@ -65,7 +65,7 @@ export function ATeamCreateModal(props) {
       <Dialog fullWidth open={open} onClose={() => onOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
-            <Typography variant="h5">Create ATeam</Typography>
+            <Typography className={dialogStyle.dialog_title}>Create ATeam</Typography>
             <Box flexGrow={1} />
             <IconButton onClick={() => onOpen(false)}>
               <CloseIcon />
@@ -88,8 +88,8 @@ export function ATeamCreateModal(props) {
             ></TextField>
           </Box>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCreate} disabled={!ateamName} sx={modalCommonButtonStyle}>
+        <DialogActions className={dialogStyle.action_area}>
+          <Button onClick={handleCreate} disabled={!ateamName} className={dialogStyle.submit_btn}>
             Create
           </Button>
         </DialogActions>

--- a/web/src/components/ATeamInviteModal.jsx
+++ b/web/src/components/ATeamInviteModal.jsx
@@ -1,3 +1,4 @@
+import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -6,6 +7,7 @@ import {
   DialogContent,
   DialogTitle,
   Grid,
+  IconButton,
   Link,
   Slider,
   TextField,
@@ -20,8 +22,8 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import styles from "../cssModule/button.module.css";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { createATeamInvitation } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 import { CopiedIcon } from "./CopiedIcon";
 
@@ -79,9 +81,15 @@ export function ATeamInviteModal(props) {
       <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
-      <Dialog open={open} fullWidth>
+      <Dialog open={open} onClose={handleClose} fullWidth>
         <DialogTitle>
-          <Typography variant="inherit">Create New Invitation Link</Typography>
+          <Box display="flex" flexDirection="row">
+            <Typography className={dialogStyle.dialog_title}>Create New Invitation Link</Typography>
+            <Box flexGrow={1} />
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </DialogTitle>
         <DialogContent>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -139,15 +147,12 @@ export function ATeamInviteModal(props) {
             )}
           </LocalizationProvider>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} sx={modalCommonButtonStyle}>
-            {invitationLink ? "Close" : "Cancel"}
-          </Button>
+        <DialogActions className={dialogStyle.action_area}>
           {!invitationLink && (
             <Button
               onClick={handleCreate}
               disabled={!isBefore(now, expiration)}
-              sx={modalCommonButtonStyle}
+              className={dialogStyle.submit_btn}
             >
               Create
             </Button>

--- a/web/src/components/ATeamMemberMenu.jsx
+++ b/web/src/components/ATeamMemberMenu.jsx
@@ -71,7 +71,7 @@ export function ATeamMemberMenu(props) {
           </MenuItem>
         )}
       </Menu>
-      <Dialog open={openAuth}>
+      <Dialog open={openAuth} onClose={() => setOpenAuth(false)}>
         <DialogContent>
           <ATeamAuthEditor
             userId={userId}
@@ -80,19 +80,17 @@ export function ATeamMemberMenu(props) {
           />
         </DialogContent>
       </Dialog>
-      <Dialog fullWidth open={openRemove}>
-        <DialogContent>
-          <ATeamMemberRemoveModal
-            userId={userId}
-            userName={userEmail}
-            ateamId={ateamId}
-            ateamName={ateam.ateam_name}
-            onClose={() => {
-              if (userId === userMe.user_id) dispatch(getUser()); // update user.ateams
-              setOpenRemove(false);
-            }}
-          />
-        </DialogContent>
+      <Dialog fullWidth open={openRemove} onClose={() => setOpenRemove(false)}>
+        <ATeamMemberRemoveModal
+          userId={userId}
+          userName={userEmail}
+          ateamId={ateamId}
+          ateamName={ateam.ateam_name}
+          onClose={() => {
+            if (userId === userMe.user_id) dispatch(getUser()); // update user.ateams
+            setOpenRemove(false);
+          }}
+        />
       </Dialog>
     </>
   );

--- a/web/src/components/ATeamMemberRemoveModal.jsx
+++ b/web/src/components/ATeamMemberRemoveModal.jsx
@@ -1,12 +1,21 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getATeamAuth, getATeamMembers } from "../slices/ateam";
 import { deleteATeamMember } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamMemberRemoveModal(props) {
   const { userId, userName, ateamId, ateamName, onClose } = props;
@@ -34,33 +43,37 @@ export function ATeamMemberRemoveModal(props) {
 
   return (
     <>
-      <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
-        <Typography>Are you sure you want to remove </Typography>
-        <Typography
-          variant="h6"
-          noWrap
-          sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
-        >
-          {userName}
-        </Typography>
-        <Typography>from the ateam </Typography>
-        <Typography noWrap sx={{ fontWeight: "bold", ml: 1 }}>
-          {ateamName}
-        </Typography>
-        <Typography>?</Typography>
-      </Box>
-      <Box display="flex">
-        <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            Cancel
-          </Button>
-        )}
-        <Button onClick={handleRemove} sx={{ ...modalCommonButtonStyle, ml: 1 }}>
+      <DialogTitle>
+        <Box display="flex" flexDirection="row">
+          <Typography className={dialogStyle.dialog_title}>Confirm</Typography>
+          <Box flexGrow={1} />
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box display="flex" flexWrap="wrap" alignItems="baseline">
+          <Typography>Are you sure you want to remove </Typography>
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
+          >
+            {userName}
+          </Typography>
+          <Typography>from the ateam </Typography>
+          <Typography noWrap sx={{ fontWeight: "bold", ml: 1 }}>
+            {ateamName}
+          </Typography>
+          <Typography>?</Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions className={dialogStyle.action_area}>
+        <Button onClick={handleRemove} className={dialogStyle.delete_btn}>
           Remove
         </Button>
-      </Box>
+      </DialogActions>
     </>
   );
 }

--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -7,7 +7,6 @@ import {
 import {
   Box,
   Button,
-  Divider,
   FormControl,
   FormControlLabel,
   IconButton,
@@ -256,7 +255,6 @@ export function ATeamNotificationSetting(props) {
           label="Slack"
         />
       </Box>
-      <Divider />
       <Box display="flex" mt={2}>
         <Box flexGrow={1} />
         <Button onClick={() => handleUpdateATeam()} sx={{ ...modalCommonButtonStyle, ml: 1 }}>

--- a/web/src/components/ATeamRequestModal.jsx
+++ b/web/src/components/ATeamRequestModal.jsx
@@ -1,4 +1,4 @@
-import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import { Close as CloseIcon, ContentCopy as ContentCopyIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -22,8 +22,8 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import styles from "../cssModule/button.module.css";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { createATeamWatchingRequest } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamRequestModal(props) {
   const { text } = props;
@@ -78,9 +78,17 @@ export function ATeamRequestModal(props) {
       <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
-      <Dialog open={open} fullWidth>
+      <Dialog open={open} onClose={handleClose} fullWidth>
         <DialogTitle>
-          <Typography variant="inherit">Create New Watching Request</Typography>
+          <Box display="flex" flexDirection="row">
+            <Typography className={dialogStyle.dialog_title}>
+              Create New Watching Request
+            </Typography>
+            <Box flexGrow={1} />
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </DialogTitle>
         <DialogContent>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -133,15 +141,12 @@ export function ATeamRequestModal(props) {
             )}
           </LocalizationProvider>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} sx={modalCommonButtonStyle}>
-            {requestLink ? "Close" : "Cancel"}
-          </Button>
+        <DialogActions className={dialogStyle.action_area}>
           {!requestLink && (
             <Button
               onClick={handleCreate}
               disabled={!isBefore(now, expiration)}
-              sx={modalCommonButtonStyle}
+              className={dialogStyle.submit_btn}
             >
               Create
             </Button>

--- a/web/src/components/ATeamSettingsModal.jsx
+++ b/web/src/components/ATeamSettingsModal.jsx
@@ -9,11 +9,11 @@ import {
   Tabs,
   Typography,
 } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import { TabPanel } from "../components/TabPanel";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { a11yProps } from "../utils/func.js";
 
 import { ATeamAuthEditor } from "./ATeamAuthEditor";
@@ -29,13 +29,13 @@ export function ATeamSettingsModal(props) {
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
   return (
-    <Dialog fullWidth onClose={handleClose} open={show} maxWidth="md">
+    <Dialog open={show} onClose={handleClose} fullWidth maxWidth="md">
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             ATeam settings
           </Typography>
-          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Box>

--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -19,17 +19,18 @@ import {
   Typography,
   List,
 } from "@mui/material";
-import { blue, grey, red, green } from "@mui/material/colors";
+import { blue, red, green } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import uuid from "react-native-uuid";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getATeamTopics } from "../slices/ateam";
 import { getTopic } from "../slices/topics";
 import { createTopic } from "../utils/api";
-import { actionTypes, modalCommonButtonStyle } from "../utils/const";
+import { actionTypes } from "../utils/const";
 import { pickMismatchedTopicActionTags, validateNotEmpty, validateUUID } from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
@@ -203,10 +204,10 @@ export function ATeamTopicCreateModal(props) {
       >
         <DialogTitle>
           <Box alignItems="center" display="flex" flexDirection="row">
-            <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
               Create Topic
             </Typography>
-            <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+            <IconButton onClick={handleClose}>
               <CloseIcon />
             </IconButton>
           </Box>
@@ -366,7 +367,7 @@ export function ATeamTopicCreateModal(props) {
                 color="inherit"
                 disabled={activeStep === 0}
                 onClick={handleBack}
-                sx={{ mr: 1, textTransform: "none" }}
+                className={dialogStyle.submit_btn}
               >
                 Back
               </Button>
@@ -375,12 +376,12 @@ export function ATeamTopicCreateModal(props) {
                 <Button
                   onClick={handleCreateTopic}
                   disabled={!validateTopicParams()}
-                  sx={modalCommonButtonStyle}
+                  className={dialogStyle.submit_btn}
                 >
                   Create
                 </Button>
               ) : (
-                <Button onClick={handleNext} sx={modalCommonButtonStyle}>
+                <Button onClick={handleNext} className={dialogStyle.submit_btn}>
                   Next
                 </Button>
               )}

--- a/web/src/components/ATeamWatchingMenu.jsx
+++ b/web/src/components/ATeamWatchingMenu.jsx
@@ -1,5 +1,5 @@
 import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
-import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
+import { Button, Dialog, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
@@ -55,19 +55,22 @@ export function ATeamWatchingMenu(props) {
       ) : (
         <></>
       )}
-      <Dialog open={openRemove}>
-        <DialogContent>
-          <ATeamWatchingStop
-            watchingPteamId={watchingPteamId}
-            watchingPteamName={watchingPteamName}
-            ateamId={ateam.ateam_id}
-            ateamName={ateam.ateam_name}
-            onClose={() => {
-              dispatch(getATeam(ateam.ateam_id)); // update ateam.pteams
-              setOpenRemove(false);
-            }}
-          />
-        </DialogContent>
+      <Dialog
+        open={openRemove}
+        onClose={() => {
+          setOpenRemove(false);
+        }}
+      >
+        <ATeamWatchingStop
+          watchingPteamId={watchingPteamId}
+          watchingPteamName={watchingPteamName}
+          ateamId={ateam.ateam_id}
+          ateamName={ateam.ateam_name}
+          onClose={() => {
+            dispatch(getATeam(ateam.ateam_id)); // update ateam.pteams
+            setOpenRemove(false);
+          }}
+        />
       </Dialog>
     </>
   );

--- a/web/src/components/ATeamWatchingStop.jsx
+++ b/web/src/components/ATeamWatchingStop.jsx
@@ -1,12 +1,21 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getATeam } from "../slices/ateam";
 import { removeWatchingPTeam } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function ATeamWatchingStop(props) {
   const { watchingPteamId, watchingPteamName, ateamId, onClose } = props;
@@ -35,29 +44,39 @@ export function ATeamWatchingStop(props) {
 
   return (
     <>
-      <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
-        <Typography>Are you sure you want to stop watching </Typography>
-        <Typography
-          variant="h6"
-          noWrap
-          sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
-        >
-          {watchingPteamName}
-        </Typography>
-        <Typography>?</Typography>
-      </Box>
-      <Box display="flex">
-        <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            Cancel
+      <DialogTitle>
+        <Box alignItems="center" display="flex" flexDirection="row">
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+            Confirm
+          </Typography>
+          {onClose && (
+            <IconButton onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
+          <Typography>Are you sure you want to stop watching </Typography>
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
+          >
+            {watchingPteamName}
+          </Typography>
+          <Typography>?</Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions className={dialogStyle.action_area}>
+        <Box display="flex">
+          <Box flexGrow={1} />
+          <Button onClick={handleRemove} className={dialogStyle.delete_btn}>
+            Stop
           </Button>
-        )}
-        <Button onClick={handleRemove} sx={{ ...modalCommonButtonStyle, ml: 1 }}>
-          Stop
-        </Button>
-      </Box>
+        </Box>
+      </DialogActions>
     </>
   );
 }

--- a/web/src/components/ActionGenerator.jsx
+++ b/web/src/components/ActionGenerator.jsx
@@ -1,7 +1,9 @@
+import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
   Checkbox,
+  IconButton,
   List,
   ListItem,
   ListItemButton,
@@ -15,7 +17,8 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
-import { actionTypes, modalCommonButtonStyle } from "../utils/const";
+import dialogStyle from "../cssModule/dialog.module.css";
+import { actionTypes } from "../utils/const";
 
 export function ActionGenerator(props) {
   const { text, tagIds, action, onGenerate, onEdit, onCancel } = props;
@@ -49,9 +52,9 @@ export function ActionGenerator(props) {
   );
 
   const cancelButton = onCancel ? (
-    <Button onClick={onCancel} sx={{ ...modalCommonButtonStyle }}>
-      Cancel
-    </Button>
+    <IconButton onClick={() => onCancel()}>
+      <CloseIcon />
+    </IconButton>
   ) : (
     <></>
   );
@@ -291,7 +294,13 @@ export function ActionGenerator(props) {
   return (
     <>
       <Box display="flex" flexDirection="column" flexGrow={1}>
-        <Typography variant="h6">{onEdit ? "Edit action" : "Create action"}</Typography>
+        <Box display="flex" flexDirection="row">
+          <Typography className={dialogStyle.dialog_title}>
+            {onEdit ? "Edit action" : "Create action"}
+          </Typography>
+          <Box flexGrow={1} />
+          {cancelButton}
+        </Box>
         {actionDescriptionEditor}
         <Typography sx={{ mt: 2 }}>
           {"Select artifact tags to which this action should be applied."}
@@ -299,7 +308,6 @@ export function ActionGenerator(props) {
         {tagsEditor}
         <Box display="flex" flexDirection="row" sx={{ mt: 1 }}>
           <Box flexGrow={1} />
-          {cancelButton}
           <Button
             disabled={buttonDisabled()}
             onClick={() => {
@@ -321,7 +329,7 @@ export function ActionGenerator(props) {
                 });
               }
             }}
-            sx={{ ...modalCommonButtonStyle, ml: 1 }}
+            className={dialogStyle.submit_btn}
           >
             {text}
           </Button>

--- a/web/src/components/AnalysisActionGenerator.jsx
+++ b/web/src/components/AnalysisActionGenerator.jsx
@@ -1,7 +1,12 @@
+import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
   Checkbox,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
   List,
   ListItem,
   ListItemButton,
@@ -15,7 +20,8 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
-import { actionTypes, modalCommonButtonStyle } from "../utils/const";
+import dialogStyle from "../cssModule/dialog.module.css";
+import { actionTypes } from "../utils/const";
 
 export function AnalysisActionGenerator(props) {
   const { text, tagIds, action, onGenerate, onEdit, onCancel } = props;
@@ -48,9 +54,9 @@ export function AnalysisActionGenerator(props) {
   );
 
   const cancelButton = onCancel ? (
-    <Button onClick={onCancel} sx={{ ...modalCommonButtonStyle }}>
-      Cancel
-    </Button>
+    <IconButton onClick={onCancel}>
+      <CloseIcon />
+    </IconButton>
   ) : (
     <></>
   );
@@ -285,8 +291,15 @@ export function AnalysisActionGenerator(props) {
 
   return (
     <>
-      <Box display="flex" flexDirection="column" flexGrow={1}>
-        <Typography variant="h6">{onEdit ? "Edit action" : "Create action"}</Typography>
+      <DialogTitle>
+        <Box alignItems="center" display="flex" flexDirection="row">
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+            {onEdit ? "Edit action" : "Create action"}
+          </Typography>
+          {cancelButton}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
         {actionDescriptionEditor}
         <Typography sx={{ mt: 2 }}>
           {"Select artifact tags to which this action should be applied."}
@@ -297,9 +310,10 @@ export function AnalysisActionGenerator(props) {
             PTeams which this action reaches
           </Typography>
         </Box>
+      </DialogContent>
+      <DialogActions className={dialogStyle.action_area}>
         <Box display="flex" flexDirection="row" sx={{ mt: 1 }}>
           <Box flexGrow={1} />
-          {cancelButton}
           <Button
             disabled={buttonDisabled()}
             onClick={() => {
@@ -321,12 +335,12 @@ export function AnalysisActionGenerator(props) {
                 });
               }
             }}
-            sx={{ ...modalCommonButtonStyle, ml: 1 }}
+            className={dialogStyle.submit_btn}
           >
             {text}
           </Button>
         </Box>
-      </Box>
+      </DialogActions>
     </>
   );
 }

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -10,13 +10,13 @@ import {
   IconButton,
   Typography,
 } from "@mui/material";
-import { grey, red } from "@mui/material/colors";
+import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { deleteATeamTopicComment as apiDeleteATeamTopicComment } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
 
 export function CommentDeleteModal(props) {
@@ -37,13 +37,13 @@ export function CommentDeleteModal(props) {
   };
 
   return (
-    <Dialog fullWidth onClose={onClose} open={Boolean(comment?.comment_id)}>
+    <Dialog open={Boolean(comment?.comment_id)} onClose={onClose} fullWidth>
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             Confirm
           </Typography>
-          <IconButton onClick={onClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={onClose}>
             <CloseIcon />
           </IconButton>
         </Box>
@@ -68,19 +68,8 @@ export function CommentDeleteModal(props) {
           </Typography>
         </Box>
       </DialogContent>
-      <DialogActions>
-        <Button color="primary" onClick={onClose} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
-          Cancel
-        </Button>
-        <Button
-          onClick={handleAction}
-          sx={{
-            ...modalCommonButtonStyle,
-            color: red[700],
-            ml: 1,
-            mt: 1,
-          }}
-        >
+      <DialogActions className={dialogStyle.action_area}>
+        <Button onClick={handleAction} className={dialogStyle.delete_btn}>
           Delete
         </Button>
       </DialogActions>

--- a/web/src/components/PTeamAuthEditor.jsx
+++ b/web/src/components/PTeamAuthEditor.jsx
@@ -2,11 +2,12 @@ import {
   CheckBox as CheckedIcon,
   CheckBoxOutlineBlank as UnCheckedIcon,
   CheckBoxOutlined as CheckedOutlinedIcon,
+  Close as CloseIcon,
 } from "@mui/icons-material";
 import {
   Box,
   Button,
-  Divider,
+  IconButton,
   Table,
   TableBody,
   TableCell,
@@ -20,9 +21,9 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getPTeamAuth, getPTeamAuthInfo } from "../slices/pteam";
 import { updatePTeamAuth } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function PTeamAuthEditor(props) {
   const { userId, userEmail, onClose } = props;
@@ -203,8 +204,17 @@ export function PTeamAuthEditor(props) {
 
   return userMe && newAuth.user && authInfo && authorities && pteamAuth ? (
     <>
-      <Typography variant="h5">Authority: {pseudoEdit ? "member & others" : userEmail}</Typography>
-      <Divider sx={{ my: 1 }} />
+      <Box display="flex" flexDirection="row">
+        <Typography className={dialogStyle.dialog_title}>
+          Authority: {pseudoEdit ? "member & others" : userEmail}
+        </Typography>
+        <Box flexGrow={1} />
+        {onClose && (
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        )}
+      </Box>
       <TableContainer>
         <Table sx={{ minWidth: 650 }}>
           <TableHead>
@@ -223,22 +233,13 @@ export function PTeamAuthEditor(props) {
       </TableContainer>
       <Box display="flex" mt={2}>
         {editable && userId && (
-          <Button onClick={switchPseudoEdit} sx={modalCommonButtonStyle}>
+          <Button onClick={switchPseudoEdit} className={dialogStyle.submit_btn}>
             {pseudoEdit ? `Edit ${userEmail}` : "Edit Pseudo"}
           </Button>
         )}
         <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            {editable && updated() ? "Cancel" : "Close"}
-          </Button>
-        )}
         {editable && (
-          <Button
-            onClick={handleSave}
-            disabled={!updated()}
-            sx={{ ...modalCommonButtonStyle, ml: 1 }}
-          >
+          <Button onClick={handleSave} disabled={!updated()} className={dialogStyle.submit_btn}>
             Update
           </Button>
         )}

--- a/web/src/components/PTeamCreateModal.jsx
+++ b/web/src/components/PTeamCreateModal.jsx
@@ -16,9 +16,9 @@ import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getUser } from "../slices/user";
 import { createPTeam } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function PTeamCreateModal(props) {
   const { open, onSetOpen, onCloseTeamSelector } = props;
@@ -68,7 +68,7 @@ export function PTeamCreateModal(props) {
       <Dialog fullWidth open={open} onClose={() => onSetOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
-            <Typography variant="h5">Create PTeam</Typography>
+            <Typography className={dialogStyle.dialog_title}>Create PTeam</Typography>
             <Box flexGrow={1} />
             <IconButton onClick={() => onSetOpen(false)}>
               <CloseIcon />
@@ -96,8 +96,8 @@ export function PTeamCreateModal(props) {
             ></TextField>
           </Box>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleCreate} disabled={!pteamName} sx={modalCommonButtonStyle}>
+        <DialogActions className={dialogStyle.action_area}>
+          <Button onClick={handleCreate} disabled={!pteamName} className={dialogStyle.submit_btn}>
             Create
           </Button>
         </DialogActions>

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -10,7 +10,6 @@ import {
   DialogContent,
   DialogTitle,
   DialogActions,
-  Divider,
   IconButton,
   List,
   Switch,
@@ -22,6 +21,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
@@ -30,7 +30,7 @@ import {
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import { updateTopic, createAction, updateAction, deleteAction } from "../utils/api";
-import { actionTypes, modalCommonButtonStyle } from "../utils/const";
+import { actionTypes } from "../utils/const";
 import { parseVulnerableVersions, versionMatch } from "../utils/versions";
 
 import { ActionGenerator } from "./ActionGenerator";
@@ -258,18 +258,17 @@ export function PTeamEditAction(props) {
 
   return (
     <>
-      <Dialog open={open === true} fullWidth>
+      <Dialog open={open === true} onClose={handleClose} fullWidth>
         <DialogTitle>
           <Box alignItems="center" display="flex" flexDirection="row">
-            <Typography flexGrow={1} variant="inherit">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
               Edit actions on this topic
             </Typography>
-            <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+            <IconButton onClick={handleClose}>
               <CloseIcon />
             </IconButton>
           </Box>
         </DialogTitle>
-        <Divider />
         <DialogContent>
           <>
             <Box flexDirection="row">
@@ -304,7 +303,7 @@ export function PTeamEditAction(props) {
                       width: "100%",
                       position: "relative",
                       overflow: "auto",
-                      maxHeight: 150,
+                      maxHeight: 200,
                     }}
                   >
                     {topicActions &&
@@ -341,12 +340,12 @@ export function PTeamEditAction(props) {
             </Box>
           </>
         </DialogContent>
-        <DialogActions>
-          <Box sx={{ display: "flex", flexDirection: "row", pt: 2 }}>
+        <DialogActions className={dialogStyle.action_area}>
+          <Box sx={{ display: "flex", flexDirection: "row" }}>
             <Button
               onClick={handleUpdateTopic}
               disabled={errors?.length > 0}
-              sx={modalCommonButtonStyle}
+              className={dialogStyle.submit_btn}
             >
               Update
             </Button>

--- a/web/src/components/PTeamInviteModal.jsx
+++ b/web/src/components/PTeamInviteModal.jsx
@@ -1,3 +1,4 @@
+import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -6,6 +7,7 @@ import {
   DialogContent,
   DialogTitle,
   Grid,
+  IconButton,
   Link,
   Slider,
   TextField,
@@ -20,8 +22,8 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import styles from "../cssModule/button.module.css";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { createPTeamInvitation } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 import { CopiedIcon } from "./CopiedIcon";
 
@@ -77,9 +79,15 @@ export function PTeamInviteModal(props) {
       <Button className={styles.prominent_btn} onClick={handleOpen}>
         {text}
       </Button>
-      <Dialog open={open} fullWidth>
+      <Dialog open={open} onClose={handleClose} fullWidth>
         <DialogTitle>
-          <Typography variant="inherit">Create New Invitation Link</Typography>
+          <Box display="flex" flexDirection="row">
+            <Typography className={dialogStyle.dialog_title}>Create New Invitation Link</Typography>
+            <Box flexGrow={1} />
+            <IconButton onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
         </DialogTitle>
         <DialogContent>
           <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -131,15 +139,12 @@ export function PTeamInviteModal(props) {
             )}
           </LocalizationProvider>
         </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose} sx={modalCommonButtonStyle}>
-            {invitationLink ? "Close" : "Cancel"}
-          </Button>
+        <DialogActions className={dialogStyle.action_area}>
           {!invitationLink && (
             <Button
               onClick={handleCreate}
               disabled={!isBefore(now, expiration)}
-              sx={modalCommonButtonStyle}
+              className={dialogStyle.submit_btn}
             >
               Create
             </Button>

--- a/web/src/components/PTeamMemberMenu.jsx
+++ b/web/src/components/PTeamMemberMenu.jsx
@@ -71,7 +71,7 @@ export function PTeamMemberMenu(props) {
           </MenuItem>
         )}
       </Menu>
-      <Dialog open={openAuth}>
+      <Dialog open={openAuth} onClose={() => setOpenAuth(false)}>
         <DialogContent>
           <PTeamAuthEditor
             userId={userId}
@@ -80,19 +80,17 @@ export function PTeamMemberMenu(props) {
           />
         </DialogContent>
       </Dialog>
-      <Dialog open={openRemove}>
-        <DialogContent>
-          <PTeamMemberRemoveModal
-            userId={userId}
-            userName={userEmail}
-            pteamId={pteamId}
-            pteamName={pteam.pteam_name}
-            onClose={() => {
-              if (userId === userMe.user_id) dispatch(getUser()); // update user.pteam_ids
-              setOpenRemove(false);
-            }}
-          />
-        </DialogContent>
+      <Dialog open={openRemove} onClose={() => setOpenRemove(false)}>
+        <PTeamMemberRemoveModal
+          userId={userId}
+          userName={userEmail}
+          pteamId={pteamId}
+          pteamName={pteam.pteam_name}
+          onClose={() => {
+            if (userId === userMe.user_id) dispatch(getUser()); // update user.pteam_ids
+            setOpenRemove(false);
+          }}
+        />
       </Dialog>
     </>
   );

--- a/web/src/components/PTeamMemberRemoveModal.jsx
+++ b/web/src/components/PTeamMemberRemoveModal.jsx
@@ -1,12 +1,21 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getPTeamAuth, getPTeamMembers } from "../slices/pteam";
 import { deletePTeamMember } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function PTeamMemberRemoveModal(props) {
   const { userId, userName, pteamId, pteamName, onClose } = props;
@@ -34,33 +43,37 @@ export function PTeamMemberRemoveModal(props) {
 
   return (
     <>
-      <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
-        <Typography>Are you sure you want to remove </Typography>
-        <Typography
-          variant="h6"
-          noWrap
-          sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
-        >
-          {userName}
-        </Typography>
-        <Typography>from the pteam </Typography>
-        <Typography noWrap sx={{ fontWeight: "bold", ml: 1 }}>
-          {pteamName}
-        </Typography>
-        <Typography>?</Typography>
-      </Box>
-      <Box display="flex">
-        <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            Cancel
-          </Button>
-        )}
-        <Button onClick={handleRemove} sx={{ ...modalCommonButtonStyle, ml: 1 }}>
+      <DialogTitle>
+        <Box display="flex" flexDirection="row">
+          <Typography className={dialogStyle.dialog_title}>Confirm</Typography>
+          <Box flexGrow={1} />
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
+          <Typography>Are you sure you want to remove </Typography>
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
+          >
+            {userName}
+          </Typography>
+          <Typography>from the pteam </Typography>
+          <Typography noWrap sx={{ fontWeight: "bold", ml: 1 }}>
+            {pteamName}
+          </Typography>
+          <Typography>?</Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions className={dialogStyle.action_area}>
+        <Button onClick={handleRemove} className={dialogStyle.delete_btn}>
           Remove
         </Button>
-      </Box>
+      </DialogActions>
     </>
   );
 }

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -15,6 +15,7 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TabPanel } from "../components/TabPanel";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getPTeamGroups, getPTeamTagsSummary } from "../slices/pteam";
 import { a11yProps } from "../utils/func.js";
 
@@ -42,10 +43,10 @@ export function PTeamSettingsModal(props) {
   };
 
   return (
-    <Dialog fullWidth onClose={handleClose} open={show} maxWidth="md">
+    <Dialog open={show} onClose={handleClose} fullWidth maxWidth="md">
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             PTeam settings
           </Typography>
           <IconButton onClick={handleClose} sx={{ color: grey[500] }}>

--- a/web/src/components/PTeamTagSettingsModal.jsx
+++ b/web/src/components/PTeamTagSettingsModal.jsx
@@ -1,8 +1,9 @@
 import { Close as CloseIcon } from "@mui/icons-material";
 import { Box, Dialog, DialogContent, DialogTitle, IconButton, Typography } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React from "react";
+
+import dialogStyle from "../cssModule/dialog.module.css";
 
 import { PTeamTagAutoClose } from "./PTeamTagAutoClose";
 
@@ -12,13 +13,13 @@ export function PTeamTagSettingsModal(props) {
   const handleClose = () => onSetShow(false);
 
   return (
-    <Dialog fullWidth onClose={handleClose} open={show}>
+    <Dialog open={show} onClose={handleClose} fullWidth>
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             Auto Close
           </Typography>
-          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Box>

--- a/web/src/components/PTeamWatcherMenu.jsx
+++ b/web/src/components/PTeamWatcherMenu.jsx
@@ -1,5 +1,5 @@
 import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui/icons-material";
-import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
+import { Button, Dialog, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch } from "react-redux";
@@ -55,19 +55,22 @@ export function PTeamWatcherMenu(props) {
       ) : (
         <></>
       )}
-      <Dialog open={openRemove}>
-        <DialogContent>
-          <PTeamWatcherRemoveModal
-            watcherAteamId={watcherAteamId}
-            watcherAteamName={watcherAteamName}
-            pteamId={pteam.pteam_id}
-            pteamName={pteam.pteam_name}
-            onClose={() => {
-              dispatch(getPTeam(pteam.pteam_id)); // update pteam.pteams
-              setOpenRemove(false);
-            }}
-          />
-        </DialogContent>
+      <Dialog
+        open={openRemove}
+        onClose={() => {
+          setOpenRemove(false);
+        }}
+      >
+        <PTeamWatcherRemoveModal
+          watcherAteamId={watcherAteamId}
+          watcherAteamName={watcherAteamName}
+          pteamId={pteam.pteam_id}
+          pteamName={pteam.pteam_name}
+          onClose={() => {
+            dispatch(getPTeam(pteam.pteam_id)); // update pteam.pteams
+            setOpenRemove(false);
+          }}
+        />
       </Dialog>
     </>
   );

--- a/web/src/components/PTeamWatcherRemoveModal.jsx
+++ b/web/src/components/PTeamWatcherRemoveModal.jsx
@@ -1,12 +1,21 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 import { useDispatch } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getPTeam } from "../slices/pteam";
 import { removeWatcherATeam } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 export function PTeamWatcherRemoveModal(props) {
   const { watcherAteamId, watcherAteamName, pteamId, onClose } = props;
@@ -35,29 +44,35 @@ export function PTeamWatcherRemoveModal(props) {
 
   return (
     <>
-      <Typography variant="h5">Confirm</Typography>
-      <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
-        <Typography>Are you sure you want to remove watcher </Typography>
-        <Typography
-          variant="h6"
-          noWrap
-          sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
-        >
-          {watcherAteamName}
-        </Typography>
-        <Typography>?</Typography>
-      </Box>
-      <Box display="flex">
-        <Box flexGrow={1} />
-        {onClose && (
-          <Button onClick={onClose} sx={modalCommonButtonStyle}>
-            Cancel
-          </Button>
-        )}
-        <Button onClick={handleRemove} sx={{ ...modalCommonButtonStyle, ml: 1 }}>
+      <DialogTitle>
+        <Box display="flex" flexDirection="row">
+          <Typography className={dialogStyle.dialog_title}>Confirm</Typography>
+          <Box flexGrow={1} />
+          {onClose && (
+            <IconButton onClick={onClose}>
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box display="flex" alignItems="baseline" sx={{ my: 2 }}>
+          <Typography>Are you sure you want to remove watcher </Typography>
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{ fontWeight: "bold", textDecoration: "underline", mx: 1 }}
+          >
+            {watcherAteamName}
+          </Typography>
+          <Typography>?</Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions className={dialogStyle.action_area}>
+        <Button onClick={handleRemove} className={dialogStyle.delete_btn}>
           Remove
         </Button>
-      </Box>
+      </DialogActions>
     </>
   );
 }

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -3,10 +3,8 @@ import {
   Box,
   Button,
   Dialog,
-  DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
   IconButton,
   TextField,
   Typography,
@@ -19,6 +17,7 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
@@ -26,7 +25,6 @@ import {
   getPTeamUnsolvedTaggedTopicIds,
 } from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 
 import { ActionTypeChip } from "./ActionTypeChip";
 import { ActionTypeIcon } from "./ActionTypeIcon";
@@ -121,25 +119,24 @@ export function ReportCompletedActions(props) {
   };
 
   return (
-    <Dialog fullWidth onClose={handleClose} open={show}>
+    <Dialog open={show} onClose={handleClose} fullWidth>
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
           {activeStep === 0 && (
-            <Typography flexGrow={1} variant="inherit">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
               Select the actions you have completed
             </Typography>
           )}
           {activeStep === 1 && (
-            <Typography flexGrow={1} variant="inherit">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
               (Optional): Enter evidence of completion
             </Typography>
           )}
-          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Box>
       </DialogTitle>
-      <Divider />
       <DialogContent>
         {activeStep === 0 && (
           <>
@@ -210,15 +207,13 @@ export function ReportCompletedActions(props) {
             />
           </>
         )}
-      </DialogContent>
-      <DialogActions>
         <Box sx={{ display: "flex", flexDirection: "row", pt: 2 }}>
-          <Box sx={{ flex: "1 1 auto" }} />
           {activeStep === 0 ? (
             <>
+              <Box sx={{ flex: "1 1 auto" }} />
               <Button
                 onClick={handleNext}
-                sx={modalCommonButtonStyle}
+                className={dialogStyle.submit_btn}
                 disabled={selectedAction.length === 0}
               >
                 {`Done ${selectedAction.length}`}
@@ -226,20 +221,22 @@ export function ReportCompletedActions(props) {
             </>
           ) : (
             <>
-              <Button onClick={handleBack} sx={modalCommonButtonStyle} disabled={activeStep === 0}>
+              <Button
+                onClick={handleBack}
+                className={dialogStyle.submit_btn}
+                disabled={activeStep === 0}
+                sx={{ ml: -2 }}
+              >
                 Back
               </Button>
-              <Button
-                color="success"
-                onClick={handleAction}
-                sx={{ textTransform: "none", fontWeight: "bold" }}
-              >
+              <Box sx={{ flex: "1 1 auto" }} />
+              <Button onClick={handleAction} className={dialogStyle.submit_btn}>
                 Submit
               </Button>
             </>
           )}
         </Box>
-      </DialogActions>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/web/src/components/SBOMDropArea.jsx
+++ b/web/src/components/SBOMDropArea.jsx
@@ -10,14 +10,13 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useRef, useState } from "react";
 
 import { WaitingModal } from "../components/WaitingModal";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { uploadSBOMFile } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 function PreUploadModal(props) {
@@ -37,10 +36,10 @@ function PreUploadModal(props) {
     <Dialog fullWidth open={open} onClose={handleClose}>
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit">
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             Upload SBOM File
           </Typography>
-          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Box>
@@ -62,10 +61,10 @@ function PreUploadModal(props) {
           </Box>
         </Box>
       </DialogContent>
-      <DialogActions>
-        <Box sx={{ display: "flex", flexDirection: "row", mr: 1, mb: 1 }}>
+      <DialogActions className={dialogStyle.action_area}>
+        <Box>
           <Box sx={{ flex: "1 1 auto" }} />
-          <Button onClick={handleUpload} disabled={!groupName} sx={modalCommonButtonStyle}>
+          <Button onClick={handleUpload} disabled={!groupName} className={dialogStyle.submit_btn}>
             Upload
           </Button>
         </Box>

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -1,13 +1,24 @@
-import { Button, Box, Dialog, DialogContent, Typography } from "@mui/material";
+import { Close as CloseIcon } from "@mui/icons-material";
+import {
+  Button,
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import { red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getPTeamTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
-import { commonButtonStyle, modalCommonButtonStyle } from "../utils/const";
+import { commonButtonStyle } from "../utils/const";
 
 export function TopicDeleteModal(props) {
   const { topicId, onSetOpenTopicModal, onDelete } = props;
@@ -54,30 +65,28 @@ export function TopicDeleteModal(props) {
         Delete Topic
       </Button>
       <Dialog hideBackdrop open={open} onClose={() => setOpen(false)}>
-        <>
-          <DialogContent>
-            <Typography variant="h5">Confirm</Typography>
-            <Typography>Are you sure you want to delete this topic?</Typography>
-            <Typography>This deletion affects other pteams.</Typography>
-            <Box display="flex">
-              <Box flexGrow={1} />
-              <Button onClick={() => setOpen(false)} sx={{ ...modalCommonButtonStyle, mt: 1 }}>
-                Cancel
-              </Button>
-              <Button
-                onClick={handleDelete}
-                sx={{
-                  ...modalCommonButtonStyle,
-                  color: red[700],
-                  ml: 1,
-                  mt: 1,
-                }}
-              >
-                Delete
-              </Button>
-            </Box>
-          </DialogContent>
-        </>
+        <DialogTitle>
+          <Box alignItems="center" display="flex" flexDirection="row">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+              Confirm
+            </Typography>
+            <IconButton onClick={() => setOpen(false)}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Typography>Are you sure you want to delete this topic?</Typography>
+          <Typography>This deletion affects other pteams.</Typography>
+        </DialogContent>
+        <DialogActions className={dialogStyle.action_area}>
+          <Box>
+            <Box sx={{ flex: "1 1 auto" }} />
+            <Button onClick={handleDelete} className={dialogStyle.delete_btn}>
+              Delete
+            </Button>
+          </Box>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/components/TopicEditModal.jsx
+++ b/web/src/components/TopicEditModal.jsx
@@ -23,16 +23,16 @@ import {
   ListItem,
   ListItemText,
 } from "@mui/material";
-import { blue, grey, green, red } from "@mui/material/colors";
+import { blue, green, red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { TabPanel } from "../components/TabPanel";
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getActions, getTopic } from "../slices/topics";
 import { createAction, deleteAction, updateAction, updateTopic } from "../utils/api";
-import { modalCommonButtonStyle } from "../utils/const";
 import { a11yProps, errorToString, setEquals, validateNotEmpty } from "../utils/func";
 
 import { ActionTypeIcon } from "./ActionTypeIcon";
@@ -206,17 +206,15 @@ export function TopicEditModal(props) {
           <AddBoxIcon />
         </IconButton>
         <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
-          <DialogContent>
-            <AnalysisActionGenerator
-              text="Add action"
-              tagIds={actionTagOptions}
-              onGenerate={(ret) => {
-                setActions([...actions, ret]);
-                setGeneratorOpen(false);
-              }}
-              onCancel={() => setGeneratorOpen(false)}
-            />
-          </DialogContent>
+          <AnalysisActionGenerator
+            text="Add action"
+            tagIds={actionTagOptions}
+            onGenerate={(ret) => {
+              setActions([...actions, ret]);
+              setGeneratorOpen(false);
+            }}
+            onCancel={() => setGeneratorOpen(false)}
+          />
         </Dialog>
       </>
     );
@@ -228,10 +226,10 @@ export function TopicEditModal(props) {
     <Dialog open={open === true} maxWidth="md" fullWidth sx={{ maxHeight: "100vh" }}>
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
-          <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+          <Typography flexGrow={1} className={dialogStyle.dialog_title}>
             Edit Topic
           </Typography>
-          <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+          <IconButton onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Box>
@@ -413,10 +411,14 @@ export function TopicEditModal(props) {
           </Box>
         </TabPanel>
       </DialogContent>
-      <DialogActions>
-        <Box sx={{ display: "flex", flexDirection: "row", mr: 1, mb: 1 }}>
+      <DialogActions className={dialogStyle.action_area}>
+        <Box sx={{ display: "flex", flexDirection: "row" }}>
           <Box sx={{ flex: "1 1 auto" }} />
-          <Button disabled={!readyForUpdate()} sx={modalCommonButtonStyle} onClick={handleUpdate}>
+          <Button
+            disabled={!readyForUpdate()}
+            onClick={handleUpdate}
+            className={dialogStyle.submit_btn}
+          >
             Update
           </Button>
         </Box>

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -26,6 +26,7 @@ import React, { useEffect, useState } from "react";
 import uuid from "react-native-uuid";
 import { useDispatch, useSelector } from "react-redux";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
@@ -41,7 +42,7 @@ import {
   updateAction,
   deleteAction,
 } from "../utils/api";
-import { actionTypes, modalCommonButtonStyle } from "../utils/const";
+import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID } from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
@@ -393,10 +394,10 @@ export function TopicModal(props) {
       >
         <DialogTitle>
           <Box alignItems="center" display="flex" flexDirection="row">
-            <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
               {presetTopicId ? "Edit Topic" : "Create Topic"}
             </Typography>
-            <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+            <IconButton onClick={handleClose}>
               <CloseIcon />
             </IconButton>
           </Box>
@@ -592,13 +593,13 @@ export function TopicModal(props) {
               <Button
                 disabled={activeStep === 0}
                 onClick={handleBackFlashsense}
-                sx={{ ...modalCommonButtonStyle, mr: 1 }}
+                className={dialogStyle.submit_btn}
               >
                 Back
               </Button>
               <Box sx={{ flex: "1 1 auto" }} />
               {isStepOptional(activeStep) && (
-                <Button onClick={handleSkipFlashsense} sx={{ ...modalCommonButtonStyle, mr: 1 }}>
+                <Button onClick={handleSkipFlashsense} className={dialogStyle.submit_btn}>
                   Skip
                 </Button>
               )}
@@ -610,7 +611,7 @@ export function TopicModal(props) {
                       : handleCreateTopic
                   }
                   disabled={errors?.length > 0}
-                  sx={modalCommonButtonStyle}
+                  className={dialogStyle.submit_btn}
                 >
                   {presetTopicId && topicId === presetTopicId ? "Update" : "Create"}
                 </Button>
@@ -618,7 +619,7 @@ export function TopicModal(props) {
                 <Button
                   onClick={handleFetchFlashsense}
                   disabled={!topicId}
-                  sx={modalCommonButtonStyle}
+                  className={dialogStyle.submit_btn}
                 >
                   Next
                 </Button>

--- a/web/src/components/TopicSearchModal.jsx
+++ b/web/src/components/TopicSearchModal.jsx
@@ -16,13 +16,14 @@ import {
   Select,
   MenuItem,
 } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import { styled } from "@mui/material/styles";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { addDays } from "date-fns";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
+
+import dialogStyle from "../cssModule/dialog.module.css";
 
 export function TopicSearchModal(props) {
   const { show, onSearch, onCancel } = props;
@@ -262,49 +263,42 @@ export function TopicSearchModal(props) {
   return (
     <>
       <Dialog onClose={handleCancel} open={show} PaperProps={{ sx: { width: 700 } }}>
-        <>
-          <DialogTitle>
-            <Box alignItems="center" display="flex" flexDirection="row" sx={{ mb: -3 }}>
-              <Typography flexGrow={1} variant="inherit" sx={{ fontWeight: 900 }}>
-                Topic Search
-              </Typography>
-              <IconButton onClick={handleCancel} sx={{ color: grey[500] }}>
-                <CloseIcon />
-              </IconButton>
+        <DialogTitle>
+          <Box alignItems="center" display="flex" flexDirection="row" sx={{ mb: -3 }}>
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+              Topic Search
+            </Typography>
+            <IconButton onClick={handleCancel}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Box display="flex" flexDirection="row-reverse" sx={{ marginTop: 0 }}>
+              <FormControlLabel
+                control={<Android12Switch checked={adModeChange} onChange={advancedChange} />}
+                label="Advanced Mode"
+              />
             </Box>
-          </DialogTitle>
-          <DialogContent>
-            <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <Box display="flex" flexDirection="row-reverse" sx={{ marginTop: 0 }}>
-                <FormControlLabel
-                  control={<Android12Switch checked={adModeChange} onChange={advancedChange} />}
-                  label="Advanced Mode"
-                />
+            {titleForm}
+            {mispForm}
+            {adModeChange && (
+              <Box>
+                {dateForm}
+                {uuidForm}
+                {creatorForm}
               </Box>
-              {titleForm}
-              {mispForm}
-              {adModeChange && (
-                <Box>
-                  {dateForm}
-                  {uuidForm}
-                  {creatorForm}
-                </Box>
-              )}
-            </LocalizationProvider>
-          </DialogContent>
-          <DialogActions>
-            <Box display="flex">
-              <Button
-                variant="contained"
-                color="success"
-                sx={{ margin: 1, textTransform: "none" }}
-                onClick={handleSearch}
-              >
-                Search
-              </Button>
-            </Box>
-          </DialogActions>
-        </>
+            )}
+          </LocalizationProvider>
+        </DialogContent>
+        <DialogActions className={dialogStyle.action_area}>
+          <Box display="flex">
+            <Button className={dialogStyle.submit_btn} onClick={handleSearch}>
+              Search
+            </Button>
+          </Box>
+        </DialogActions>
       </Dialog>
     </>
   );

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -1,4 +1,4 @@
-import { ArrowDropDown as ArrowDropDownIcon } from "@mui/icons-material";
+import { ArrowDropDown as ArrowDropDownIcon, Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -8,6 +8,7 @@ import {
   DialogTitle,
   ClickAwayListener,
   Grow,
+  IconButton,
   MenuItem,
   MenuList,
   Paper,
@@ -24,6 +25,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
@@ -31,7 +33,7 @@ import {
   getPTeamUnsolvedTaggedTopicIds,
 } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
-import { topicStatusProps, modalCommonButtonStyle } from "../utils/const";
+import { topicStatusProps } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
 
 export function TopicStatusSelector(props) {
@@ -182,37 +184,40 @@ export function TopicStatusSelector(props) {
             </Grow>
           )}
         </Popper>
-        <Dialog onClose={handleHideDatepicker} open={datepickerOpen} fullWidth>
+        <Dialog open={datepickerOpen} onClose={handleHideDatepicker} fullWidth>
           <DialogTitle>
-            <Box alignItems="center" display="flex" flexGrow={1}>
-              <Typography flexGrow={1} variant="inherit">
+            <Box alignItems="center" display="flex" flexDirection="row">
+              <Typography flexGrow={1} className={dialogStyle.dialog_title}>
                 Set schedule
               </Typography>
+              <IconButton onClick={handleHideDatepicker}>
+                <CloseIcon />
+              </IconButton>
             </Box>
           </DialogTitle>
           <DialogContent>
-            <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <DateTimePicker
-                inputFormat={dateFormat}
-                label="Schedule Date (future date)"
-                mask="____/__/__ __:__"
-                minDateTime={now}
-                value={schedule}
-                onChange={(newDate) => setSchedule(newDate)}
-                renderInput={(params) => (
-                  <TextField fullWidth margin="dense" required {...params} />
-                )}
-              />
-            </LocalizationProvider>
+            <Box sx={{ mt: 3 }}>
+              <LocalizationProvider dateAdapter={AdapterDateFns}>
+                <DateTimePicker
+                  inputFormat={dateFormat}
+                  label="Schedule Date (future date)"
+                  mask="____/__/__ __:__"
+                  minDateTime={now}
+                  value={schedule}
+                  onChange={(newDate) => setSchedule(newDate)}
+                  renderInput={(params) => (
+                    <TextField fullWidth margin="dense" required {...params} />
+                  )}
+                  sx={{ width: "100%" }}
+                />
+              </LocalizationProvider>
+            </Box>
           </DialogContent>
-          <DialogActions>
-            <Button onClick={handleHideDatepicker} sx={modalCommonButtonStyle}>
-              Cancel
-            </Button>
+          <DialogActions className={dialogStyle.action_area}>
             <Button
               onClick={handleUpdateSchedule}
               disabled={!isBefore(now, schedule)}
-              sx={modalCommonButtonStyle}
+              className={dialogStyle.submit_btn}
             >
               Schedule
             </Button>

--- a/web/src/components/TopicTagSelector.jsx
+++ b/web/src/components/TopicTagSelector.jsx
@@ -1,8 +1,13 @@
-import { Search as SearchIcon, Upload as UploadIcon } from "@mui/icons-material";
+import {
+  Close as CloseIcon,
+  Search as SearchIcon,
+  Upload as UploadIcon,
+} from "@mui/icons-material";
 import {
   Box,
   Button,
   Checkbox,
+  IconButton,
   ListItem,
   ListItemButton,
   ListItemIcon,
@@ -16,9 +21,10 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { FixedSizeList } from "react-window";
 
+import dialogStyle from "../cssModule/dialog.module.css";
 import { getTags } from "../slices/tags";
 import { createTag } from "../utils/api";
-import { modalCommonButtonStyle, commonButtonStyle } from "../utils/const";
+import { commonButtonStyle } from "../utils/const";
 
 export function TopicTagSelector(props) {
   const { currentSelectedIds, onCancel, onApply, sx } = props;
@@ -93,10 +99,16 @@ export function TopicTagSelector(props) {
   return (
     <Box sx={{ ...sx, display: "flex" }}>
       <Box display="flex" flexDirection="column">
-        <Typography fontWeight={900} mb={2}>
-          Select tags
-        </Typography>
-        <Box display="flex" flexDirection="row" alignItems="center">
+        <Box display="flex" flexDirection="row">
+          <Typography className={dialogStyle.dialog_title}>Select tags</Typography>
+          <Box flexGrow={1} />
+          {onCancel && (
+            <IconButton onClick={() => onCancel()}>
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
+        <Box display="flex" flexDirection="row" alignItems="center" sx={{ mt: 1 }}>
           <Box display="flex" flexGrow={1} />
           <SearchIcon sx={{ ml: 2 }} />
           <TextField
@@ -129,17 +141,12 @@ export function TopicTagSelector(props) {
         {(onApply || onCancel) && (
           <Box display="flex" flexDirection="row">
             <Box flexGrow={1} />
-            {onCancel && (
-              <Button onClick={() => onCancel()} sx={{ ...modalCommonButtonStyle, mr: 1 }}>
-                Cancel
-              </Button>
-            )}
             {onApply && (
               <Button
                 onClick={() => {
                   onApply(selectedIds);
                 }}
-                sx={{ ...modalCommonButtonStyle, mr: 1 }}
+                className={dialogStyle.submit_btn}
               >
                 Apply
               </Button>

--- a/web/src/cssModule/dialog.module.css
+++ b/web/src/cssModule/dialog.module.css
@@ -1,5 +1,4 @@
 .dialog_title.dialog_title {
-    color: red;
     font-size: 20px;
     margin-top: 5px;
 }

--- a/web/src/cssModule/dialog.module.css
+++ b/web/src/cssModule/dialog.module.css
@@ -1,0 +1,26 @@
+.dialog_title.dialog_title {
+    color: red;
+    font-size: 20px;
+    margin-top: 5px;
+}
+
+.submit_btn.submit_btn {
+    color: black;
+    text-transform: none;
+    &:disabled {
+        color: #c0c0c0;
+    }
+}
+
+.delete_btn.delete_btn {
+    color: red;
+    text-transform: none;
+    &:disabled {
+        color: #c0c0c0;
+    }
+}
+
+.action_area.action_area {
+    margin-right: 1%;
+    margin-bottom: 1%;
+}


### PR DESCRIPTION
## PR の目的

- 機能追加の場合
  - モーダルのデザインがバラバラだったものを統一し、共通するパーツについてはCSSを使用する

## 経緯・意図・意思決定
- 全てのモーダルの基本構成を<Dialog><DialogTitle><DialogContent>とし、使用できる場面においては<DialogActions>も使用する
- CSSに記載した共通パーツは以下の通り
　- タイトル
　- Submit系ボタン
　- Delete系ボタン
　- <DialogActions>の幅調整
- モーダル外クリックでモーダルが閉じるよう修正したが、Create/Edit Topicなど二重モーダルになる部分の親モーダルに関しては×押下で閉じるように してある。（いずれ二重モーダルは解消する）

