### PR TITLE
Improved test alert coverage

### DIFF
--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -142,7 +142,8 @@ def test_pick_alert_when_the_matching_tag_exists_when_the_topic_is_created(testd
     assert _find_expected(alert_targets, 10, parent_tag2)
     assert _find_expected(alert_targets, 10, child_tag21)  # matches multiple
 
-    # topic4: has parent_tag1 + parent_tag2 --> alerted to parent_tag1, child_tag1*, parent_tag2, child_tag2*
+    # topic4: has parent_tag1 + parent_tag2
+    #   --> alerted to parent_tag1, child_tag1*, parent_tag2, child_tag2*
     topic = create_topic(USER1, _gen_topic_params([parent_tag1, parent_tag2]))
     alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
     assert len(alert_targets) == 15
@@ -198,7 +199,7 @@ def test_pick_alert_when_the_matching_tag_exists_when_the_topic_is_created(testd
         (4, 4, True),
     ],
 )
-def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_threat_impact_of_a_pteam(
+def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_threat_impact_of_pteam(
     testdb, alert_threat_impact, threshold, expected
 ) -> None:
     create_user(USER1)

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -90,19 +90,18 @@ class TestPTeamHasParentTag:
         assert self.check_tag_in_alert_target(alert_targets, self.parent_tag1) == expected
 
     @pytest.mark.parametrize(
-        "child_tag, expected",
+        "child_tag",
         # parent_tag: Tags used when creating topics
-        # expected: Ture if an alert is received, False if not
         [
-            ("pkg1:info1:mgr1", False),
+            ("pkg1:info1:mgr1"),
         ],
     )
     def test_it_should_not_alert_when_topic_with_related_childtag_is_created(
-        self, testdb, child_tag, expected
+        self, testdb, child_tag
     ):
         topic = create_topic(USER1, self._gen_topic_params(child_tag))
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self.check_tag_in_alert_target(alert_targets, self.parent_tag1) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.parent_tag1) is False
 
 
 class TestPTeamHasChildTag:
@@ -300,13 +299,13 @@ class TestTopicHasVersion:
         return any(_tgt.tag.tag_name == tag.tag_name for _tgt in _targets)
 
     @pytest.mark.parametrize(
-        "vulnerable_versions, expected",
+        "vulnerable_versions",
         # vulnerable_versions: Vulnerable versions when creating topics
         # expected: Ture if an alert is received, False if not
-        [("< 1.0.0", False)],
+        [("< 1.0.0")],
     )
     def test_it_should_not_alert_when_version_of_topic_is_lower_than_version_registered_in_pteam(
-        self, testdb, vulnerable_versions, expected
+        self, testdb, vulnerable_versions
     ):
         ext_tags = {
             self.child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
@@ -325,7 +324,7 @@ class TestTopicHasVersion:
         # create topic and verification of alerts
         topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self.check_tag_in_alert_target(alert_targets, self.child_tag11) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag11) is False
 
     @pytest.mark.parametrize(
         "vulnerable_versions, expected",

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select
 
 from app import models, schemas
 from app.alert import (
@@ -30,149 +29,158 @@ from app.tests.medium.utils import (
 client = TestClient(app)
 
 
-def test_pick_alert_when_the_matching_tag_exists_when_the_topic_is_created(testdb) -> None:
-    create_user(USER1)
-    parent_tag1 = create_tag(USER1, "pkg1:info1:")
-    child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")
-    child_tag12 = create_tag(USER1, "pkg1:info1:mgr2")
-    parent_tag2 = create_tag(USER1, "pkg2:info1:")
-    child_tag21 = create_tag(USER1, "pkg2:info1:mgr1")
+class TestPTeamHasParentTag:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        # create pteam with parent_tag
+        create_user(USER1)
+        self.parent_tag1 = create_tag(USER1, "pkg1:info1:")
 
-    pteam_tags_patterns: List[List[schemas.TagResponse]] = [
-        [],  # 0
-        [parent_tag1],  # 1
-        [child_tag11],  # 2
-        [child_tag12],  # 3
-        [parent_tag2],  # 4
-        [child_tag21],  # 5
-        [parent_tag1, child_tag11],  # 6
-        [parent_tag1, parent_tag2],  # 7
-        [parent_tag1, child_tag21],  # 8
-        [parent_tag2, child_tag11],  # 9
-        [parent_tag2, child_tag21],  # 10
-        [parent_tag1],  # 11 (for disabled)
-    ]
+        def _gen_pteam_params() -> dict:
+            return {
+                "pteam_name": "pteam1",
+                "alert_slack": {
+                    "enable": True,
+                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+                },
+                "alert_mail": {
+                    "enable": True,
+                    "address": "account1@example.com",
+                },
+                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+            }
 
-    def _gen_pteam_params(idx: int) -> dict:
-        return {
-            "pteam_name": f"pteam{idx}",
-            "alert_slack": {
-                "enable": True,
-                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
-            },
-            "alert_mail": {
-                "enable": True,
-                "address": f"account{idx}@example.com",
-            },
-            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-        }
+        pteam = create_pteam(USER1, _gen_pteam_params())
+        ext_tags = {self.parent_tag1.tag_name: [("api/Pipfile.lock", "1.0.0")]}
+        upload_pteam_tags(USER1, pteam.pteam_id, GROUP1, ext_tags)
 
-    def _gen_topic_params(tags: List[schemas.TagResponse]) -> dict:
+    # common functions used in tests
+    def _gen_topic_params(self, tag: schemas.TagResponse) -> dict:
         topic_id = str(uuid4())
         return {
             "topic_id": topic_id,
             "title": "test topic " + topic_id,
             "abstract": "test abstract " + topic_id,
             "threat_impact": 1,
-            "tags": [tag.tag_name for tag in tags],
+            "tags": [tag],
             "misp_tags": [],
             "actions": [],
         }
 
+    # common functions used in tests
     def _find_expected(
+        self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
-        idx: int,
         tag: schemas.TagResponse,
     ) -> bool:
-        return any(
-            _tgt.pteam.pteam_name == f"pteam{idx}" and _tgt.tag.tag_name == tag.tag_name
-            for _tgt in _targets
-        )
+        return any(_tgt.tag.tag_name == tag.tag_name for _tgt in _targets)
 
-    pteams: List[schemas.PTeamInfo] = []
-    for idx in range(len(pteam_tags_patterns)):
-        pteams.append(create_pteam(USER1, _gen_pteam_params(idx)))
-        if pteam_tags := pteam_tags_patterns[idx]:
-            ext_tags = {tag.tag_name: [("api/Pipfile.lock", "1.0.0")] for tag in pteam_tags}
-            upload_pteam_tags(USER1, pteams[idx].pteam_id, GROUP1, ext_tags)
-    # disable pteams[11]
-    db_pteam11 = testdb.execute(
-        select(models.PTeam).where(models.PTeam.pteam_id == str(pteams[11].pteam_id))
-    ).one()[0]
-    db_pteam11.disabled = True
-    testdb.add(db_pteam11)
-    testdb.commit()
+    @pytest.mark.parametrize(
+        "parent_tag, expected",
+        # parent_tag: Tags used when creating topics
+        # expected: Ture if an alert is received, False if not
+        [
+            ("pkg1:info1:", True),
+        ],
+    )
+    def test_it_should_alert_when_topic_with_same_parenttag_is_created(
+        self, testdb, parent_tag, expected
+    ):
+        topic = create_topic(USER1, self._gen_topic_params(parent_tag))
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, self.parent_tag1) == expected
 
-    # topic0: no tags
-    topic = create_topic(USER1, _gen_topic_params([]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert alert_targets == []
+    @pytest.mark.parametrize(
+        "child_tag, expected",
+        # parent_tag: Tags used when creating topics
+        # expected: Ture if an alert is received, False if not
+        [
+            ("pkg1:info1:mgr1", False),
+        ],
+    )
+    def test_it_should_not_alert_when_topic_with_related_childtag_is_created(
+        self, testdb, child_tag, expected
+    ):
+        topic = create_topic(USER1, self._gen_topic_params(child_tag))
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, self.parent_tag1) == expected
 
-    # topic1: has parent_tag1  --> alerted to watching parent_tag1 or child_tag1*
-    topic = create_topic(USER1, _gen_topic_params([parent_tag1]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 8
-    assert _find_expected(alert_targets, 1, parent_tag1)
-    assert _find_expected(alert_targets, 2, child_tag11)
-    assert _find_expected(alert_targets, 3, child_tag12)
-    assert _find_expected(alert_targets, 6, parent_tag1)
-    assert _find_expected(alert_targets, 6, child_tag11)  # matches multiple
-    assert _find_expected(alert_targets, 7, parent_tag1)
-    assert _find_expected(alert_targets, 8, parent_tag1)
-    assert _find_expected(alert_targets, 9, child_tag11)
 
-    # topic2: has child_tag11  --> alerted to watching child_tag11
-    topic = create_topic(USER1, _gen_topic_params([child_tag11]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 3
-    assert _find_expected(alert_targets, 2, child_tag11)
-    assert _find_expected(alert_targets, 6, child_tag11)
-    assert _find_expected(alert_targets, 9, child_tag11)
+class TestPTeamHasChildTag:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        # create pteam with child_tag
+        create_user(USER1)
+        self.child_tag1 = create_tag(USER1, "pkg1:info1:mgr1")
 
-    # topic3: has child_tag12 + parent_tag2  --> alerted to child_tag12, parent_tag2, child_tag2*
-    topic = create_topic(USER1, _gen_topic_params([child_tag12, parent_tag2]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 8
-    assert _find_expected(alert_targets, 3, child_tag12)
-    assert _find_expected(alert_targets, 4, parent_tag2)
-    assert _find_expected(alert_targets, 5, child_tag21)
-    assert _find_expected(alert_targets, 7, parent_tag2)
-    assert _find_expected(alert_targets, 8, child_tag21)
-    assert _find_expected(alert_targets, 9, parent_tag2)
-    assert _find_expected(alert_targets, 10, parent_tag2)
-    assert _find_expected(alert_targets, 10, child_tag21)  # matches multiple
+        def _gen_pteam_params() -> dict:
+            return {
+                "pteam_name": "pteam1",
+                "alert_slack": {
+                    "enable": True,
+                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+                },
+                "alert_mail": {
+                    "enable": True,
+                    "address": "account1@example.com",
+                },
+                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+            }
 
-    # topic4: has parent_tag1 + parent_tag2
-    #   --> alerted to parent_tag1, child_tag1*, parent_tag2, child_tag2*
-    topic = create_topic(USER1, _gen_topic_params([parent_tag1, parent_tag2]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 15
-    assert _find_expected(alert_targets, 1, parent_tag1)
-    assert _find_expected(alert_targets, 2, child_tag11)
-    assert _find_expected(alert_targets, 3, child_tag12)
-    assert _find_expected(alert_targets, 4, parent_tag2)
-    assert _find_expected(alert_targets, 5, child_tag21)
-    assert _find_expected(alert_targets, 6, parent_tag1)
-    assert _find_expected(alert_targets, 6, child_tag11)
-    assert _find_expected(alert_targets, 7, parent_tag1)
-    assert _find_expected(alert_targets, 7, parent_tag2)
-    assert _find_expected(alert_targets, 8, parent_tag1)
-    assert _find_expected(alert_targets, 8, child_tag21)
-    assert _find_expected(alert_targets, 9, parent_tag2)
-    assert _find_expected(alert_targets, 9, child_tag11)
-    assert _find_expected(alert_targets, 10, parent_tag2)
-    assert _find_expected(alert_targets, 10, child_tag21)
+        pteam = create_pteam(USER1, _gen_pteam_params())
+        ext_tags = {self.child_tag1.tag_name: [("api/Pipfile.lock", "1.0.0")]}
+        upload_pteam_tags(USER1, pteam.pteam_id, GROUP1, ext_tags)
 
-    # topic5: has child_tag11 + child_tag21 --> alerted to child_tag11, child_tag21
-    topic = create_topic(USER1, _gen_topic_params([child_tag11, child_tag21]))
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 6
-    assert _find_expected(alert_targets, 2, child_tag11)
-    assert _find_expected(alert_targets, 5, child_tag21)
-    assert _find_expected(alert_targets, 6, child_tag11)
-    assert _find_expected(alert_targets, 8, child_tag21)
-    assert _find_expected(alert_targets, 9, child_tag11)
-    assert _find_expected(alert_targets, 10, child_tag21)
+    # common functions used in tests
+    def _gen_topic_params(self, tag: schemas.TagResponse) -> dict:
+        topic_id = str(uuid4())
+        return {
+            "topic_id": topic_id,
+            "title": "test topic " + topic_id,
+            "abstract": "test abstract " + topic_id,
+            "threat_impact": 1,
+            "tags": [tag],
+            "misp_tags": [],
+            "actions": [],
+        }
+
+    # common functions used in tests
+    def _find_expected(
+        self,
+        _targets: Sequence[models.CurrentPTeamTopicTagStatus],
+        tag: schemas.TagResponse,
+    ) -> bool:
+        return any(_tgt.tag.tag_name == tag.tag_name for _tgt in _targets)
+
+    @pytest.mark.parametrize(
+        "parent_tag, expected",
+        # parent_tag: Tags used when creating topics
+        # expected: Ture if an alert is received, False if not
+        [
+            ("pkg1:info1:", True),
+        ],
+    )
+    def test_it_should_alert_when_topic_with_related_parenttag_is_created(
+        self, testdb, parent_tag, expected
+    ):
+        topic = create_topic(USER1, self._gen_topic_params(parent_tag))
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, self.child_tag1) == expected
+
+    @pytest.mark.parametrize(
+        "child_tag, expected",
+        # parent_tag: Tags used when creating topics
+        # expected: Ture if an alert is received, False if not
+        [
+            ("pkg1:info1:mgr1", True),
+        ],
+    )
+    def test_it_should_alert_when_topic_with_asme_childtag_is_created(
+        self, testdb, child_tag, expected
+    ):
+        topic = create_topic(USER1, self._gen_topic_params(child_tag))
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, self.child_tag1) == expected
 
 
 @pytest.mark.parametrize(
@@ -249,32 +257,33 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
     assert _find_expected(alert_targets, child_tag11) == expected
 
 
-@pytest.mark.parametrize(
-    "vulnerable_versions, expected",
-    [("< 1.0.0", False), ("< 2.0.0", True)],
-)
-def test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag(
-    testdb, vulnerable_versions, expected
-) -> None:
-    create_user(USER1)
-    parent_tag1 = create_tag(USER1, "pkg1:info1:")
-    child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")
+class TestTopicHasVersion:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        create_user(USER1)
+        self.parent_tag1 = create_tag(USER1, "pkg1:info1:")
+        self.child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")
+        self.parent_tag2 = create_tag(USER1, "pkg2:info1:")
+        self.child_tag21 = create_tag(USER1, "pkg2:info1:mgr1")
 
-    def _gen_pteam_params(idx: int) -> dict:
-        return {
-            "pteam_name": f"pteam{idx}",
-            "alert_slack": {
-                "enable": True,
-                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
-            },
-            "alert_mail": {
-                "enable": True,
-                "address": f"account{idx}@example.com",
-            },
-            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-        }
+        def _gen_pteam_params(idx: int) -> dict:
+            return {
+                "pteam_name": f"pteam{idx}",
+                "alert_slack": {
+                    "enable": True,
+                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
+                },
+                "alert_mail": {
+                    "enable": True,
+                    "address": f"account{idx}@example.com",
+                },
+                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+            }
 
-    def _gen_topic_params(tags: List[schemas.TagResponse]) -> dict:
+        self.pteam = create_pteam(USER1, _gen_pteam_params(0))
+
+    # common functions used in tests
+    def _gen_topic_params(self, tags: List[schemas.TagResponse]) -> dict:
         topic_id = str(uuid4())
         return {
             "topic_id": topic_id,
@@ -286,7 +295,9 @@ def test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag(
             "actions": [],
         }
 
+    # common functions used in tests
     def _find_expected(
+        self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
         idx: int,
         tag: schemas.TagResponse,
@@ -296,112 +307,108 @@ def test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag(
             for _tgt in _targets
         )
 
-    pteam0 = create_pteam(USER1, _gen_pteam_params(0))
-    ext_tags = {
-        child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
-    }
-    upload_pteam_tags(USER1, pteam0.pteam_id, GROUP1, ext_tags)
-
-    action = {
-        "action": "action one",
-        "action_type": models.ActionType.elimination,
-        "recommended": True,
-        "ext": {
-            "tags": [child_tag11.tag_name],
-            "vulnerable_versions": {child_tag11.tag_name: [vulnerable_versions]},
-        },
-    }
-
-    # create topic and verification of alerts
-    topic = create_topic(USER1, _gen_topic_params([parent_tag1]), actions=[action])
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert _find_expected(alert_targets, 0, child_tag11) == expected
-
-
-@pytest.mark.parametrize(
-    "vulnerable_versions1, vulnerable_versions2, expected",
-    [("< 1.0.0", "< 2.0.0", True)],  # closed  # unclosed
-)
-def test_pick_alert_when_the_tag_with_and_without_auto_closed_and_remains_in_the_tag(
-    testdb, vulnerable_versions1, vulnerable_versions2, expected
-) -> None:
-    create_user(USER1)
-    parent_tag1 = create_tag(USER1, "pkg1:info1:")
-    child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")
-    parent_tag2 = create_tag(USER1, "pkg2:info1:")
-    child_tag21 = create_tag(USER1, "pkg2:info1:mgr1")
-
-    def _gen_pteam_params(idx: int) -> dict:
-        return {
-            "pteam_name": f"pteam{idx}",
-            "alert_slack": {
-                "enable": True,
-                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
-            },
-            "alert_mail": {
-                "enable": True,
-                "address": f"account{idx}@example.com",
-            },
-            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-        }
-
-    def _gen_topic_params(tags: List[schemas.TagResponse]) -> dict:
-        topic_id = str(uuid4())
-        return {
-            "topic_id": topic_id,
-            "title": "test topic " + topic_id,
-            "abstract": "test abstract " + topic_id,
-            "threat_impact": 1,
-            "tags": [tag.tag_name for tag in tags],
-            "misp_tags": [],
-            "actions": [],
-        }
-
-    def _find_expected(
-        _targets: Sequence[models.CurrentPTeamTopicTagStatus],
-        idx: int,
-        tag: schemas.TagResponse,
-    ) -> bool:
-        return any(
-            _tgt.pteam.pteam_name == f"pteam{idx}" and _tgt.tag.tag_name == tag.tag_name
-            for _tgt in _targets
-        )
-
-    pteam0 = create_pteam(USER1, _gen_pteam_params(0))
-    ext_tags = {
-        child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
-        child_tag21.tag_name: [("api/Pipfile.lock", "1.0.0")],
-    }
-    upload_pteam_tags(USER1, pteam0.pteam_id, GROUP1, ext_tags)
-
-    action1_closable = {
-        "action": "action one",
-        "action_type": models.ActionType.elimination,
-        "recommended": True,
-        "ext": {
-            "tags": [child_tag11.tag_name],
-            "vulnerable_versions": {child_tag11.tag_name: [vulnerable_versions1]},  # closable
-        },
-    }
-    action2_unclosable = {
-        "action": "action two",
-        "action_type": models.ActionType.elimination,
-        "recommended": True,
-        "ext": {
-            "tags": [child_tag21.tag_name],
-            "vulnerable_versions": {child_tag21.tag_name: [vulnerable_versions2]},  # unclosable
-        },
-    }
-
-    # complex
-    topic = create_topic(
-        USER1,
-        _gen_topic_params([parent_tag1, parent_tag2]),
-        actions=[action1_closable, action2_unclosable],
+    @pytest.mark.parametrize(
+        "vulnerable_versions, expected",
+        # vulnerable_versions: Vulnerable versions when creating topics
+        # expected: Ture if an alert is received, False if not
+        [("< 1.0.0", False)],
     )
-    alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert len(alert_targets) == 1
-    assert _find_expected(alert_targets, 0, child_tag21) == expected  # alert only uncompleted
+    def test_it_should_not_alert_when_version_of_topic_is_lower_than_version_registered_in_pteam(
+        self, testdb, vulnerable_versions, expected
+    ):
+        ext_tags = {
+            self.child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
+        }
+        upload_pteam_tags(USER1, self.pteam.pteam_id, GROUP1, ext_tags)
+        action = {
+            "action": "action one",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [self.child_tag11.tag_name],
+                "vulnerable_versions": {self.child_tag11.tag_name: [vulnerable_versions]},
+            },
+        }
+
+        # create topic and verification of alerts
+        topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, 0, self.child_tag11) == expected
+
+    @pytest.mark.parametrize(
+        "vulnerable_versions, expected",
+        # vulnerable_versions: Vulnerable versions when creating topics
+        # expected: Ture if an alert is received, False if not
+        [("< 2.0.0", True)],
+    )
+    def test_it_should_alert_when_version_of_topic_is_higher_than_version_registered_in_pteam(
+        self, testdb, vulnerable_versions, expected
+    ):
+        ext_tags = {
+            self.child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
+        }
+        upload_pteam_tags(USER1, self.pteam.pteam_id, GROUP1, ext_tags)
+        action = {
+            "action": "action one",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [self.child_tag11.tag_name],
+                "vulnerable_versions": {self.child_tag11.tag_name: [vulnerable_versions]},
+            },
+        }
+
+        # create topic and verification of alerts
+        topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert self._find_expected(alert_targets, 0, self.child_tag11) == expected
+
+    @pytest.mark.parametrize(
+        "vulnerable_versions1, vulnerable_versions2, expected",
+        # vulnerable_versions1: closed vulnerable versions
+        # vulnerable_versions2: unclosed vulnerable versions
+        # expected: Ture if an alert is received, False if not
+        [("< 1.0.0", "< 2.0.0", True)],
+    )
+    def test_it_should_alert_only_version_matched_tag_and_not_alert_unmattched(
+        self, testdb, vulnerable_versions1, vulnerable_versions2, expected
+    ):
+        ext_tags = {
+            self.child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")],
+            self.child_tag21.tag_name: [("api/Pipfile.lock", "1.0.0")],
+        }
+        upload_pteam_tags(USER1, self.pteam.pteam_id, GROUP1, ext_tags)
+
+        action1_closable = {
+            "action": "action one",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [self.child_tag11.tag_name],
+                "vulnerable_versions": {self.child_tag11.tag_name: [vulnerable_versions1]},
+            },
+        }
+        action2_unclosable = {
+            "action": "action two",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [self.child_tag21.tag_name],
+                "vulnerable_versions": {self.child_tag21.tag_name: [vulnerable_versions2]},
+            },
+        }
+
+        # complex
+        topic = create_topic(
+            USER1,
+            self._gen_topic_params([self.parent_tag1, self.parent_tag2]),
+            actions=[action1_closable, action2_unclosable],
+        )
+        alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
+        assert len(alert_targets) == 1
+
+        # alert only uncompleted
+        assert self._find_expected(alert_targets, 0, self.child_tag21) == expected
 
 
 def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -318,7 +318,7 @@ def test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag(
     assert _find_expected(alert_targets, 0, child_tag11) == expected
 
 
-def test_alert_new_topic__by_mail(mocker) -> None:
+def test_alert_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:
     create_user(USER1)
     parent_tag1 = create_tag(USER1, "pkg1:info1:")
     child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -67,7 +67,7 @@ class TestPTeamHasParentTag:
         }
 
     # common functions used in tests
-    def _find_expected(
+    def check_tag_in_alert_target(
         self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
         tag: schemas.TagResponse,
@@ -87,7 +87,7 @@ class TestPTeamHasParentTag:
     ):
         topic = create_topic(USER1, self._gen_topic_params(parent_tag))
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.parent_tag1) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.parent_tag1) == expected
 
     @pytest.mark.parametrize(
         "child_tag, expected",
@@ -102,7 +102,7 @@ class TestPTeamHasParentTag:
     ):
         topic = create_topic(USER1, self._gen_topic_params(child_tag))
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.parent_tag1) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.parent_tag1) == expected
 
 
 class TestPTeamHasChildTag:
@@ -143,7 +143,7 @@ class TestPTeamHasChildTag:
         }
 
     # common functions used in tests
-    def _find_expected(
+    def check_tag_in_alert_target(
         self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
         tag: schemas.TagResponse,
@@ -163,7 +163,7 @@ class TestPTeamHasChildTag:
     ):
         topic = create_topic(USER1, self._gen_topic_params(parent_tag))
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.child_tag1) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag1) == expected
 
     @pytest.mark.parametrize(
         "child_tag, expected",
@@ -178,7 +178,7 @@ class TestPTeamHasChildTag:
     ):
         topic = create_topic(USER1, self._gen_topic_params(child_tag))
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.child_tag1) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag1) == expected
 
 
 @pytest.mark.parametrize(
@@ -237,7 +237,7 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
             "actions": [],
         }
 
-    def _find_expected(
+    def check_tag_in_alert_target(
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
         tag: schemas.TagResponse,
     ) -> bool:
@@ -251,7 +251,7 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
     # create topic and verification of alerts
     topic = create_topic(USER1, _gen_topic_params(threshold))
     alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-    assert _find_expected(alert_targets, child_tag11) == expected
+    assert check_tag_in_alert_target(alert_targets, child_tag11) == expected
 
 
 class TestTopicHasVersion:
@@ -292,7 +292,7 @@ class TestTopicHasVersion:
         }
 
     # common functions used in tests
-    def _find_expected(
+    def check_tag_in_alert_target(
         self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
         tag: schemas.TagResponse,
@@ -325,7 +325,7 @@ class TestTopicHasVersion:
         # create topic and verification of alerts
         topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.child_tag11) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag11) == expected
 
     @pytest.mark.parametrize(
         "vulnerable_versions, expected",
@@ -353,7 +353,7 @@ class TestTopicHasVersion:
         # create topic and verification of alerts
         topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, self.child_tag11) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag11) == expected
 
     @pytest.mark.parametrize(
         "vulnerable_versions1, vulnerable_versions2, expected",
@@ -400,7 +400,7 @@ class TestTopicHasVersion:
         assert len(alert_targets) == 1
 
         # alert only uncompleted
-        assert self._find_expected(alert_targets, self.child_tag21) == expected
+        assert self.check_tag_in_alert_target(alert_targets, self.child_tag21) == expected
 
 
 def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -251,7 +251,7 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
 
 @pytest.mark.parametrize(
     "vulnerable_versions, expected",
-    [("< 1.0.0", False), ("< 2.0.0", True)],  # closed  # unclosed
+    [("< 1.0.0", False), ("< 2.0.0", True)],
 )
 def test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag(
     testdb, vulnerable_versions, expected

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -404,7 +404,7 @@ def test_pick_alert_when_the_tag_with_and_without_auto_closed_and_remains_in_the
     assert _find_expected(alert_targets, 0, child_tag21) == expected  # alert only uncompleted
 
 
-def test_alert_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:
+def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:
     create_user(USER1)
     parent_tag1 = create_tag(USER1, "pkg1:info1:")
     child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -36,21 +36,20 @@ class TestPTeamHasParentTag:
         create_user(USER1)
         self.parent_tag1 = create_tag(USER1, "pkg1:info1:")
 
-        def _gen_pteam_params() -> dict:
-            return {
-                "pteam_name": "pteam1",
-                "alert_slack": {
-                    "enable": True,
-                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
-                },
-                "alert_mail": {
-                    "enable": True,
-                    "address": "account1@example.com",
-                },
-                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-            }
+        pteam_params = {
+            "pteam_name": "pteam1",
+            "alert_slack": {
+                "enable": True,
+                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+            },
+            "alert_mail": {
+                "enable": True,
+                "address": "account1@example.com",
+            },
+            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+        }
 
-        pteam = create_pteam(USER1, _gen_pteam_params())
+        pteam = create_pteam(USER1, pteam_params)
         ext_tags = {self.parent_tag1.tag_name: [("api/Pipfile.lock", "1.0.0")]}
         upload_pteam_tags(USER1, pteam.pteam_id, GROUP1, ext_tags)
 
@@ -113,21 +112,20 @@ class TestPTeamHasChildTag:
         create_user(USER1)
         self.child_tag1 = create_tag(USER1, "pkg1:info1:mgr1")
 
-        def _gen_pteam_params() -> dict:
-            return {
-                "pteam_name": "pteam1",
-                "alert_slack": {
-                    "enable": True,
-                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
-                },
-                "alert_mail": {
-                    "enable": True,
-                    "address": "account1@example.com",
-                },
-                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-            }
+        pteam_params = {
+            "pteam_name": "pteam1",
+            "alert_slack": {
+                "enable": True,
+                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+            },
+            "alert_mail": {
+                "enable": True,
+                "address": "account1@example.com",
+            },
+            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+        }
 
-        pteam = create_pteam(USER1, _gen_pteam_params())
+        pteam = create_pteam(USER1, pteam_params)
         ext_tags = {self.child_tag1.tag_name: [("api/Pipfile.lock", "1.0.0")]}
         upload_pteam_tags(USER1, pteam.pteam_id, GROUP1, ext_tags)
 
@@ -214,19 +212,18 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
     parent_tag1 = create_tag(USER1, "pkg1:info1:")
     child_tag11 = create_tag(USER1, "pkg1:info1:mgr1")
 
-    def _gen_pteam_params() -> dict:
-        return {
-            "pteam_name": "pteam1",
-            "alert_slack": {
-                "enable": True,
-                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
-            },
-            "alert_mail": {
-                "enable": True,
-                "address": "account1@example.com",
-            },
-            "alert_threat_impact": alert_threat_impact,
-        }
+    pteam_params = {
+        "pteam_name": "pteam1",
+        "alert_slack": {
+            "enable": True,
+            "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+        },
+        "alert_mail": {
+            "enable": True,
+            "address": "account1@example.com",
+        },
+        "alert_threat_impact": alert_threat_impact,
+    }
 
     def _gen_topic_params(impact: int) -> dict:
         topic_id = str(uuid4())
@@ -247,7 +244,7 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
         return any(_tgt.tag.tag_name == tag.tag_name for _tgt in _targets)
 
     # create pteam and upload pteam tags
-    pteam = create_pteam(USER1, _gen_pteam_params())
+    pteam = create_pteam(USER1, pteam_params)
     ext_tags = {child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")]}
     upload_pteam_tags(USER1, pteam.pteam_id, GROUP1, ext_tags)
 
@@ -266,21 +263,20 @@ class TestTopicHasVersion:
         self.parent_tag2 = create_tag(USER1, "pkg2:info1:")
         self.child_tag21 = create_tag(USER1, "pkg2:info1:mgr1")
 
-        def _gen_pteam_params(idx: int) -> dict:
-            return {
-                "pteam_name": f"pteam{idx}",
-                "alert_slack": {
-                    "enable": True,
-                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
-                },
-                "alert_mail": {
-                    "enable": True,
-                    "address": f"account{idx}@example.com",
-                },
-                "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
-            }
+        pteam_params = {
+            "pteam_name": "pteam1",
+            "alert_slack": {
+                "enable": True,
+                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + "1",
+            },
+            "alert_mail": {
+                "enable": True,
+                "address": "account@example.com",
+            },
+            "alert_threat_impact": DEFAULT_ALERT_THREAT_IMPACT,
+        }
 
-        self.pteam = create_pteam(USER1, _gen_pteam_params(0))
+        self.pteam = create_pteam(USER1, pteam_params)
 
     # common functions used in tests
     def _gen_topic_params(self, tags: List[schemas.TagResponse]) -> dict:
@@ -299,13 +295,9 @@ class TestTopicHasVersion:
     def _find_expected(
         self,
         _targets: Sequence[models.CurrentPTeamTopicTagStatus],
-        idx: int,
         tag: schemas.TagResponse,
     ) -> bool:
-        return any(
-            _tgt.pteam.pteam_name == f"pteam{idx}" and _tgt.tag.tag_name == tag.tag_name
-            for _tgt in _targets
-        )
+        return any(_tgt.tag.tag_name == tag.tag_name for _tgt in _targets)
 
     @pytest.mark.parametrize(
         "vulnerable_versions, expected",
@@ -333,7 +325,7 @@ class TestTopicHasVersion:
         # create topic and verification of alerts
         topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, 0, self.child_tag11) == expected
+        assert self._find_expected(alert_targets, self.child_tag11) == expected
 
     @pytest.mark.parametrize(
         "vulnerable_versions, expected",
@@ -361,7 +353,7 @@ class TestTopicHasVersion:
         # create topic and verification of alerts
         topic = create_topic(USER1, self._gen_topic_params([self.parent_tag1]), actions=[action])
         alert_targets = _pick_alert_targets_for_new_topic(testdb, topic.topic_id)
-        assert self._find_expected(alert_targets, 0, self.child_tag11) == expected
+        assert self._find_expected(alert_targets, self.child_tag11) == expected
 
     @pytest.mark.parametrize(
         "vulnerable_versions1, vulnerable_versions2, expected",
@@ -408,7 +400,7 @@ class TestTopicHasVersion:
         assert len(alert_targets) == 1
 
         # alert only uncompleted
-        assert self._find_expected(alert_targets, 0, self.child_tag21) == expected
+        assert self._find_expected(alert_targets, self.child_tag21) == expected
 
 
 def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) -> None:


### PR DESCRIPTION
## PR の目的
- test_alert.pyにあるテストの名前を変更しました。
- パラメトリックを用いてテストを整理しました。
- テストケースを追加しました。

## 経緯・意図・意思決定
### 名前変更について
- test_pick_alert_target_for_new_topic__tags → test_pick_alert_when_the_matching_tag_exists_when_the_topic_is_created
- test_pick_alert_target_for_new_topic__threshold → test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_threat_impact_of_pteam
- test_pick_alert_target_for_new_topic__auto_closed → test_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tag
test_pick_alert_when_the_tag_with_and_without_auto_closed_and_remains_in_the_tag
- test_alert_new_topic__by_mail → test_alert_by_email_if_vulnerabilities_are_found_when_creating_topic

### パラメトリックを用いてテストを整理について
- test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_threat_impact_of_a_pteamとtest_pick_alert_when_the_tag_is_not_auto_closed_and_remains_in_the_tagの2つのテストについてパラメトリックを用いたテストに変更しました。

### テストケースを追加について
- test_pick_alert_when_the_matching_tag_exists_when_the_topic_is_createdについてテストを2つテストを追加しました
- 単一トピックに複数親のタグで合致するケースと単一トピックに複数子のタグで合致するケースを追加しました。


