### PR TITLE
limit action length 1024

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -522,6 +522,7 @@ def main() -> None:
             actions = [
                 {
                     **x,
+                    "action": x["action"][:1024],
                     "ext": {
                         "tags": list(x["ext"]["tags"]),
                         "vulnerable_versions": {


### PR DESCRIPTION
## PR の目的
trivydb2tc で作成されるaction の長さが、1024文字を超える可能性がある問題への対応
https://github.com/nttcom/threatconnectome/blob/5f271e6840a2cc1bd9dc0254c864329c8f0cc9d2/api/app/schemas.py#L198

## 経緯・意図・意思決定
trivydb2tcでは、actionの説明文の長さを制限していないが、APIスキーマでは1024文字に制限している
これによりactionが1024文字を超えた場合にactionが作成できない問題があったため、これを修正する

## 参考文献
