### PR TITLE
Topic/use firebase email from userinfo

### DIFF
--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -33,7 +33,7 @@ def get_firebase_credentials():
 def verify_id_token(
     token: HTTPAuthorizationCredentials = Depends(token_scheme),
     firebase_credentials=Depends(get_firebase_credentials),
-) -> Dict[str, Any]:
+) -> auth.UserRecord:
     if firebase_credentials is None or token is None:
         raise credentials_exception
     try:
@@ -61,23 +61,23 @@ def verify_id_token(
     except (auth.InvalidIdTokenError, ValueError) as error:
         raise credentials_exception from error
 
+    user_info = auth.get_user(decoded_token["uid"])
+
     # check email verified if not using firebase emulator
     emulator_host = os.getenv("FIREBASE_AUTH_EMULATOR_HOST", "")
-    if emulator_host == "":
-        user_info = auth.get_user(decoded_token["uid"])
-        if user_info.email_verified is False:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Email is not verified. Try logging in on UI and verify email.",
-            )
+    if emulator_host == "" and user_info.email_verified is False:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Email is not verified. Try logging in on UI and verify email.",
+        )
 
-    return decoded_token
+    return user_info
 
 
 def get_current_user(
-    decoded_token: Dict[str, Any] = Depends(verify_id_token), db: Session = Depends(get_db)
+    user_info: auth.UserRecord = Depends(verify_id_token), db: Session = Depends(get_db)
 ) -> Account:
-    user = persistence.get_account_by_firebase_uid(db, decoded_token["uid"])
+    user = persistence.get_account_by_firebase_uid(db, user_info.uid)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -30,9 +30,9 @@ def create_user(
     """
     Create a user.
     """
-    decoded_token = verify_id_token(token)
-    uid = decoded_token["uid"]
-    email = decoded_token["email"]
+    user_info = verify_id_token(token)
+    uid = user_info.uid
+    email = user_info.email
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -38,6 +38,9 @@ def create_user(
         if len(user_info.provider_data) > 0:
             email = user_info.provider_data[0].email
 
+    if not email:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email does not exist")
+
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -39,7 +39,10 @@ def create_user(
             email = user_info.provider_data[0].email
 
     if not email:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email does not exist")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The requested Email information could not be retrieved.",
+        )
 
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -38,7 +38,6 @@ def create_user(
         if len(user_info.provider_data) > 0:
             email = user_info.provider_data[0].email
 
-    email = user_info.provider_data[0].email
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -32,7 +32,8 @@ def create_user(
     """
     user_info = verify_id_token(token)
     uid = user_info.uid
-    email = user_info.email
+    # Get email from auth provider data
+    email = user_info.provider_data[0].email
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
 

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -32,7 +32,12 @@ def create_user(
     """
     user_info = verify_id_token(token)
     uid = user_info.uid
-    # Get email from auth provider data
+    email = user_info.email
+    # if user_info.email is empty, get email from auth provider data
+    if email is None:
+        if len(user_info.provider_data) > 0:
+            email = user_info.provider_data[0].email
+
     email = user_info.provider_data[0].email
     if persistence.get_account_by_email(db, email):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")


### PR DESCRIPTION
## PR の目的
FirebaseでSAMLログインをしていた場合、 firebase.email にメールアドレスが含まれず、新規ユーザの作成ができないパターンがあることがわかった。
この問題を修正するため、 tokenの情報ではなくFirebaseから取得した情報を利用するように変更する。

## 経緯・意図・意思決定
- tokenに含まれるemail情報ではなく、tokenに含まれるuidを元にユーザ情報をfirebaseから取得するように変更


## 参考文献
UserInfoの provider_data よりUserProviderにアクセス可能
https://firebase.google.com/docs/reference/admin/python/firebase_admin.auth?_gl=1*o27izs*_up*MQ..*_ga*MTMwOTQzMDYyLjE3MTM3NTQ1NTg.*_ga_CW55HF8NVT*MTcxMzc1NDU1OC4xLjAuMTcxMzc1NDU1OC4wLjAuMA..#firebase_admin.auth.UserRecord

FirebaseのUserProvider.email を利用する
https://firebase.google.com/docs/reference/admin/node/firebase-admin.auth.userprovider