### PR TITLE
Topic/threat api

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -11,6 +11,7 @@ from app.routers import (
     misptags,
     pteams,
     tags,
+    threat,
     topics,
     users,
 )
@@ -47,6 +48,7 @@ def create_app():
     app.include_router(tags.router)
     app.include_router(topics.router)
     app.include_router(users.router)
+    app.include_router(threat.router)
 
     # setup firebase
     cred = setup_firebase_auth()

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union
+from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy import select
@@ -418,8 +418,8 @@ def delete_topic(db: Session, topic: models.Topic):
 
 
 ### Threat
-def create_threat(db: Session, ateam: models.Threat) -> None:
-    db.add(ateam)
+def create_threat(db: Session, threat: models.Threat) -> None:
+    db.add(threat)
     db.flush()
 
 
@@ -428,17 +428,17 @@ def delete_threat(db: Session, threat: models.Threat) -> None:
     db.flush()
 
 
-def get_threat(db: Session, threat_id: UUID | str) -> models.Threat | None:
+def get_threat_by_id(db: Session, threat_id: UUID | str) -> models.Threat | None:
     return db.scalars(
         select(models.Threat).where(models.Threat.threat_id == str(threat_id))
     ).one_or_none()
 
 
 def get_all_threats(
-    tag_id: Union[UUID, None],
-    service_id: Union[UUID, None],
-    topic_id: Union[UUID, None],
     db: Session,
+    tag_id: UUID | None,
+    service_id: UUID | None,
+    topic_id: UUID | None,
 ) -> Sequence[models.Threat]:
     select_stmt = select(models.Threat)
     if tag_id:

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -432,3 +432,10 @@ def get_threat(db: Session, threat_id: UUID | str) -> models.Threat | None:
     return db.scalars(
         select(models.Threat).where(models.Threat.threat_id == str(threat_id))
     ).one_or_none()
+
+
+### Service
+def get_service_by_id(db: Session, service_id: UUID | str) -> models.Service | None:
+    return db.scalars(
+        select(models.Service).where(models.Service.service_id == str(service_id))
+    ).one_or_none()

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Union
 from uuid import UUID
 
 from sqlalchemy import select
@@ -432,6 +432,23 @@ def get_threat(db: Session, threat_id: UUID | str) -> models.Threat | None:
     return db.scalars(
         select(models.Threat).where(models.Threat.threat_id == str(threat_id))
     ).one_or_none()
+
+
+def get_all_threats(
+    tag_id: Union[UUID, None],
+    service_id: Union[UUID, None],
+    topic_id: Union[UUID, None],
+    db: Session,
+) -> Sequence[models.Threat]:
+    select_stmt = select(models.Threat)
+    if tag_id:
+        select_stmt = select_stmt.where(models.Threat.tag_id == str(tag_id))
+    if service_id:
+        select_stmt = select_stmt.where(models.Threat.service_id == str(service_id))
+    if topic_id:
+        select_stmt = select_stmt.where(models.Threat.service_id == str(service_id))
+
+    return db.scalars(select_stmt).all()
 
 
 ### Service

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -446,7 +446,7 @@ def get_all_threats(
     if service_id:
         select_stmt = select_stmt.where(models.Threat.service_id == str(service_id))
     if topic_id:
-        select_stmt = select_stmt.where(models.Threat.service_id == str(service_id))
+        select_stmt = select_stmt.where(models.Threat.topic_id == str(topic_id))
 
     return db.scalars(select_stmt).all()
 

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -415,3 +415,20 @@ def create_topic(db: Session, topic: models.Topic):
 def delete_topic(db: Session, topic: models.Topic):
     db.delete(topic)
     db.flush()
+
+
+### Threat
+def create_threat(db: Session, ateam: models.Threat) -> None:
+    db.add(ateam)
+    db.flush()
+
+
+def delete_threat(db: Session, threat: models.Threat) -> None:
+    db.delete(threat)
+    db.flush()
+
+
+def get_threat(db: Session, threat_id: UUID | str) -> models.Threat | None:
+    return db.scalars(
+        select(models.Threat).where(models.Threat.threat_id == str(threat_id))
+    ).one_or_none()

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -8,14 +8,23 @@ from app.database import get_db
 
 router = APIRouter(prefix="/threats", tags=["threats"])
 
-NO_SUCH_THREAT = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
-
 
 @router.post("", response_model=schemas.ThreatResponse)
 def create_threat(
     data: schemas.ThreatRequest,
     db: Session = Depends(get_db),
 ):
+    tag_id = persistence.get_tag_by_id(db, data.tag_id)
+    topic_id = persistence.get_topic_by_id(db, data.topic_id)
+    service_id = persistence.get_service_by_id(db, data.service_id)
+    if tag_id is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such tag_id")
+
+    if topic_id is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such topic_id")
+
+    if service_id is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service_id")
 
     threat = models.Threat(**data.model_dump())
     persistence.create_threat(db, threat)
@@ -31,7 +40,8 @@ def delete_threat(
 ):
     threat = persistence.get_threat(db, threat_id)
     if threat is None:
-        raise NO_SUCH_THREAT
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
+
     persistence.delete_threat(db, threat)
     db.commit()
 

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -1,0 +1,38 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.orm import Session
+
+from app import models, persistence, schemas
+from app.database import get_db
+
+router = APIRouter(prefix="/threats", tags=["threats"])
+
+NO_SUCH_THREAT = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
+
+
+@router.post("", response_model=schemas.ThreatResponse)
+def create_threat(
+    data: schemas.ThreatRequest,
+    db: Session = Depends(get_db),
+):
+
+    threat = models.Threat(**data.model_dump())
+    persistence.create_threat(db, threat)
+    db.commit()
+
+    return threat
+
+
+@router.delete("/{threat_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_threat(
+    threat_id: UUID,
+    db: Session = Depends(get_db),
+):
+    threat = persistence.get_threat(db, threat_id)
+    if threat is None:
+        raise NO_SUCH_THREAT
+    persistence.delete_threat(db, threat)
+    db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -553,3 +553,16 @@ class ATeamTopicCommentResponse(ORMModel):
     updated_at: Optional[datetime] = None
     comment: str
     email: str
+
+
+class ThreatResponse(ORMModel):
+    threat_id: UUID
+    tag_id: UUID
+    service_id: UUID
+    topic_id: UUID
+
+
+class ThreatRequest(ORMModel):
+    tag_id: UUID
+    service_id: UUID
+    topic_id: UUID

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -26,6 +26,15 @@ headers = {
 }
 
 
+def test_get_threat(testdb: Session):
+    response1 = create_threat(testdb, USER1, PTEAM1, TOPIC1)
+    data = assert_200(client.get("/threats/" + str(response1.threat_id), headers=headers))
+    assert data["threat_id"] == str(response1.threat_id)
+    assert data["tag_id"] == str(response1.tag_id)
+    assert data["service_id"] == str(response1.service_id)
+    assert data["topic_id"] == str(response1.topic_id)
+
+
 def test_get_threat_no_data():
     with pytest.raises(HTTPError, match=r"404: Not Found: No such threat"):
         assert_200(client.get("/threats/3fa85f64-5717-4562-b3fc-2c963f66afa6", headers=headers))
@@ -37,22 +46,31 @@ def test_get_all_threats(testdb: Session):
     data = assert_200(client.get("/threats", headers=headers))
     assert len(data) == 2
 
-    if str(response1.threat_id) < str(response2.threat_id):
-        first_threat = response1
-        second_threat = response2
-    else:
-        first_threat = response2
-        second_threat = response1
+    assert (data[0]["threat_id"] == str(response1.threat_id)) or (
+        data[0]["threat_id"] == str(response2.threat_id)
+    )
+    assert (data[0]["tag_id"] == str(response1.tag_id)) or (
+        data[0]["tag_id"] == str(response2.tag_id)
+    )
+    assert (data[0]["service_id"] == str(response1.service_id)) or (
+        data[0]["service_id"] == str(response2.service_id)
+    )
+    assert (data[0]["topic_id"] == str(response1.topic_id)) or (
+        data[0]["topic_id"] == str(response2.topic_id)
+    )
 
-    assert data[0]["threat_id"] == str(first_threat.threat_id)
-    assert data[0]["tag_id"] == str(first_threat.tag_id)
-    assert data[0]["service_id"] == str(first_threat.service_id)
-    assert data[0]["topic_id"] == str(first_threat.topic_id)
-
-    assert data[1]["threat_id"] == str(second_threat.threat_id)
-    assert data[1]["tag_id"] == str(second_threat.tag_id)
-    assert data[1]["service_id"] == str(second_threat.service_id)
-    assert data[1]["topic_id"] == str(second_threat.topic_id)
+    assert (data[1]["threat_id"] == str(response1.threat_id)) or (
+        data[1]["threat_id"] == str(response2.threat_id)
+    )
+    assert (data[1]["tag_id"] == str(response1.tag_id)) or (
+        data[1]["tag_id"] == str(response2.tag_id)
+    )
+    assert (data[1]["service_id"] == str(response1.service_id)) or (
+        data[1]["service_id"] == str(response2.service_id)
+    )
+    assert (data[0]["topic_id"] == str(response1.topic_id)) or (
+        data[0]["topic_id"] == str(response2.topic_id)
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from typing import Dict, Union
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models
+from app import models, schemas
 from app.main import app
 from app.tests.medium.constants import PTEAM1, TOPIC1, USER1
 from app.tests.medium.exceptions import HTTPError
@@ -25,10 +26,25 @@ headers = {
 }
 
 
-def create_threat(testdb: Session, user: dict, pteam: dict, topic: dict):
+def test_get_threat_no_data():
+    with pytest.raises(HTTPError, match=r"404: Not Found: No such threat"):
+        assert_200(client.get("/threats/3fa85f64-5717-4562-b3fc-2c963f66afa6", headers=headers))
+
+
+def test_get_all_threats(testdb: Session):
+    response1 = create_threat(testdb, USER1, PTEAM1, TOPIC1)
+    data = assert_200(client.get("/threats", headers=headers))
+    assert len(data) == 1
+    assert data[0]["threat_id"] == str(response1.threat_id)
+    assert data[0]["tag_id"] == str(response1.tag_id)
+    assert data[0]["service_id"] == str(response1.service_id)
+    assert data[0]["topic_id"] == str(response1.topic_id)
+
+
+def create_threat(testdb: Session, user: dict, pteam: dict, topic: dict) -> schemas.ThreatResponse:
     create_user(user)
     pteam1 = create_pteam(user, pteam)
-    topic = create_topic(user, topic)
+    topic1 = create_topic(user, topic)
 
     params: Dict[str, Union[str, bool]] = {"group": "threatconnectome", "force_mode": True}
     sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
@@ -43,7 +59,7 @@ def create_threat(testdb: Session, user: dict, pteam: dict, topic: dict):
         )
 
     ##tag_idの取得
-    tags = [tag["tag_name"] for tag in data]
+    tag_id = data[0]["tag_id"]
 
     ##service_idの取得
     service_id = testdb.scalars(
@@ -53,13 +69,17 @@ def create_threat(testdb: Session, user: dict, pteam: dict, topic: dict):
         )
     ).one_or_none()
 
-    request = {"tag_id": tag_id, "service_id": str(service_id), "topic_id": str(topic.topic_id)}
-    response = client.post("/threat", headers=headers, json=request)
+    request = {
+        "tag_id": str(tag_id),
+        "service_id": str(service_id),
+        "topic_id": str(topic1.topic_id),
+    }
+    response = client.post("/threats", headers=headers, json=request)
     if response.status_code != 200:
         raise HTTPError(response)
 
-    # return response
+    return schemas.ThreatResponse(**response.json())
 
 
 def test_create_threat(testdb: Session):
-    response = create_threat(testdb, USER1, PTEAM1, TOPIC1)
+    create_threat(testdb, USER1, PTEAM1, TOPIC1)

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import Dict, Union
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app import models
+from app.main import app
+from app.tests.medium.constants import PTEAM1, TOPIC1, USER1
+from app.tests.medium.exceptions import HTTPError
+from app.tests.medium.utils import (
+    assert_200,
+    create_pteam,
+    create_topic,
+    create_user,
+    file_upload_headers,
+)
+
+client = TestClient(app)
+
+headers = {
+    "accept": "application/json",
+    "Content-Type": "application/json",
+}
+
+
+def create_threat(testdb: Session, user: dict, pteam: dict, topic: dict):
+    create_user(user)
+    pteam1 = create_pteam(user, pteam)
+    topic = create_topic(user, topic)
+
+    params: Dict[str, Union[str, bool]] = {"group": "threatconnectome", "force_mode": True}
+    sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
+    with open(sbom_file, "rb") as tags:
+        data = assert_200(
+            client.post(
+                f"/pteams/{pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+        )
+
+    ##tag_idの取得
+    tags = [tag["tag_name"] for tag in data]
+
+    ##service_idの取得
+    service_id = testdb.scalars(
+        select(models.Service.service_id).where(
+            models.Service.pteam_id == str(pteam1.pteam_id),
+            models.Service.service_name == str(params["group"]),
+        )
+    ).one_or_none()
+
+    request = {"tag_id": tag_id, "service_id": str(service_id), "topic_id": str(topic.topic_id)}
+    response = client.post("/threat", headers=headers, json=request)
+    if response.status_code != 200:
+        raise HTTPError(response)
+
+    # return response
+
+
+def test_create_threat(testdb: Session):
+    response = create_threat(testdb, USER1, PTEAM1, TOPIC1)

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -68,8 +68,8 @@ def test_get_all_threats(testdb: Session):
     assert (data[1]["service_id"] == str(response1.service_id)) or (
         data[1]["service_id"] == str(response2.service_id)
     )
-    assert (data[0]["topic_id"] == str(response1.topic_id)) or (
-        data[0]["topic_id"] == str(response2.topic_id)
+    assert (data[1]["topic_id"] == str(response1.topic_id)) or (
+        data[1]["topic_id"] == str(response2.topic_id)
     )
 
 


### PR DESCRIPTION
## PR の目的
- threatのapi(GET, POST, DELETE)を作成しました。

## 経緯・意図・意思決定
### api作成について
- GETではtag_id, service_id, topic_idを指定して取ってくるものとthreat_idを指定して取ってくる2種類を作成しました。
- POSTではtag_id, service_id, topic_idを使用してcreateし、threat_id, tag_id, service_id, topic_idが返ってくるようにしました。
- DELETEではthreat_idを用いて削除できるようにしました。

### testについて
- 6種類のテストを作成しました。(GET 4種類, POST 1種類, DELETE 1種類)
