### PR TITLE
fix wrong attribute name

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -257,7 +257,7 @@ class Dependency(Base):
 
 class Service(Base):
     __tablename__ = "service"
-    __tableargs__ = (
+    __table_args__: tuple = (
         UniqueConstraint("pteam_id", "service_name", name="service_pteam_id_service_name_key"),
     )
 


### PR DESCRIPTION
## PR の目的

- 複合ユニークキー制約を設定するための属性名を誤っていたため修正

## 経緯・意図・意思決定

-  `__table_args__` （単語間にアンダスコア）が正しい。
   - テーブル名が `__tablename__` ということもあり混乱しそう...
   - sqlalchemy 本家の issue とかでも `__tableargs__` と誤記されているケースも散見される
   - alembic マイグレーションスクリプトが `__tableargs__` でも機能しているように見えたのは勘違いで、後付で手動調整していただけ（実際、HEAD で `alembic check` すると件の制約を drop しようとする）。
 - ついでに、 `tuple` であることが分かり難いので型ヒントで明示
