### PR TITLE
fix default dependency_mission_impact to None

### DIFF
--- a/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
+++ b/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
@@ -46,7 +46,7 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('alert_id')
     )
     op.create_index(op.f('ix_alert_ticket_id'), 'alert', ['ticket_id'], unique=False)
-    op.add_column('dependency', sa.Column('dependency_mission_impact', mission_impact_enum, server_default='MISSION_FAILURE', nullable=False))
+    op.add_column('dependency', sa.Column('dependency_mission_impact', mission_impact_enum, server_default=None, nullable=True))
     op.add_column('service', sa.Column('exposure', exposure_enum, server_default='OPEN', nullable=False))
     op.add_column('service', sa.Column('service_mission_impact', mission_impact_enum, server_default='MISSION_FAILURE', nullable=False))
     op.add_column('topic', sa.Column('safety_impact', safety_impact_enum, server_default='CATASTROPHIC', nullable=False))

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -287,8 +287,6 @@ class Dependency(Base):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        if not self.dependency_mission_impact:
-            self.dependency_mission_impact = MissionImpactEnum.MISSION_FAILURE
 
     service_id: Mapped[StrUUID] = mapped_column(
         ForeignKey("service.service_id", ondelete="CASCADE"), primary_key=True, index=True
@@ -298,8 +296,8 @@ class Dependency(Base):
     )
     version: Mapped[str] = mapped_column(primary_key=True)
     target: Mapped[str] = mapped_column(primary_key=True)
-    dependency_mission_impact: Mapped[MissionImpactEnum] = mapped_column(
-        server_default=MissionImpactEnum.MISSION_FAILURE
+    dependency_mission_impact: Mapped[MissionImpactEnum | None] = mapped_column(
+        server_default=None, nullable=True
     )
 
     service = relationship("Service", back_populates="dependencies")


### PR DESCRIPTION
## PR の目的

- dependency_mission_impact を nullable に変更し、デフォルト値を NULL に変更。
  - NULL の場合は service_mission_impact を代替参照する
  - `MissionImpactEnum.None` と `None` は意味が異なるので注意。
    - 前者は MissionImpact 界隈での None という値、後者は未設定であることを意味する。
