### PR TITLE
Topic/add new parameter to topic

### DIFF
--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -298,6 +298,7 @@ def create_topic(
 
     # create topic core
     now = datetime.now()
+
     topic = models.Topic(
         topic_id=str(topic_id),
         title=fixed_title,
@@ -309,6 +310,8 @@ def create_topic(
         content_fingerprint=calculate_topic_content_fingerprint(
             fixed_title, fixed_abstract, data.threat_impact, data.tags
         ),
+        safety_impact=data.safety_impact,
+        hint_for_action=data.hint_for_action,
     )
     # fix relations
     topic.tags = [requested_tags[tag_name] for tag_name in set(data.tags)]

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -298,7 +298,6 @@ def create_topic(
 
     # create topic core
     now = datetime.now()
-
     topic = models.Topic(
         topic_id=str(topic_id),
         title=fixed_title,
@@ -311,6 +310,8 @@ def create_topic(
             fixed_title, fixed_abstract, data.threat_impact, data.tags
         ),
         safety_impact=data.safety_impact,
+        exploitation=data.exploitation,
+        automatable=data.automatable,
         hint_for_action=data.hint_for_action,
     )
     # fix relations

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -224,10 +224,10 @@ class TopicCreateRequest(ORMModel):
     tags: list[str] = []
     misp_tags: list[str] = []
     actions: list[ActionCreateRequest] = []
-    safety_impact: SafetyImpactEnum | None
-    exploitation: ExploitationEnum | None
-    automatable: bool | None
-    hint_for_action: str | None
+    safety_impact: SafetyImpactEnum | None = None
+    exploitation: ExploitationEnum | None = None
+    automatable: bool | None = None
+    hint_for_action: str | None = None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -8,7 +8,9 @@ from app.constants import DEFAULT_ALERT_THREAT_IMPACT
 from app.models import (
     ActionType,
     ATeamAuthEnum,
+    ExploitationEnum,
     PTeamAuthEnum,
+    SafetyImpactEnum,
     TopicStatusType,
 )
 
@@ -164,6 +166,10 @@ class Topic(TopicEntry):
     created_by: UUID
     created_at: datetime
     disabled: bool
+    safety_impact: SafetyImpactEnum | None
+    exploitation: ExploitationEnum | None
+    automatable: bool | None
+    hint_for_action: str | None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 
@@ -218,6 +224,10 @@ class TopicCreateRequest(ORMModel):
     tags: list[str] = []
     misp_tags: list[str] = []
     actions: list[ActionCreateRequest] = []
+    safety_impact: SafetyImpactEnum | None
+    exploitation: ExploitationEnum | None
+    automatable: bool | None
+    hint_for_action: str | None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 

--- a/api/app/tests/medium/constants.py
+++ b/api/app/tests/medium/constants.py
@@ -98,6 +98,10 @@ TOPIC1 = {
     "tags": [TAG1],
     "misp_tags": [MISPTAG1],
     "actions": [],
+    "safety_impact": "catastrophic",
+    "exploitation": "active",
+    "automatable": True,
+    "hint_for_action": "",
 }
 TOPIC2 = {
     "topic_id": uuid4(),
@@ -107,6 +111,10 @@ TOPIC2 = {
     "tags": [TAG1],
     "misp_tags": [],
     "actions": [],
+    "safety_impact": "hazardous",
+    "exploitation": "active",
+    "automatable": True,
+    "hint_for_action": "",
 }
 TOPIC3 = {
     "topic_id": uuid4(),
@@ -116,6 +124,10 @@ TOPIC3 = {
     "tags": [TAG1, TAG3],
     "misp_tags": [],
     "actions": [],
+    "safety_impact": "catastrophic",
+    "exploitation": "active",
+    "automatable": True,
+    "hint_for_action": "",
 }
 TOPIC4 = {
     "topic_id": uuid4(),
@@ -125,6 +137,10 @@ TOPIC4 = {
     "tags": [TAG3],
     "misp_tags": [],
     "actions": [],
+    "safety_impact": "hazardous",
+    "exploitation": "active",
+    "automatable": True,
+    "hint_for_action": "",
 }
 ACTION1 = {
     "action": "action one",

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -71,6 +71,10 @@ def test_create_topic():
     assert TOPIC1["misp_tags"][0] in [m.tag_name for m in topic1.misp_tags]
     assert ACTION1["action"] in [a.action for a in topic1.actions]
     assert ACTION2["action"] in [a.action for a in topic1.actions]
+    assert topic1.safety_impact == TOPIC1["safety_impact"]
+    assert topic1.exploitation == TOPIC1["exploitation"]
+    assert topic1.automatable == TOPIC1["automatable"]
+    assert topic1.hint_for_action ==  TOPIC1["hint_for_action"]
 
 
 def test_create_topic__with_new_tags():
@@ -188,6 +192,10 @@ def test_get_topic():
     assert responsed_topic.updated_at == topic1.updated_at
     assert TOPIC1["tags"][0] in [t.tag_name for t in responsed_topic.tags]
     assert TOPIC1["misp_tags"][0] in [m.tag_name for m in responsed_topic.misp_tags]
+    assert responsed_topic.safety_impact == TOPIC1["safety_impact"]
+    assert responsed_topic.exploitation == TOPIC1["exploitation"]
+    assert responsed_topic.automatable == TOPIC1["automatable"]
+    assert responsed_topic.hint_for_action ==  TOPIC1["hint_for_action"]
     # actions are removed from TopicResponse.
     # use 'GET /topics/{tid}/actions/pteam/{pid}' to get actions.
 
@@ -713,6 +721,10 @@ class TestSearchTopics:
                 "abstract": "",
                 "threat_impact": 1,
                 **params,
+                "safety_impact": "catastrophic",
+                "exploitation": "active",
+                "automatable": True,
+                "hint_for_action": "",
             }
             return create_topic(user, minimal_topic)
 

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -64,6 +64,10 @@ class TestPTeamHasParentTag:
             "tags": [tag],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     # common functions used in tests
@@ -139,6 +143,10 @@ class TestPTeamHasChildTag:
             "tags": [tag],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     # common functions used in tests
@@ -234,6 +242,10 @@ def test_pick_alert_when_the_threat_impact_of_a_topic_is_less_than_the_alert_thr
             "tags": [parent_tag1.tag_name],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     def check_tag_in_alert_target(
@@ -288,6 +300,10 @@ class TestTopicHasVersion:
             "tags": [tag.tag_name for tag in tags],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     # common functions used in tests
@@ -431,6 +447,10 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) 
             "tags": [tag.tag_name for tag in tags],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     def _find_expected(

--- a/api/app/tests/medium/test_slack.py
+++ b/api/app/tests/medium/test_slack.py
@@ -98,6 +98,10 @@ def test_pick_alert_targets__disabled(testdb):
             "tags": [parent_tag1.tag_name],
             "misp_tags": [],
             "actions": [],
+            "safety_impact": "catastrophic",
+            "exploitation": "active",
+            "automatable": True,
+            "hint_for_action": "",
         }
 
     def _select_topic(topic: schemas.TopicCreateResponse) -> models.Topic:

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -558,8 +558,6 @@ def main() -> None:
                 "misp_tags": misp_tags,
                 "actions": actions,
                 "safety_impact": safety_impact.get(severity, "none"),
-                "exploitation": "active",
-                "automatable": True,
                 "hint_for_action": vuln_content["fix_vers"],
             }
 

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -575,7 +575,6 @@ def main() -> None:
 
     for topic_id, topic in topics.items():
         if topic_id not in existing_topics:  # new topic
-            print(topic["safety_impact"])
             tc_client.create_topic(topic_id, topic)
             continue
 

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -359,12 +359,14 @@ def vuln_info(repos, txs):
     return vulns
 
 
-def solution_from_vuln(vuln) -> tuple[str | None, str | None]:
+def solution_from_vuln(vuln) -> tuple[str | None, str | None, str | None]:
     if vuln["version_details"]:
-        solution, vuln_vers = make_update_action(vuln["pkg_name"], vuln["version_details"])
+        solution, vuln_vers, fix_vers = make_update_action(
+            vuln["pkg_name"], vuln["version_details"]
+        )
         if solution:
-            return solution, vuln_vers
-    return None, None
+            return solution, vuln_vers, fix_vers
+    return None, None, None
 
 
 def make_update_action(pkg_name, version_details: dict):
@@ -399,7 +401,9 @@ def make_update_action(pkg_name, version_details: dict):
     else:
         action = None
 
-    return action, vulnerable_versions
+    fixed_versions_str = ",".join(fixed_versions)
+
+    return action, vulnerable_versions, fixed_versions_str
 
 
 def _gen_action_id(topic_id: uuid.UUID | str, tags: list[str], action: str) -> str:
@@ -455,7 +459,7 @@ def main() -> None:
     trivy_db = Path(args.trivy_db).expanduser()
     bdb = BoltDB(trivy_db)
 
-    vuln_dict: dict[str, dict[str, dict | set]] = {}
+    vuln_dict: dict[str, dict[str, dict | set | str | None]] = {}
     with bdb.view() as txs:
         for repos, _ in txs.bucket():
             if repos in allow_list:
@@ -463,11 +467,13 @@ def main() -> None:
                 category = get_package_info(repos)
                 vulns = vuln_info(repos, txs)
                 for vuln in vulns:
-                    solution, vuln_vers = solution_from_vuln(vuln)
+                    solution, vuln_vers, fix_vers = solution_from_vuln(vuln)
                     if not solution:
                         continue
                     vuln_id = vuln["vuln_id"]
-                    vuln_obj = vuln_dict.get(vuln_id, {"tags": set(), "actions": {}})
+                    vuln_obj = vuln_dict.get(
+                        vuln_id, {"tags": set(), "actions": {}, "fix_vers": {}}
+                    )
                     tag = f"{vuln['pkg_name']}:{category}"
                     assert isinstance(vuln_obj["tags"], set)
                     vuln_obj["tags"].add(tag)
@@ -489,6 +495,7 @@ def main() -> None:
                     vers_obj.update(vuln_vers or [])
                     act_obj["ext"]["vulnerable_versions"][tag] = vers_obj
                     vuln_obj["actions"][solution] = act_obj
+                    vuln_obj["fix_vers"] = fix_vers
                     vuln_dict[vuln_id] = vuln_obj
 
         topics: dict[str, dict] = {}
@@ -516,7 +523,8 @@ def main() -> None:
                 title = vuln_id
                 abstract = "This Vuln is not yet published."
                 severity = "UNKNOWN"
-            tags = list(vuln_content["tags"])
+            if vuln_content["tags"]:
+                tags = list(vuln_content["tags"])
             misp_tags = [vuln_id]
             assert isinstance(vuln_content["actions"], dict)
             actions = [
@@ -535,6 +543,13 @@ def main() -> None:
             ]
 
             convert_impact = {"CRITICAL": 1, "HIGH": 2, "MEDIUM": 3, "LOW": 3, "UNKNOWN": 4}
+            safety_impact = {
+                "CRITICAL": "catastrophic",
+                "HIGH": "hazardous",
+                "MEDIUM": "major",
+                "LOW": "minor",
+                "UNKNOWN": "none",
+            }
             topics[topic_id] = {
                 "title": title,
                 "abstract": abstract,
@@ -542,6 +557,10 @@ def main() -> None:
                 "tags": tags,
                 "misp_tags": misp_tags,
                 "actions": actions,
+                "safety_impact": safety_impact.get(severity, "none"),
+                "exploitation": "active",
+                "automatable": True,
+                "hint_for_action": vuln_content["fix_vers"],
             }
 
     tc_client = ThreatconnectomeClient(args.url, refresh_token, retry_max=3)
@@ -556,6 +575,7 @@ def main() -> None:
 
     for topic_id, topic in topics.items():
         if topic_id not in existing_topics:  # new topic
+            print(topic["safety_impact"])
             tc_client.create_topic(topic_id, topic)
             continue
 


### PR DESCRIPTION
## PR の目的
- Topicにsafety_impact, exploitation, automatable, hint_for_actionの4つのパラメータが加わるに伴い、Topic生成スクリプトやapiやテストを変更しました。

## 経緯・意図・意思決定
### 生成スクリプト (scripts/trivydb2tc.py)
- safety_impactとhint_for_actionの2つがTopic生成時に加わるように変更しました。
- safety_impactはtrivyにあるSeverityの値を入れました。safety_impactとSeverityを以下のように対応させました
CRITICAL": "catastrophic",  "HIGH": "hazardous", "MEDIUM": "major", "LOW": "minor", "UNKNOWN": "none"
- hint_for_actionにはFixedVersionとFixedVersionを文字列にしたものを入れました。

### API (api/app/routers/topics.py, api/app/schemas.py)
- GET, POSTの2つを変更しました。(PUTは未実装)
- POSTのAPIでTopicテーブルにsafety_impact,  hint_for_actionの値が入るようにしました。
- TopicとTopicCreateRequestスキーマにsafety_impact, exploitation, automatable, hint_for_actionの4つのパラメータを加えました。

### テスト (api/app/tests/medium/constants.py, api/app/tests/medium/routers/test_topics.py, api/app/tests/medium/test_alert.py, api/app/tests/medium/test_slack.py)
- create_topicをする際にsafety_impact, exploitation, automatable, hint_for_actionの4つのパラメータが加わったのに対応しました。
- test_create_topicとtest_get_topicに新しくsafety_impact, exploitation, automatable, hint_for_actionの4つのパラメータの比較する部分を追加しました。