### PR TITLE
add new parameter

### DIFF
--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -398,6 +398,14 @@ def update_topic(
         topic.threat_impact = data.threat_impact
     if data.disabled is not None:
         topic.disabled = data.disabled
+    if data.safety_impact is not None:
+        topic.safety_impact = data.safety_impact
+    if data.exploitation is not None:
+        topic.exploitation = data.exploitation
+    if data.automatable is not None:
+        topic.automatable = data.automatable
+    if data.hint_for_action is not None:
+        topic.hint_for_action = data.hint_for_action
 
     if need_update_content_fingerprint:
         topic.content_fingerprint = calculate_topic_content_fingerprint(

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -239,6 +239,10 @@ class TopicUpdateRequest(ORMModel):
     tags: list[str] | None = None
     misp_tags: list[str] | None = None
     disabled: bool | None = None
+    safety_impact: SafetyImpactEnum | None = None
+    exploitation: ExploitationEnum | None = None
+    automatable: bool | None = None
+    hint_for_action: str | None = None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -74,7 +74,7 @@ def test_create_topic():
     assert topic1.safety_impact == TOPIC1["safety_impact"]
     assert topic1.exploitation == TOPIC1["exploitation"]
     assert topic1.automatable == TOPIC1["automatable"]
-    assert topic1.hint_for_action ==  TOPIC1["hint_for_action"]
+    assert topic1.hint_for_action == TOPIC1["hint_for_action"]
 
 
 def test_create_topic__with_new_tags():
@@ -195,7 +195,7 @@ def test_get_topic():
     assert responsed_topic.safety_impact == TOPIC1["safety_impact"]
     assert responsed_topic.exploitation == TOPIC1["exploitation"]
     assert responsed_topic.automatable == TOPIC1["automatable"]
-    assert responsed_topic.hint_for_action ==  TOPIC1["hint_for_action"]
+    assert responsed_topic.hint_for_action == TOPIC1["hint_for_action"]
     # actions are removed from TopicResponse.
     # use 'GET /topics/{tid}/actions/pteam/{pid}' to get actions.
 
@@ -236,6 +236,10 @@ def test_update_topic():
         "threat_impact": 2,
         "tags": [tag1.tag_name],
         "misp_tags": ["tlp:white"],
+        "safety_impact": "hazardous",
+        "exploitation": "poc",
+        "automatable": False,
+        "hint_for_action": "2.9.3",
     }
     response = client.put(f"/topics/{TOPIC1['topic_id']}", headers=headers(USER1), json=request)
 
@@ -253,6 +257,14 @@ def test_update_topic():
     assert TOPIC1["misp_tags"][0] not in [
         misp_tag.tag_name for misp_tag in responsed_topic.misp_tags
     ]
+    assert responsed_topic.safety_impact == request["safety_impact"]
+    assert responsed_topic.safety_impact != TOPIC1["safety_impact"]
+    assert responsed_topic.exploitation == request["exploitation"]
+    assert responsed_topic.exploitation != TOPIC1["exploitation"]
+    assert responsed_topic.automatable == request["automatable"]
+    assert responsed_topic.automatable != TOPIC1["automatable"]
+    assert responsed_topic.hint_for_action == request["hint_for_action"]
+    assert responsed_topic.hint_for_action != TOPIC1["hint_for_action"]
 
 
 def test_update_topic__with_new_tags():


### PR DESCRIPTION
## PR の目的
- update_topicにsafety_impact, exploitation, automatable, hint_for_actionの4つのパラメータが加わえました。

## 経緯・意図・意思決定
### API (api/app/routers/topics.py, api/app/schemas.py)
- update_topicでsafety_impact, exploitation, automatable, hint_for_actionの4つの値を変更できるようにしました。
- TopicUpdateRequestスキーマにsafety_impact, exploitation, automatable, hint_for_actionの4つの値を加えました。

###テスト(api/app/tests/medium/routers/test_topics.py)
- test_update_topicでsafety_impact, exploitation, automatable, hint_for_actionの4つ値が加わったテストケースを実装しました。