### PR TITLE
implement creating/sending alert based on ticket

### DIFF
--- a/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
+++ b/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
     sa.ForeignKeyConstraint(['threat_id'], ['threat.threat_id'], ondelete='CASCADE'),
     sa.PrimaryKeyConstraint('ticket_id')
     )
-    op.create_index(op.f('ix_ticket_threat_id'), 'ticket', ['threat_id'], unique=False)
+    op.create_index(op.f('ix_ticket_threat_id'), 'ticket', ['threat_id'], unique=True)
     op.create_table('alert',
     sa.Column('alert_id', sa.String(length=36), nullable=False),
     sa.Column('ticket_id', sa.String(length=36), nullable=True),
@@ -45,7 +45,7 @@ def upgrade() -> None:
     sa.ForeignKeyConstraint(['ticket_id'], ['ticket.ticket_id'], ),
     sa.PrimaryKeyConstraint('alert_id')
     )
-    op.create_index(op.f('ix_alert_ticket_id'), 'alert', ['ticket_id'], unique=False)
+    op.create_index(op.f('ix_alert_ticket_id'), 'alert', ['ticket_id'], unique=True)
     op.add_column('dependency', sa.Column('dependency_mission_impact', mission_impact_enum, server_default=None, nullable=True))
     op.add_column('service', sa.Column('exposure', exposure_enum, server_default='OPEN', nullable=False))
     op.add_column('service', sa.Column('service_mission_impact', mission_impact_enum, server_default='MISSION_FAILURE', nullable=False))

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -381,7 +381,7 @@ class Ticket(Base):
 
     ticket_id: Mapped[StrUUID] = mapped_column(primary_key=True)
     threat_id: Mapped[StrUUID] = mapped_column(
-        ForeignKey("threat.threat_id", ondelete="CASCADE"), index=True
+        ForeignKey("threat.threat_id", ondelete="CASCADE"), index=True, unique=True
     )
     created_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
     updated_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
@@ -404,7 +404,7 @@ class Alert(Base):
 
     alert_id: Mapped[StrUUID] = mapped_column(primary_key=True)
     ticket_id: Mapped[StrUUID | None] = mapped_column(
-        ForeignKey("ticket.ticket_id"), index=True, nullable=True
+        ForeignKey("ticket.ticket_id"), index=True, nullable=True, unique=True
     )
     alerted_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
     alert_content: Mapped[str | None] = mapped_column(nullable=True)  # WORKAROUND

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -388,6 +388,7 @@ class Ticket(Base):
     ssvc_deployer_priority: Mapped[SSVCDeployerPriorityEnum | None] = mapped_column(nullable=True)
 
     threat = relationship("Threat", back_populates="ticket")
+    alert = relationship("Alert", back_populates="ticket")
 
 
 class Alert(Base):
@@ -407,6 +408,8 @@ class Alert(Base):
     )
     alerted_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
     alert_content: Mapped[str | None] = mapped_column(nullable=True)  # WORKAROUND
+
+    ticket = relationship("Ticket", back_populates="alert")
 
 
 class PTeam(Base):

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -436,9 +436,9 @@ def get_threat_by_id(db: Session, threat_id: UUID | str) -> models.Threat | None
 
 def search_threats(
     db: Session,
-    tag_id: UUID | None,
-    service_id: UUID | None,
-    topic_id: UUID | None,
+    tag_id: UUID | str | None,
+    service_id: UUID | str | None,
+    topic_id: UUID | str | None,
 ) -> Sequence[models.Threat]:
     select_stmt = select(models.Threat)
     if tag_id:
@@ -474,3 +474,22 @@ def get_dependency_from_service_id_and_tag_id(
             models.Dependency.tag_id == str(tag_id),
         )
     ).one_or_none()
+
+
+### Alert
+
+
+def get_alert_by_id(db: Session, alert_id: UUID | str) -> models.Alert | None:
+    return db.scalars(
+        select(models.Alert).where(models.Alert.alert_id == str(alert_id))
+    ).one_or_none()
+
+
+def create_alert(db: Session, alert: models.Alert) -> None:
+    db.add(alert)
+    db.flush()
+
+
+def delete_alert(db: Session, alert: models.Alert) -> None:
+    db.delete(alert)
+    db.flush()


### PR DESCRIPTION
## PR の目的

- Ticket に基づき Alert を生成・送付する機能を実装
  - Alert 生成のしきい値には PTeam の alert_threat_impact を代用
  - 実際に通知する内容は、既存の slack/email 通知を代用（title, threat_impact, groups を Alert ベースでアレンジ）
