### PR TITLE
add 3 test cases

### DIFF
--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -167,40 +167,52 @@ def test_create_wrong_threat_level_topic():
         create_topic(USER1, _topic)
 
 
-def test_create_wrong_safety_impact_topic():
+def test_it_should_return_422_when_use_try_to_create_wrong_safety_impact_topic():
     create_user(USER1)
+    create_tag(USER1, TAG1)
     _topic = TOPIC1.copy()
     _topic["safety_impact"] = "test"
-    with pytest.raises(HTTPError, match="422: Unprocessable Entity"):
-        create_topic(USER1, _topic)
+
+    request = {**_topic}
+    del request["topic_id"]
+
+    response = client.post(f'/topics/{_topic["topic_id"]}', headers=headers(USER1), json=request)
+    assert response.status_code == 422
 
 
-def test_create_wrong_exploitation_topic():
+def test_it_should_return_422_when_use_try_to_create_wrong_exploitation_topic():
     create_user(USER1)
+    create_tag(USER1, TAG1)
     _topic = TOPIC1.copy()
     _topic["exploitation"] = "test"
-    with pytest.raises(HTTPError, match="422: Unprocessable Entity"):
-        create_topic(USER1, _topic)
+
+    request = {**_topic}
+    del request["topic_id"]
+
+    response = client.post(f'/topics/{_topic["topic_id"]}', headers=headers(USER1), json=request)
+    assert response.status_code == 422
 
 
-def test_create_topic_default_value_when_registered_empty():
+def test_default_value_is_set_when_ssvc_related_value_is_empty_in_creation():
     create_user(USER1)
+    create_tag(USER1, TAG1)
     _topic = TOPIC1.copy()
     del _topic["safety_impact"]
     del _topic["exploitation"]
     del _topic["automatable"]
     del _topic["hint_for_action"]
 
-    topic1 = create_topic(
-        USER1,
-        _topic,
-        actions=[ACTION1, ACTION2],
-    )
+    request = {**_topic}
+    del request["topic_id"]
 
-    assert topic1.safety_impact == SafetyImpactEnum.CATASTROPHIC
-    assert topic1.exploitation == ExploitationEnum.ACTIVE
-    assert topic1.automatable is True
-    assert topic1.hint_for_action is None
+    response = client.post(f'/topics/{_topic["topic_id"]}', headers=headers(USER1), json=request)
+    assert response.status_code == 200
+
+    responsed_topic = schemas.TopicCreateResponse(**response.json())
+    assert responsed_topic.safety_impact == SafetyImpactEnum.CATASTROPHIC
+    assert responsed_topic.exploitation == ExploitationEnum.ACTIVE
+    assert responsed_topic.automatable is True
+    assert responsed_topic.hint_for_action is None
 
 
 def test_create_too_long_action():


### PR DESCRIPTION
## PR の目的
- Topicテーブルの変更に伴い、test_topics.pyに異常系のテストケースを3つ追加しました。

## 経緯・意図・意思決定
- test_create_wrong_safety_impact_topicではsafety_impactの値を間違えて登録した場合、正しくエラーが出るか検証しています
- test_create_wrong_exploitation_topicではexploitationの値を間違えて登録した場合、正しくエラーが出るか検証しています
- test_create_topic_default_value_when_registered_emptyではsafety_impact, exploitation, automatable, hint_for_actionの4つの値を登録するときに空だった場合、デフォルトで設定している値になるか検証しています