### PR TITLE
add ondelete='SET NULL' option to Alert.ticket_id

### DIFF
--- a/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
+++ b/api/app/alembic/versions/3a0582573298_expand_for_ssvc.py
@@ -42,7 +42,7 @@ def upgrade() -> None:
     sa.Column('ticket_id', sa.String(length=36), nullable=True),
     sa.Column('alerted_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
     sa.Column('alert_content', sa.Text(), nullable=True),
-    sa.ForeignKeyConstraint(['ticket_id'], ['ticket.ticket_id'], ),
+    sa.ForeignKeyConstraint(['ticket_id'], ['ticket.ticket_id'], ondelete='SET NULL'),
     sa.PrimaryKeyConstraint('alert_id')
     )
     op.create_index(op.f('ix_alert_ticket_id'), 'alert', ['ticket_id'], unique=True)

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -363,7 +363,7 @@ class Threat(Base):
     tag = relationship("Tag", back_populates="threats")
     service = relationship("Service", back_populates="threats")
     topic = relationship("Topic", back_populates="threats")
-    ticket = relationship("Ticket", back_populates="threat")
+    ticket = relationship("Ticket", back_populates="threat", cascade="all, delete")
 
 
 class Ticket(Base):

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -404,7 +404,7 @@ class Alert(Base):
 
     alert_id: Mapped[StrUUID] = mapped_column(primary_key=True)
     ticket_id: Mapped[StrUUID | None] = mapped_column(
-        ForeignKey("ticket.ticket_id"), index=True, nullable=True, unique=True
+        ForeignKey("ticket.ticket_id", ondelete="SET NULL"), index=True, nullable=True, unique=True
     )
     alerted_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
     alert_content: Mapped[str | None] = mapped_column(nullable=True)  # WORKAROUND


### PR DESCRIPTION
## PR の目的

- Alert.ticket_id の外部キー制約に `ondelete="SET NULL"` オプションを追加しました。
  - Alert を残したまま Ticket が削除可能です。
