### PR TITLE
Topic/changed to refer to topic action from hint for action

### DIFF
--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -68,7 +68,7 @@ def create_threat(
                 continue
             action_tag_names_set |= set(action_tag_names)
 
-        exit_related_action: bool = False
+        exist_related_action: bool = False
         for action_tag_name in action_tag_names_set:
             tag_by_action = persistence.get_tag_by_name(db, action_tag_name)
             if (
@@ -76,10 +76,10 @@ def create_threat(
                 and tag_by_action
                 and (tag_by_action.tag_id == tag.tag_id or tag_by_action.tag_id == tag.parent_id)
             ):
-                exit_related_action = True
+                exist_related_action = True
                 break
 
-        if exit_related_action:
+        if exist_related_action:
             dependency = persistence.get_dependency_from_service_id_and_tag_id(
                 db, service.service_id, tag.tag_id
             )

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -57,23 +57,38 @@ def create_threat(
     )
     persistence.create_threat(db, threat)
 
-    topic = threat.topic
-    if topic and topic.hint_for_action:
-        now = datetime.now()
-        dependency = persistence.get_dependency_from_service_id_and_tag_id(
-            db, service.service_id, tag.tag_id
-        )
-        ticket = models.Ticket(
-            threat_id=str(threat.threat_id),
-            created_at=now,
-            updated_at=now,
-            ssvc_deployer_priority=ssvc.calculate_ssvc_deployer_priority(threat, dependency),
-        )
-        persistence.create_ticket(db, ticket)
+    actions = persistence.get_actions_by_topic_id(db, data.topic_id)
 
-        if alert := create_alert_from_ticket_if_meet_threshold(ticket):
-            persistence.create_alert(db, alert)
-            send_alert_to_pteam(alert)
+    if actions:
+        for action in actions:
+            action_tag_names = action.ext.get("tags")
+            assert action_tag_names
+            for action_tag_name in action_tag_names:
+                tag_by_action = persistence.get_tag_by_name(db, action_tag_name)
+                if (
+                    threat.topic
+                    and tag_by_action
+                    and (
+                        tag_by_action.tag_id == tag.tag_id or tag_by_action.tag_id == tag.parent_id
+                    )
+                ):
+                    now = datetime.now()
+                    dependency = persistence.get_dependency_from_service_id_and_tag_id(
+                        db, service.service_id, tag.tag_id
+                    )
+                    ticket = models.Ticket(
+                        threat_id=str(threat.threat_id),
+                        created_at=now,
+                        updated_at=now,
+                        ssvc_deployer_priority=ssvc.calculate_ssvc_deployer_priority(
+                            threat, dependency
+                        ),
+                    )
+                    persistence.create_ticket(db, ticket)
+
+                    if alert := create_alert_from_ticket_if_meet_threshold(ticket):
+                        persistence.create_alert(db, alert)
+                        send_alert_to_pteam(alert)
 
     db.commit()
 

--- a/api/app/tests/medium/constants.py
+++ b/api/app/tests/medium/constants.py
@@ -23,6 +23,7 @@ USER3 = {
 TAG1 = "alpha:alpha2:alpha3"
 TAG2 = "bravo:bravo2:bravo3"
 TAG3 = "charlie:charlie2:charlie3"
+TAG4 = "axios:npm:npm"
 GROUP1 = "Threatconnectome"
 GROUP2 = "RepoA"
 REF1 = [

--- a/api/app/tests/medium/constants.py
+++ b/api/app/tests/medium/constants.py
@@ -23,7 +23,6 @@ USER3 = {
 TAG1 = "alpha:alpha2:alpha3"
 TAG2 = "bravo:bravo2:bravo3"
 TAG3 = "charlie:charlie2:charlie3"
-TAG4 = "axios:npm:npm"
 GROUP1 = "Threatconnectome"
 GROUP2 = "RepoA"
 REF1 = [


### PR DESCRIPTION
## PR の目的
- Ticket必要判定をhint_for_actionではなくTopic Actionで行うように変更しました
- 既存のtest_ticket.pyを変更しました。

## 経緯・意図・意思決定
### API (api/app/routers/threat.py)
- Ticketテーブルを作る時の条件をtopicテーブルにあるhint_for_actionカラムで判定していたところをTopicActionテーブルで判定するようにしました。
- 判定条件は以下の通りです
1.Threatテーブルのtopic_idとTopicActionテーブルのtopic_idが合致している
2.TopicAction.ext.get("tags") を models.Tag に変換したもの（ActionTag と呼称します) が下記の条件のいずれかに合致してる
     - ActionTag.tag_id が Tag.tag_id と合致
     - ActionTag.tag_id が Tag.parent_id と合致

### テスト (api/app/tests/integrations/test_ticket.py, api/app/tests/medium/constants.py)
- TopicActionを参照するに伴い、既存のテストを変更しました
- テスト名を変更
test_ticket_should_not_be_created_when_topic_has_not_hint_for_action → test_ticket_should_not_be_created_when_topic_action_does_not_exist
test_ticket_should_be_created_when_topic_has_hint_for_action → test_ticket_should_be_created_when_topic_action_exist_and_both_action_and_tag_have_child_tags

test_ticket_should_be_created_when_topic_action_exist_and_both_action_and_tag_have_child_tagsの変更
- tagとserviceを紐づけて登録したいためupload_sbom_file apiを使用してtagを登録しました。
- test_syft_cyclonedx.jsonに存在するtagをTopicActionテーブルに追加したいため、api/app/tests/medium/constants.pyにTAG4 = "axios:npm:npm"を追加しました
- create_topic関数を使用するとtagも一緒に作成されてしまうため、client.postを使用しtopicとactionを作成しました
