### PR TITLE
Topic/api create threat at creating topic

### DIFF
--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 from typing import Sequence
 from urllib.parse import urljoin
 from uuid import UUID
@@ -151,42 +150,6 @@ def create_mail_alert_for_new_topic(
         ]
     )
     return subject, body
-
-
-def create_alert_from_ticket_if_meet_threshold(ticket: models.Ticket) -> models.Alert | None:
-    # abort if deployer_priofiry is not yet calclated
-    if ticket.ssvc_deployer_priority is None:
-        return None
-    if not (
-        int_priority := {
-            models.SSVCDeployerPriorityEnum.IMMEDIATE: 1,
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE: 2,
-            models.SSVCDeployerPriorityEnum.SCHEDULED: 3,
-            models.SSVCDeployerPriorityEnum.DEFER: 4,
-        }.get(ticket.ssvc_deployer_priority)
-    ):
-        raise ValueError(f"Invalid SSVCDeployerPriority: {ticket.ssvc_deployer_priority}")
-
-    service = ticket.threat.service
-    pteam = service.pteam
-    topic = ticket.threat.topic
-
-    # WORKAROUND
-    # use pteam.alert_threat_impact as threshold for alert.
-    # threshold should be defined in pteam and/or service.
-    int_threshold = pteam.alert_threat_impact or 4
-    if int_priority > int_threshold:
-        return None
-
-    now = datetime.now()
-    alert_content = topic.hint_for_action  # WORKAROUND
-    alert = models.Alert(
-        ticket_id=ticket.ticket_id,
-        alerted_at=now,
-        alert_content=alert_content,
-    )
-
-    return alert
 
 
 def send_alert_to_pteam(alert: models.Alert) -> None:

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -473,7 +473,7 @@ def get_dependency_from_service_id_and_tag_id(
             models.Dependency.service_id == str(service_id),
             models.Dependency.tag_id == str(tag_id),
         )
-    ).one_or_none()
+    ).first()  # FIXME: WORKAROUND to avoid getting multiple row
 
 
 ### Alert

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -1,11 +1,11 @@
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas, ssvc
+from app import models, persistence, schemas
 from app.alert import create_alert_from_ticket_if_meet_threshold, send_alert_to_pteam
+from app.common import create_ticket_from_threat_if_meet_condition
 from app.database import get_db
 
 router = APIRouter(prefix="/threats", tags=["threats"])
@@ -50,6 +50,9 @@ def create_threat(
     if service is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service")
 
+    if persistence.search_threats(db, data.tag_id, data.service_id, data.topic_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Threat already exists")
+
     threat = models.Threat(
         tag_id=str(data.tag_id),
         service_id=str(data.service_id),
@@ -57,43 +60,11 @@ def create_threat(
     )
     persistence.create_threat(db, threat)
 
-    actions = persistence.get_actions_by_topic_id(db, data.topic_id)
-    now = datetime.now()
-    action_tag_names_set: set = set()
-
-    if actions:
-        for action in actions:
-            action_tag_names = action.ext.get("tags")
-            if action_tag_names is None:
-                continue
-            action_tag_names_set |= set(action_tag_names)
-
-        exist_related_action: bool = False
-        for action_tag_name in action_tag_names_set:
-            tag_by_action = persistence.get_tag_by_name(db, action_tag_name)
-            if (
-                threat.topic
-                and tag_by_action
-                and (tag_by_action.tag_id == tag.tag_id or tag_by_action.tag_id == tag.parent_id)
-            ):
-                exist_related_action = True
-                break
-
-        if exist_related_action:
-            dependency = persistence.get_dependency_from_service_id_and_tag_id(
-                db, service.service_id, tag.tag_id
-            )
-            ticket = models.Ticket(
-                threat_id=str(threat.threat_id),
-                created_at=now,
-                updated_at=now,
-                ssvc_deployer_priority=ssvc.calculate_ssvc_deployer_priority(threat, dependency),
-            )
-            persistence.create_ticket(db, ticket)
-
-            if alert := create_alert_from_ticket_if_meet_threshold(ticket):
-                persistence.create_alert(db, alert)
-                send_alert_to_pteam(alert)
+    if ticket := create_ticket_from_threat_if_meet_condition(db, threat):
+        persistence.create_ticket(db, ticket)
+        if alert := create_alert_from_ticket_if_meet_threshold(ticket):
+            persistence.create_alert(db, alert)
+            send_alert_to_pteam(alert)
 
     db.commit()
 

--- a/api/app/tests/integrations/test_ticket.py
+++ b/api/app/tests/integrations/test_ticket.py
@@ -69,7 +69,7 @@ def test_ticket_should_be_created_when_topic_action_exist_and_both_action_and_ta
         "ext": {
             "tags": [tag_name_of_upload_sbom_file],
             "vulnerable_versions": {
-                tag_name_of_upload_sbom_file: ["<0.30"],
+                tag_name_of_upload_sbom_file: ["<0"],  # trigger auto close
             },
         },
     }


### PR DESCRIPTION
## PR の目的

- 新規トピック生成時に Threat を生成するように改修

## 経緯・意図・意思決定

- Threat 生成の条件は（前PRによるTopicActionチェックに加え）CurrentPTeamTopicTagStatus が「completed でも未来時刻の scheduled でもない」こと。
- Threat は Dependency 単位であるが、現状のステータス管理が PTeam 単位であるため、１つでも生成条件を満たすサービスが存在すると同PTeamの全てのサービスに対して生成される。
- 旧来のトピック生成時のアラート通知機能と、Threat 生成を発端とする Alert 通知機能が混在するため、両方の通知が行われる可能性がある。
- Topic から Dependency への relationship を追加している。関係性としては Threat 経由と Tag 経由があるため、後者であることを明示する意味で `dependencies_via_tag` としている。
