### PR TITLE
fix calculate_ssvc_deployer_priority function

### DIFF
--- a/api/app/ssvc.py
+++ b/api/app/ssvc.py
@@ -12,11 +12,20 @@ def calculate_ssvc_deployer_priority(
     mission_impact = calculate_mission_impact(threat.dependency.service, dependency)
     safety_impact = topic.safety_impact
     # TODO Calculation not implemented.
-    return (
-        models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE
-        if exploitation and exposure and automatable and mission_impact and safety_impact
-        else models.SSVCDeployerPriorityEnum.DEFER
-    )
+
+    if threat.topic.threat_impact == 1:
+        ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.IMMEDIATE
+    elif threat.topic.threat_impact == 2:
+        ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE
+    elif threat.topic.threat_impact == 3:
+        ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.SCHEDULED
+    elif threat.topic.threat_impact == 4:
+        ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.DEFER
+
+    if exploitation and exposure and automatable and mission_impact and safety_impact:
+        pass
+
+    return ssvc_deployer_priority
 
 
 def calculate_mission_impact(

--- a/api/app/ssvc.py
+++ b/api/app/ssvc.py
@@ -6,11 +6,11 @@ def calculate_ssvc_deployer_priority(
 ) -> models.SSVCDeployerPriorityEnum | None:
     topic = threat.topic
     service = threat.dependency.service
-    exploitation = topic.exploitation
-    exposure = service.exposure
-    automatable = topic.automatable
-    mission_impact = calculate_mission_impact(threat.dependency.service, dependency)
-    safety_impact = topic.safety_impact
+    exploitation = topic.exploitation  # noqa: F841
+    exposure = service.exposure  # noqa: F841
+    automatable = topic.automatable  # noqa: F841
+    mission_impact = calculate_mission_impact(threat.dependency.service, dependency)  # noqa: F841
+    safety_impact = topic.safety_impact  # noqa: F841
     # TODO Calculation not implemented.
 
     if threat.topic.threat_impact == 1:
@@ -21,9 +21,8 @@ def calculate_ssvc_deployer_priority(
         ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.SCHEDULED
     elif threat.topic.threat_impact == 4:
         ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.DEFER
-
-    if exploitation and exposure and automatable and mission_impact and safety_impact:
-        pass
+    else:
+        ssvc_deployer_priority = models.SSVCDeployerPriorityEnum.IMMEDIATE
 
     return ssvc_deployer_priority
 


### PR DESCRIPTION
## PR の目的
- calculate_ssvc_deployer_priority関数が返す値を固定値ではなく、topic.threat_impactを参照するようにしました。

## 経緯・意図・意思決定
- threat_impactの値をSSVCDeployerPriorityEnumに対応させました。
- exploitation, exposure, automatable, mission_impact, safety_impactを使用しないとruffに引っかかるため下記のコードのようにして、エラーがでないようにしています。
```
if exploitation and exposure and automatable and mission_impact and safety_impact:
        pass
```

