### PR TITLE
Delete/create threat

### DIFF
--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -1,17 +1,10 @@
-from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas
-from app.alert import send_alert_to_pteam
-from app.common import (
-    threat_meets_condition_to_create_ticket,
-    ticket_meets_condition_to_create_alert,
-)
+from app import persistence, schemas
 from app.database import get_db
-from app.ssvc import calculate_ssvc_deployer_priority
 
 router = APIRouter(prefix="/threats", tags=["threats"])
 
@@ -32,52 +25,6 @@ def get_threats(
     """
     threats = persistence.search_threats(db, dependency_id, topic_id)
     return threats
-
-
-@router.post("", response_model=schemas.ThreatResponse)
-def create_threat(
-    data: schemas.ThreatRequest,
-    db: Session = Depends(get_db),
-):
-    now = datetime.now()
-    dependency = persistence.get_dependency_by_id(db, data.dependency_id)
-    topic = persistence.get_topic_by_id(db, data.topic_id)
-
-    if dependency is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such dependency")
-
-    if topic is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such topic")
-
-    if persistence.search_threats(db, data.dependency_id, data.topic_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Threat already exists")
-
-    threat = models.Threat(
-        dependency_id=str(data.dependency_id),
-        topic_id=str(data.topic_id),
-    )
-    persistence.create_threat(db, threat)
-
-    if threat_meets_condition_to_create_ticket(db, threat):
-        ticket = models.Ticket(
-            threat_id=threat.threat_id,
-            created_at=now,
-            updated_at=now,
-            ssvc_deployer_priority=calculate_ssvc_deployer_priority(threat, threat.dependency),
-        )
-        persistence.create_ticket(db, ticket)
-        if ticket_meets_condition_to_create_alert(ticket):
-            alert = models.Alert(
-                ticket_id=ticket.ticket_id,
-                alerted_at=now,
-                alert_content=topic.hint_for_action,
-            )
-            persistence.create_alert(db, alert)
-            send_alert_to_pteam(alert)
-
-    db.commit()
-
-    return threat
 
 
 @router.get("/{threat_id}", response_model=schemas.ThreatResponse)

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app import persistence, schemas
@@ -39,18 +39,3 @@ def get_threat(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
 
     return threat
-
-
-@router.delete("/{threat_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_threat(
-    threat_id: UUID,
-    db: Session = Depends(get_db),
-):
-    threat = persistence.get_threat_by_id(db, threat_id)
-    if threat is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
-
-    persistence.delete_threat(db, threat)
-    db.commit()
-
-    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tests/integrations/test_ticket.py
+++ b/api/app/tests/integrations/test_ticket.py
@@ -1,22 +1,13 @@
 from datetime import datetime, timedelta
-from pathlib import Path
 
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas
+from app import models
 from app.main import app
 from app.tests.common import threat_utils
 from app.tests.medium.constants import ACTION1, PTEAM1, TOPIC1, USER1
-from app.tests.medium.exceptions import HTTPError
-from app.tests.medium.utils import (
-    assert_200,
-    create_pteam,
-    create_user,
-    file_upload_headers,
-    headers,
-)
 
 client = TestClient(app)
 
@@ -27,7 +18,7 @@ header_threat = {
 
 
 def test_ticket_should_not_be_created_when_topic_action_does_not_exist(testdb: Session):
-    threat = threat_utils.create_threat(testdb, USER1, PTEAM1, TOPIC1)
+    threat = threat_utils.create_threat(testdb, USER1, PTEAM1, TOPIC1, None)
 
     ticket = testdb.scalars(
         select(models.Ticket).where(models.Ticket.threat_id == str(threat.threat_id))
@@ -38,84 +29,10 @@ def test_ticket_should_not_be_created_when_topic_action_does_not_exist(testdb: S
 def test_ticket_should_be_created_when_topic_action_exist_and_both_action_and_tag_have_child_tags(
     testdb: Session,
 ):
-    # Given
-    # Topic has been created with topic action table.
-    create_user(USER1)
-    pteam1 = create_pteam(USER1, PTEAM1)
-
-    # Uploaded sbom file.
-    params: dict[str, str | bool] = {"group": "threatconnectome", "force_mode": True}
-    sbom_file = (
-        Path(__file__).resolve().parent.parent
-        / "common"
-        / "upload_test"
-        / "test_syft_cyclonedx.json"
-    )
-    with open(sbom_file, "rb") as tags:
-        data = assert_200(
-            client.post(
-                f"/pteams/{pteam1.pteam_id}/upload_sbom_file",
-                headers=file_upload_headers(USER1),
-                params=params,
-                files={"file": tags},
-            )
-        )
-
-    # create topic and topic action table
-    tag_name_of_upload_sbom_file = data[0]["tag_name"]
-
-    action = {
-        **ACTION1,
-        "ext": {
-            "tags": [tag_name_of_upload_sbom_file],
-            "vulnerable_versions": {
-                tag_name_of_upload_sbom_file: ["<0"],  # trigger auto close
-            },
-        },
-    }
-
-    topic = {
-        **TOPIC1,
-        "tags": [tag_name_of_upload_sbom_file],
-        "actions": [action],
-    }
-
-    request = {**topic}
-    del request["topic_id"]
-
-    response = client.post(f'/topics/{topic["topic_id"]}', headers=headers(USER1), json=request)
-
-    assert response.status_code == 200
-    responsed_topic = schemas.TopicCreateResponse(**response.json())
-
-    # Create post threats request.
-    service_id = testdb.scalars(
-        select(models.Service.service_id).where(
-            models.Service.pteam_id == str(pteam1.pteam_id),
-            models.Service.service_name == str(params["group"]),
-        )
-    ).one_or_none()
-
-    dependency = persistence.get_dependency_from_service_id_and_tag_id(
-        testdb, str(service_id), data[0]["tag_id"]
-    )
-
-    if dependency:
-        request = {
-            "dependency_id": str(dependency.dependency_id),
-            "topic_id": str(responsed_topic.topic_id),
-        }
-
-    # When
-    # Post threats request.
-    response = client.post("/threats", headers=header_threat, json=request)
-    if response.status_code != 200:
-        raise HTTPError(response)
+    threat = threat_utils.create_threat(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
 
     # Then
     # Registered in the Ticket table.
-    threat = schemas.ThreatResponse(**response.json())
-
     ticket = testdb.scalars(
         select(models.Ticket).where(models.Ticket.threat_id == str(threat.threat_id))
     ).one_or_none()

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -57,9 +57,6 @@ def test_get_threat(threat1: schemas.ThreatResponse, threat2: schemas.ThreatResp
     assert data["dependency_id"] == str(threat1.dependency_id)
     assert data["topic_id"] == str(threat1.topic_id)
 
-    response = client.get("/threats", headers=header_threat)
-    print(response.json())
-
 
 def test_get_threat_no_data():
     with pytest.raises(HTTPError, match=r"404: Not Found: No such threat"):

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -357,11 +357,3 @@ def test_create_threat(testdb: Session):
         for threat in threats:
             assert dependency.dependency_id == threat.dependency_id
             assert str(responsed_topic.topic_id) == threat.topic_id
-
-
-def test_delete_threat(threat1: schemas.ThreatResponse):
-    response = client.delete(f"/threats/{threat1.threat_id}", headers=header_threat)
-    assert response.status_code == 204
-
-    data = assert_200(client.get("/threats", headers=header_threat))
-    assert len(data) == 0

--- a/api/app/tests/requests/test_threat.py
+++ b/api/app/tests/requests/test_threat.py
@@ -1,57 +1,160 @@
+import uuid
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import insert, select
 from sqlalchemy.orm import Session
 
 from app import models, persistence, schemas
 from app.main import app
 from app.tests.common import threat_utils
-from app.tests.medium.constants import PTEAM1, PTEAM2, TOPIC1, TOPIC2, USER1, USER2
+from app.tests.medium.constants import (
+    ACTION1,
+    PTEAM1,
+    PTEAM2,
+    TAG1,
+    TAG2,
+    TOPIC1,
+    TOPIC2,
+    USER1,
+    USER2,
+)
 from app.tests.medium.exceptions import HTTPError
 from app.tests.medium.utils import (
     assert_200,
     create_pteam,
+    create_tag,
     create_topic,
     create_user,
     file_upload_headers,
+    headers,
 )
 
 client = TestClient(app)
 
-headers = {
+header_threat = {
     "accept": "application/json",
     "Content-Type": "application/json",
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def threat1(testdb: Session) -> schemas.ThreatResponse:
-    return threat_utils.create_threat(testdb, USER1, PTEAM1, TOPIC1)
+    return threat_utils.create_threat(testdb, USER1, PTEAM1, TOPIC1, None)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def threat2(testdb: Session) -> schemas.ThreatResponse:
-    return threat_utils.create_threat(testdb, USER2, PTEAM2, TOPIC2)
+    return threat_utils.create_threat(testdb, USER2, PTEAM2, TOPIC2, None)
 
 
 def test_get_threat(threat1: schemas.ThreatResponse, threat2: schemas.ThreatResponse):
 
-    data = assert_200(client.get("/threats/" + str(threat1.threat_id), headers=headers))
+    data = assert_200(client.get("/threats/" + str(threat1.threat_id), headers=header_threat))
     assert data["threat_id"] == str(threat1.threat_id)
     assert data["dependency_id"] == str(threat1.dependency_id)
     assert data["topic_id"] == str(threat1.topic_id)
 
+    response = client.get("/threats", headers=header_threat)
+    print(response.json())
+
 
 def test_get_threat_no_data():
     with pytest.raises(HTTPError, match=r"404: Not Found: No such threat"):
-        assert_200(client.get("/threats/3fa85f64-5717-4562-b3fc-2c963f66afa6", headers=headers))
+        assert_200(
+            client.get("/threats/3fa85f64-5717-4562-b3fc-2c963f66afa6", headers=header_threat)
+        )
 
 
-def test_get_all_threats(threat1: schemas.ThreatResponse, threat2: schemas.ThreatResponse):
-    data = assert_200(client.get("/threats", headers=headers))
+def test_get_all_threats(testdb: Session):
+    # create pteam
+    create_user(USER1)
+    pteam1 = create_pteam(USER1, PTEAM1)
+
+    # create topic
+    tag1 = create_tag(USER1, TAG1)
+    tag2 = create_tag(USER1, TAG2)
+
+    action1 = {
+        **ACTION1,
+        "ext": {
+            "tags": [tag1.parent_name],
+            "vulnerable_versions": {
+                tag1.parent_name: ["<0.30"],
+            },
+        },
+    }
+    action2 = {
+        **ACTION1,
+        "ext": {
+            "tags": [tag2.parent_name],
+            "vulnerable_versions": {
+                tag1.parent_name: ["<0.30"],
+            },
+        },
+    }
+
+    topic1 = create_topic(USER1, {**TOPIC1, "tags": [tag1.parent_name]}, actions=[action1])
+    topic2 = create_topic(USER1, {**TOPIC2, "tags": [tag2.parent_name]}, actions=[action2])
+
+    # create service
+    group1_name = "group_x"
+    service1_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Service).values(
+            service_id=service1_id, pteam_id=pteam1.pteam_id, service_name=group1_name
+        )
+    )
+
+    group2_name = "group_y"
+    service2_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Service).values(
+            service_id=service2_id, pteam_id=pteam1.pteam_id, service_name=group2_name
+        )
+    )
+
+    # create dependency
+    dependency1_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Dependency).values(
+            dependency_id=dependency1_id,
+            service_id=service1_id,
+            tag_id=str(tag1.tag_id),
+            version="1.0",
+            target="Pipfile.lock",
+        )
+    )
+
+    dependency2_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Dependency).values(
+            dependency_id=dependency2_id,
+            service_id=service2_id,
+            tag_id=str(tag2.tag_id),
+            version="1.0",
+            target="Pipfile.lock",
+        )
+    )
+
+    # create threat
+    threat1 = models.Threat(
+        dependency_id=str(dependency1_id),
+        topic_id=str(topic1.topic_id),
+    )
+
+    threat2 = models.Threat(
+        dependency_id=str(dependency2_id),
+        topic_id=str(topic2.topic_id),
+    )
+
+    persistence.create_threat(testdb, threat1)
+    persistence.create_threat(testdb, threat2)
+    testdb.commit()
+
+    data = assert_200(client.get("/threats", headers=header_threat))
     assert len(data) == 2
 
     assert (data[0]["threat_id"] == str(threat1.threat_id)) or (
@@ -85,19 +188,103 @@ def test_get_all_threats(threat1: schemas.ThreatResponse, threat2: schemas.Threa
     ],
 )
 def test_get_all_threats_with_param(
+    testdb: Session,
     exist_dependency_id: bool,
     exist_topic_id: bool,
     expected_len: int,
-    threat1: schemas.ThreatResponse,
-    threat2: schemas.ThreatResponse,
 ):
+    # create pteam
+    create_user(USER1)
+    pteam1 = create_pteam(USER1, PTEAM1)
+
+    # create topic
+    tag1 = create_tag(USER1, TAG1)
+    tag2 = create_tag(USER1, TAG2)
+
+    action1 = {
+        **ACTION1,
+        "ext": {
+            "tags": [tag1.parent_name],
+            "vulnerable_versions": {
+                tag1.parent_name: ["<0.30"],
+            },
+        },
+    }
+    action2 = {
+        **ACTION1,
+        "ext": {
+            "tags": [tag2.parent_name],
+            "vulnerable_versions": {
+                tag1.parent_name: ["<0.30"],
+            },
+        },
+    }
+
+    topic1 = create_topic(USER1, {**TOPIC1, "tags": [tag1.parent_name]}, actions=[action1])
+    topic2 = create_topic(USER1, {**TOPIC2, "tags": [tag2.parent_name]}, actions=[action2])
+
+    # create service
+    group1_name = "group_x"
+    service1_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Service).values(
+            service_id=service1_id, pteam_id=pteam1.pteam_id, service_name=group1_name
+        )
+    )
+
+    group2_name = "group_y"
+    service2_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Service).values(
+            service_id=service2_id, pteam_id=pteam1.pteam_id, service_name=group2_name
+        )
+    )
+
+    # create dependency
+    dependency1_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Dependency).values(
+            dependency_id=dependency1_id,
+            service_id=service1_id,
+            tag_id=str(tag1.tag_id),
+            version="1.0",
+            target="Pipfile.lock",
+        )
+    )
+
+    dependency2_id = str(uuid.uuid4())
+    testdb.execute(
+        insert(models.Dependency).values(
+            dependency_id=dependency2_id,
+            service_id=service2_id,
+            tag_id=str(tag2.tag_id),
+            version="1.0",
+            target="Pipfile.lock",
+        )
+    )
+
+    # create threat
+    threat1 = models.Threat(
+        dependency_id=str(dependency1_id),
+        topic_id=str(topic1.topic_id),
+    )
+
+    threat2 = models.Threat(
+        dependency_id=str(dependency2_id),
+        topic_id=str(topic2.topic_id),
+    )
+
+    persistence.create_threat(testdb, threat1)
+    persistence.create_threat(testdb, threat2)
+    testdb.commit()
+
     params = {}
     if exist_dependency_id:
         params["dependency_id"] = str(threat1.dependency_id)
     if exist_topic_id:
         params["topic_id"] = str(threat1.topic_id)
 
-    response = client.get("/threats", headers=headers, params=params)
+    response = client.get("/threats", headers=header_threat, params=params)
     if response.status_code != 200:
         raise HTTPError(response)
     data = response.json()
@@ -107,9 +294,10 @@ def test_get_all_threats_with_param(
 def test_create_threat(testdb: Session):
     create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)
-    topic1 = create_topic(USER1, TOPIC1)
 
-    params: Dict[str, Union[str, bool]] = {"group": "threatconnectome", "force_mode": True}
+    # Uploaded sbom file.
+    # Create tag, service and dependency table
+    params: Dict[str, str | bool] = {"group": "threatconnectome", "force_mode": True}
     sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
     with open(sbom_file, "rb") as tags:
         data = assert_200(
@@ -123,6 +311,34 @@ def test_create_threat(testdb: Session):
 
     tag_id = data[0]["tag_id"]
 
+    # Create topic and topicaction table
+    tag_name_of_upload_sbom_file = data[0]["tag_name"]
+
+    action = {
+        **ACTION1,
+        "ext": {
+            "tags": [tag_name_of_upload_sbom_file],
+            "vulnerable_versions": {
+                tag_name_of_upload_sbom_file: ["<100"],  # Prevent auto close from being executed
+            },
+        },
+    }
+
+    topic = {
+        **TOPIC1,
+        "tags": [tag_name_of_upload_sbom_file],
+        "actions": [action],
+    }
+
+    request = {**topic}
+    del request["topic_id"]
+
+    response = client.post(f'/topics/{topic["topic_id"]}', headers=headers(USER1), json=request)
+
+    assert response.status_code == 200
+    responsed_topic = schemas.TopicCreateResponse(**response.json())
+
+    # Saerch threat table
     service_id = testdb.scalars(
         select(models.Service.service_id).where(
             models.Service.pteam_id == str(pteam1.pteam_id),
@@ -135,24 +351,20 @@ def test_create_threat(testdb: Session):
     )
 
     if dependency:
-        request = {
-            "dependency_id": str(dependency.dependency_id),
-            "topic_id": str(topic1.topic_id),
-        }
+        threats = persistence.search_threats(
+            testdb, str(dependency.dependency_id), str(responsed_topic.topic_id)
+        )
 
-    response = client.post("/threats", headers=headers, json=request)
-    if response.status_code != 200:
-        raise HTTPError(response)
+        assert threats
 
-    threat = schemas.ThreatResponse(**response.json())
-
-    assert request["dependency_id"] == str(threat.dependency_id)
-    assert request["topic_id"] == str(threat.topic_id)
+        for threat in threats:
+            assert dependency.dependency_id == threat.dependency_id
+            assert str(responsed_topic.topic_id) == threat.topic_id
 
 
 def test_delete_threat(threat1: schemas.ThreatResponse):
-    response = client.delete(f"/threats/{threat1.threat_id}", headers=headers)
+    response = client.delete(f"/threats/{threat1.threat_id}", headers=header_threat)
     assert response.status_code == 204
 
-    data = assert_200(client.get("/threats", headers=headers))
+    data = assert_200(client.get("/threats", headers=header_threat))
     assert len(data) == 0


### PR DESCRIPTION
## PR の目的
- create_threat(POST)を削除しました。
- create_threatを削除したため、テスト修正しました。

## 経緯・意図・意思決定
### api/app/tests/common/threat_utils.py
- 既存のテストコードでpostしてthreatテーブルを作成していた部分を変更しました。
- postではなく、create_topicして作成されたthreatテーブルを使用するようにしました。

### api/app/tests/integrations/test_ticket.py
- test_ticket_should_be_created_when_topic_action_exist_and_both_action_and_tag_have_child_tagsに書かれている内容がthreat_utils.pyと似ていたため、置き換えました。

### api/app/tests/integrations/test_ticket_status.py
- postしてthreatとticketテーブルを作成していた部分を変更しました。
- persistenceの関数を使って、直接データベースにthreatとticketを登録するように変更しました。

### api/app/tests/requests/test_threat.py
- test_get_all_threatsf, test_get_all_threats_with_paramについては@pytest.fixture threat1, threat2を使用してデータを登録していましたが、threat_utils.pyの内容をcreate_topicからthreatテーブルを作成するように変更したため、テスト自体を大幅に変更する必要がててきました。本テストで確かめたいことは、@pytest.fixture threat1, threat2でデータ登録できるかでなはく、get_threat APIが正常に動作しているかを検証したいので、データ登録はpersistenceの関数を使用して直接データベースに入れるように変更しました。
- test_create_threatについてはpost APIを削除したため、create_topicをしてthreatテーブルにデータが登録できているかを検証するように変更しました。
