### PR TITLE
Topic/api get service summary

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -402,9 +402,11 @@ class Ticket(Base):
     threat = relationship("Threat", back_populates="ticket")
     alert = relationship("Alert", uselist=False, back_populates="ticket")
     ticket_statuses = relationship(
-        "TicketStatus", uselist=False, back_populates="ticket", cascade="all, delete-orphan"
+        "TicketStatus", uselist=False, back_populates="ticket", cascade="all, delete"
     )
-    curent_ticket_status = relationship("CurrentTicketStatus", back_populates="ticket")
+    current_ticket_status: Mapped["CurrentTicketStatus"] = relationship(
+        "CurrentTicketStatus", uselist=False, back_populates="ticket", cascade="all, delete"
+    )
 
 
 class TicketStatus(Base):
@@ -451,7 +453,7 @@ class CurrentTicketStatus(Base):
     threat_impact: Mapped[int | None]
     updated_at: Mapped[datetime | None]
 
-    ticket = relationship("Ticket", back_populates="curent_ticket_status")
+    ticket = relationship("Ticket", back_populates="current_ticket_status")
 
 
 class Alert(Base):

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -122,6 +122,11 @@ class PTeamGroupResponse(ORMModel):
     groups: list[str] = []
 
 
+class PTeamServiceResponse(ORMModel):
+    service_name: str
+    service_id: UUID
+
+
 class PTeamtagRequest(ORMModel):
     references: list[dict] | None = None
 
@@ -247,6 +252,7 @@ class TopicUpdateRequest(ORMModel):
 class PTeamInfo(PTeamEntry):
     alert_slack: Slack
     alert_threat_impact: int
+    services: list[PTeamServiceResponse]
     ateams: list[ATeamEntry]
     alert_mail: Mail
 
@@ -502,6 +508,21 @@ class PTeamTagSummary(ExtTagResponse):
 class PTeamTagsSummary(ORMModel):
     threat_impact_count: dict[str, int]  # str(threat_impact): tags count
     tags: list[PTeamTagSummary]
+
+
+class PTeamServiceTagsSummary(ORMModel):
+    class PTeamServiceTagSummary(ORMModel):
+        tag_id: UUID
+        tag_name: str
+        parent_id: UUID | None
+        parent_name: str | None
+        references: list[dict]
+        threat_impact: int | None
+        updated_at: datetime | None
+        status_count: dict[str, int]  # TopicStatusType.value: tickets count
+
+    threat_impact_count: dict[str, int]  # str(threat_impact): tags count
+    tags: list[PTeamServiceTagSummary]
 
 
 class SlackCheckRequest(ORMModel):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4117,3 +4117,187 @@ def test_upload_pteam_sbom_file_wrong_content_format():
                     files={"file": tags},
                 )
             )
+
+
+class TestGetPTeamServiceTagsSummary:
+    @staticmethod
+    def _get_access_token(user: dict) -> str:
+        body = {
+            "username": user["email"],
+            "password": user["pass"],
+        }
+        response = client.post("/auth/token", data=body)
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        return data["access_token"]
+
+    @staticmethod
+    def _get_service_id_by_service_name(user: dict, pteam_id: UUID | str, service_name: str) -> str:
+        response = client.get(f"/pteams/{pteam_id}/services", headers=headers(user))
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        service = next(filter(lambda x: x["service_name"] == service_name, data))
+        return service["service_id"]
+
+    def test_returns_summary_even_if_no_topics(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+
+        # no topics, no threats, no tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "references": [
+                    {
+                        "target": test_target,
+                        "version": test_version,
+                        "service": test_service,
+                    },
+                ],
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_even_if_no_threats(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # create topic1
+        create_topic(USER1, TOPIC1)  # Tag1
+
+        # no threats nor tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "references": [
+                    {
+                        "target": test_target,
+                        "version": test_version,
+                        "service": test_service,
+                    },
+                ],
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_if_having_alerted_ticket(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        vulnerable_version = "1.2.0"  # vulnerable
+        refs0 = {tag1.tag_name: [(test_target, vulnerable_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # add actionable topic1
+        action1 = {
+            "action": "action one",
+            "action_type": "elimination",
+            "recommended": True,
+            "ext": {
+                "tags": [tag1.tag_name],
+                "vulnerable_versions": {
+                    tag1.tag_name: ["< 1.2.3"],  # > vulnerable_version
+                },
+            },
+        }
+        topic1 = create_topic(USER1, TOPIC1, actions=[action1])  # Tag1
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {
+            **{"1": 0, "2": 0, "3": 0, "4": 0},
+            str(topic1.threat_impact): 1,
+        }
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "references": [
+                    {
+                        "target": test_target,
+                        "version": vulnerable_version,
+                        "service": test_service,
+                    },
+                ],
+                "threat_impact": topic1.threat_impact,
+                "updated_at": datetime.isoformat(topic1.updated_at),
+                "status_count": {
+                    **{status_type.value: 0 for status_type in list(models.TopicStatusType)},
+                    models.TopicStatusType.alerted.value: 1,  # default status is ALERTED
+                },
+            }
+        ]


### PR DESCRIPTION
## PR の目的

- pteam_id, service_id を指定し、Tag で束ねたサマリを返す api を実装
  - 旧来のサマリと仕様が異なる点に注意
    - status_count は Ticket の数（threat_impact_count は従来通り Tag の数）
    - Ticket が発行されていない Threat（Topic）は計上の対象外

----
- service_id を得る api が存在しなかったため、そちらも追加
  - 既存のグループ取得とはスキーマが異なるので新設
  - pteam 情報（schemas.PTeamInfo）にも services を追加
- テストが不十分なので別途追加予定
- サマリ算出をループで回していることもあり、処理性能としては低い
  - チューニングは別タスクで行う予定（後日）