### PR TITLE
fix test_get_pteam_services

### DIFF
--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -119,10 +119,6 @@ class ExtTagResponse(TagResponse):
 
 
 class PTeamServiceResponse(ORMModel):
-    services: list[str] = []
-
-
-class PTeamServiceResponse(ORMModel):
     service_name: str
     service_id: UUID
 

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -141,9 +141,9 @@ def get_pteam_tags(user: dict, pteam_id: str) -> list[schemas.ExtTagResponse]:
     return [schemas.ExtTagResponse(**item) for item in data]
 
 
-def get_pteam_services(user: dict, pteam_id: str) -> schemas.PTeamServiceResponse:
+def get_pteam_services(user: dict, pteam_id: str) -> list[schemas.PTeamServiceResponse]:
     data = assert_200(client.get(f"/pteams/{pteam_id}/services", headers=headers(user)))
-    return schemas.PTeamServiceResponse(**data)
+    return [schemas.PTeamServiceResponse(**item) for item in data]
 
 
 def create_ateam(user: dict, ateam: dict) -> schemas.ATeamInfo:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -317,7 +317,7 @@ def test_get_pteam_services():
     # no services at created pteam
     services1 = get_pteam_services(USER1, pteam1.pteam_id)
     services2 = get_pteam_services(USER1, pteam2.pteam_id)
-    assert services1.services == services2.services == []
+    assert services1 == services2 == []
 
     refs0 = {TAG1: [("fake target", "fake version")]}
 
@@ -327,8 +327,8 @@ def test_get_pteam_services():
 
     services1a = get_pteam_services(USER1, pteam1.pteam_id)
     services2a = get_pteam_services(USER1, pteam2.pteam_id)
-    assert services1a.services == [service_x]
-    assert services2a.services == []
+    assert services1a[0].service_name == service_x
+    assert services2a == []
 
     # add grserviceoup y to pteam2
     service_y = "service_y"
@@ -336,16 +336,18 @@ def test_get_pteam_services():
 
     services1b = get_pteam_services(USER1, pteam1.pteam_id)
     services2b = get_pteam_services(USER1, pteam2.pteam_id)
-    assert services1b.services == [service_x]
-    assert services2b.services == [service_y]
+    assert services1b[0].service_name == service_x
+    assert services2b[0].service_name == service_y
 
     # add service y to pteam1
     upload_pteam_tags(USER1, pteam1.pteam_id, service_y, refs0)
 
     services1c = get_pteam_services(USER1, pteam1.pteam_id)
     services2c = get_pteam_services(USER1, pteam2.pteam_id)
-    assert set(services1c.services) == {service_x, service_y}
-    assert services2c.services == [service_y]
+    print(services1c)
+    assert services1c[0].service_name == service_x or service_y
+    assert services1c[1].service_name == service_x or service_y
+    assert services2c[0].service_name == service_y
 
     # only members get services
     with pytest.raises(HTTPError, match=r"403: Forbidden: Not a pteam member"):


### PR DESCRIPTION
## PR の目的
- test_pteams.py::test_get_pteam_servicesで起きていたエラーを修正しました。

## 経緯・意図・意思決定
- test_get_pteam_servicesで検証しているAPIがリスト型でレスポンスするようになったため、テストケースを修正しました。
- 以前使用していたschemasにあったPTeamServiceResponseを削除しました。


