### PR TITLE
Topic/create currentticketstatus

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app import command, models, persistence, schemas, ticket_manager
+from app import command, models, persistence, schemas
 from app.constants import MEMBER_UUID, NOT_MEMBER_UUID, SYSTEM_UUID
 from app.version import (
     PackageFamily,
@@ -324,7 +324,6 @@ def _complete_topic(
         tag,
         topicStatusRequest,
     )
-    ticket_manager.set_ticket_statuses(db, system_account, pteam, topic, tag, topicStatusRequest)
 
 
 def pteamtag_try_auto_close_topic(

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -9,8 +9,8 @@ from fastapi.responses import Response
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
-from app import command, models, persistence, schemas
-from app.alert import alert_new_topic, send_alert_to_pteam
+from app import command, models, persistence, schemas, ticket_manager
+from app.alert import alert_new_topic
 from app.auth import get_current_user, token_scheme
 from app.common import (
     auto_close_by_topic,
@@ -19,11 +19,8 @@ from app.common import (
     check_topic_action_tags_integrity,
     get_or_create_misp_tag,
     get_sorted_topics,
-    threat_meets_condition_to_create_ticket,
-    ticket_meets_condition_to_create_alert,
 )
 from app.database import get_db
-from app.ssvc import calculate_ssvc_deployer_priority
 
 router = APIRouter(prefix="/topics", tags=["topics"])
 
@@ -370,25 +367,7 @@ def create_topic(
         ):
             continue  # skip if already exists
         persistence.create_threat(db, threat)
-        if threat_meets_condition_to_create_ticket(db, threat):
-            dependency = persistence.get_dependency_from_service_id_and_tag_id(
-                db, threat.dependency.service_id, threat.dependency.tag.tag_id
-            )
-            ticket = models.Ticket(
-                threat_id=threat.threat_id,
-                created_at=now,
-                updated_at=now,
-                ssvc_deployer_priority=calculate_ssvc_deployer_priority(threat, dependency),
-            )
-            persistence.create_ticket(db, ticket)
-            if ticket_meets_condition_to_create_alert(ticket):
-                alert = models.Alert(
-                    ticket_id=ticket.ticket_id,
-                    alerted_at=now,
-                    alert_content=data.hint_for_action,
-                )
-                persistence.create_alert(db, alert)
-                send_alert_to_pteam(alert)
+        ticket_manager.create_ticket(db, threat, data.hint_for_action)
 
     db.commit()
 

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -367,7 +367,7 @@ def create_topic(
         ):
             continue  # skip if already exists
         persistence.create_threat(db, threat)
-        ticket_manager.create_ticket(db, threat, data.hint_for_action)
+        ticket_manager.create_ticket(db, threat)
 
     db.commit()
 

--- a/api/app/ticket_manager.py
+++ b/api/app/ticket_manager.py
@@ -3,6 +3,49 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 
 from app import models, persistence, schemas
+from app.alert import send_alert_to_pteam
+from app.common import (
+    threat_meets_condition_to_create_ticket,
+    ticket_meets_condition_to_create_alert,
+)
+from app.ssvc import calculate_ssvc_deployer_priority
+
+
+def create_ticket(db: Session, threat: models.Threat, alert_content: str | None):
+    if not threat_meets_condition_to_create_ticket(db, threat):
+        return
+
+    # create Ticket
+    dependency = persistence.get_dependency_from_service_id_and_tag_id(
+        db, threat.dependency.service_id, threat.dependency.tag.tag_id
+    )
+    now = datetime.now()
+    ticket = models.Ticket(
+        threat_id=threat.threat_id,
+        created_at=now,
+        updated_at=now,
+        ssvc_deployer_priority=calculate_ssvc_deployer_priority(threat, dependency),
+    )
+    persistence.create_ticket(db, ticket)
+
+    # create CurrentTicketStatus without TicketStatus
+    current_status = models.CurrentTicketStatus(
+        ticket_id=ticket.ticket_id,
+        status_id=None,
+        topic_status=models.TopicStatusType.alerted,
+        threat_impact=threat.topic.threat_impact,
+        updated_at=threat.topic.updated_at,
+    )
+    persistence.create_current_ticket_status(db, current_status)
+
+    if ticket_meets_condition_to_create_alert(ticket):
+        alert = models.Alert(
+            ticket_id=ticket.ticket_id,
+            alerted_at=now,
+            alert_content=alert_content,
+        )
+        persistence.create_alert(db, alert)
+        send_alert_to_pteam(alert)
 
 
 def set_ticket_statuses(

--- a/api/app/ticket_manager.py
+++ b/api/app/ticket_manager.py
@@ -11,7 +11,7 @@ from app.common import (
 from app.ssvc import calculate_ssvc_deployer_priority
 
 
-def create_ticket(db: Session, threat: models.Threat, alert_content: str | None):
+def create_ticket(db: Session, threat: models.Threat):
     if not threat_meets_condition_to_create_ticket(db, threat):
         return
 
@@ -42,7 +42,7 @@ def create_ticket(db: Session, threat: models.Threat, alert_content: str | None)
         alert = models.Alert(
             ticket_id=ticket.ticket_id,
             alerted_at=now,
-            alert_content=alert_content,
+            alert_content=threat.topic.hint_for_action,
         )
         persistence.create_alert(db, alert)
         send_alert_to_pteam(alert)


### PR DESCRIPTION
## PR の目的
- CurrentTicketStatusの更新を整理
1. complete_topic 内で set_ticket_statuses()呼び出しは削除。　
1. Ticket作成時、TopicStatusType = alerted、でCurrentTicketStatusを生成。
　TicketStatusは生成しない。

<br>

## 経緯・意図・意思決定
- pteam.alert_threat_impactの変更によりアラート条件を満たさなくなった場合、
Ticketに関係ないためステータス変更も無し。
- 課題 (後日対応)
Ticket生成時、TicketStatusを生成すべきか？
その場合はデータとして何を格納するのか（ユーザを記録するなら何のためにどのユーザを？
