### PR TITLE
Topic/create status api

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -534,13 +534,13 @@ def get_last_updated_at_in_current_pteam_topic_tag_status(
 def pteam_topic_tag_status_to_response(
     db: Session,
     status: models.PTeamTopicTagStatus,
-) -> schemas.TopicStatusResponse:
+) -> schemas.PTeamTopicStatusResponse:
     actionlogs = db.scalars(
         select(models.ActionLog)
         .where(func.array_position(status.logging_ids, models.ActionLog.logging_id).is_not(None))
         .order_by(models.ActionLog.executed_at.desc())
     ).all()
-    return schemas.TopicStatusResponse(
+    return schemas.PTeamTopicStatusResponse(
         status_id=UUID(status.status_id),
         topic_id=UUID(status.topic_id),
         pteam_id=UUID(status.pteam_id),

--- a/api/app/common.py
+++ b/api/app/common.py
@@ -213,7 +213,7 @@ def set_pteam_topic_status_internal(
     topic: models.Topic,
     tag: models.Tag,  # should be PTeamTag, not TopicTag
     data: schemas.TopicStatusRequest,
-) -> schemas.TopicStatusResponse | None:
+) -> schemas.PTeamTopicStatusResponse | None:
     current_status = persistence.get_current_pteam_topic_tag_status(
         db, pteam.pteam_id, topic.topic_id, tag.tag_id
     )

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -401,9 +401,7 @@ class Ticket(Base):
 
     threat = relationship("Threat", back_populates="ticket")
     alert = relationship("Alert", uselist=False, back_populates="ticket")
-    ticket_statuses = relationship(
-        "TicketStatus", back_populates="ticket", cascade="all, delete"
-    )
+    ticket_statuses = relationship("TicketStatus", back_populates="ticket", cascade="all, delete")
     current_ticket_status: Mapped["CurrentTicketStatus"] = relationship(
         "CurrentTicketStatus", uselist=False, back_populates="ticket", cascade="all, delete"
     )
@@ -433,6 +431,9 @@ class TicketStatus(Base):
     created_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
 
     ticket = relationship("Ticket", back_populates="ticket_statuses")
+    current_ticket_status = relationship(
+        "CurrentTicketStatus", uselist=False, back_populates="ticket_status"
+    )
 
 
 class CurrentTicketStatus(Base):
@@ -455,6 +456,7 @@ class CurrentTicketStatus(Base):
     updated_at: Mapped[datetime | None]
 
     ticket = relationship("Ticket", back_populates="current_ticket_status")
+    ticket_status = relationship("TicketStatus", back_populates="current_ticket_status")
 
 
 class Alert(Base):

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -402,7 +402,7 @@ class Ticket(Base):
     threat = relationship("Threat", back_populates="ticket")
     alert = relationship("Alert", uselist=False, back_populates="ticket")
     ticket_statuses = relationship(
-        "TicketStatus", uselist=False, back_populates="ticket", cascade="all, delete"
+        "TicketStatus", back_populates="ticket", cascade="all, delete"
     )
     current_ticket_status: Mapped["CurrentTicketStatus"] = relationship(
         "CurrentTicketStatus", uselist=False, back_populates="ticket", cascade="all, delete"

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
@@ -43,6 +44,7 @@ NO_SUCH_PTEAM = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No 
 NO_SUCH_TOPIC = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such topic")
 NO_SUCH_TAG = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such tag")
 NO_SUCH_SERVICE = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service")
+NO_SUCH_PTEAM_TAG = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
 
 
 @router.get("", response_model=list[schemas.PTeamEntry])
@@ -297,7 +299,7 @@ def get_pteam_tagged_solved_topic_ids(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     topic_ids = command.get_sorted_topic_ids_by_pteam_tag_and_status(db, pteam_id, tag_id, True)
     threat_impact_count = command.count_pteam_topics_per_threat_impact(db, pteam_id, tag_id, True)
@@ -329,7 +331,7 @@ def get_pteam_tagged_unsolved_topic_ids(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     topic_ids = command.get_sorted_topic_ids_by_pteam_tag_and_status(db, pteam_id, tag_id, False)
     threat_impact_count = command.count_pteam_topics_per_threat_impact(db, pteam_id, tag_id, False)
@@ -392,6 +394,146 @@ def get_service_tagged_ticket_ids(
             "ticket_ids": ticket_ids_unsoloved,
         },
     }
+
+
+@router.get(
+    "/{pteam_id}/services/{service_id}/topicstatus/{topic_id}/{tag_id}",
+    response_model=schemas.TopicStatusResponse | None,
+)
+def get_service_topic_status(
+    pteam_id: UUID,
+    service_id: UUID,
+    topic_id: UUID,
+    tag_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get the current status (or None) of the service.
+    """
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(db, pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    if not (service := persistence.get_service_by_id(db, service_id)):
+        raise NO_SUCH_SERVICE
+    if service.pteam_id != str(pteam_id):
+        raise NO_SUCH_SERVICE
+    if not persistence.get_topic_by_id(db, topic_id):
+        raise NO_SUCH_TOPIC
+    if not (tag := persistence.get_tag_by_id(db, tag_id)):
+        raise NO_SUCH_TAG
+    if tag not in pteam.tags:
+        raise NO_SUCH_PTEAM_TAG
+
+    firstest_updated_at: datetime | None = None
+    firstest_status: models.TicketStatus | None = None
+    for dependency in service.dependencies:
+        if dependency.tag_id != str(tag_id):
+            continue
+        for threat in persistence.search_threats(db, dependency.dependency_id, topic_id):
+            if not (ticket := threat.ticket):
+                continue
+            if not (current_ticket_status := ticket.current_ticket_status):
+                continue
+            for ticket_status in ticket.ticket_statuses:
+                if ticket_status.status_id != current_ticket_status.status_id:
+                    continue
+
+                if firstest_status is None or (
+                    firstest_updated_at is not None
+                    and current_ticket_status.updated_at is not None
+                    and current_ticket_status.updated_at < firstest_updated_at
+                ):
+                    firstest_status = ticket_status
+
+    return (
+        ticket_manager.ticket_status_to_response(db, firstest_status)
+        if firstest_status is not None
+        else {
+            "pteam_id": pteam_id,
+            "service_id": service_id,
+            "topic_id": topic_id,
+            "tag_id": tag_id,
+        }
+    )
+
+
+@router.post(
+    "/{pteam_id}/services/{service_id}/topicstatus/{topic_id}/{tag_id}",
+    response_model=schemas.TopicStatusResponse | None,
+)
+def set_services_topic_status(
+    pteam_id: UUID,
+    service_id: UUID,
+    topic_id: UUID,
+    tag_id: UUID,
+    data: schemas.TopicStatusRequest,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Set topic status of the pteam.
+    """
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(db, pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    if not (service := persistence.get_service_by_id(db, service_id)):
+        raise NO_SUCH_SERVICE
+    if service.pteam_id != str(pteam_id):
+        raise NO_SUCH_SERVICE
+    if not (topic := persistence.get_topic_by_id(db, topic_id)):
+        raise NO_SUCH_TOPIC
+    if not (tag := persistence.get_tag_by_id(db, tag_id)):
+        raise NO_SUCH_TAG
+    if tag not in pteam.tags:
+        raise NO_SUCH_PTEAM_TAG
+
+    if not command.check_tag_is_related_to_topic(db, tag, topic):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Tag mismatch")
+
+    if data.topic_status not in {
+        models.TopicStatusType.acknowledged,
+        models.TopicStatusType.scheduled,
+        models.TopicStatusType.completed,
+    }:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wrong topic status")
+
+    for logging_id_ in data.logging_ids:
+        if not (log := persistence.get_action_log_by_id(db, logging_id_)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No such actionlog",
+            )
+        if log.pteam_id != str(pteam_id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Not an actionlog for the pteam",
+            )
+        if log.topic_id != str(topic_id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Not an actionlog for the topic",
+            )
+    for assignee in data.assignees:
+        if not (a_user := persistence.get_account_by_id(db, assignee)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No such user",
+            )
+        if not check_pteam_membership(db, pteam, a_user):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Not a pteam member",
+            )
+
+    response = ticket_manager.set_ticket_statuses_in_service(
+        db, current_user, service, topic, tag, data
+    )
+    db.commit()
+
+    return response
 
 
 @router.get("/{pteam_id}/topics", response_model=list[schemas.TopicResponse])
@@ -589,7 +731,7 @@ def get_pteamtag(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     references = []
     for service in pteam.services:
@@ -914,7 +1056,7 @@ def get_pteam_topic_statuses_summary(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
     return command.get_pteam_topic_statuses_summary(db, pteam, tag)
 
 
@@ -940,14 +1082,14 @@ def set_pteam_topic_status(
     # TODO: should check pteam auth: topic_status
 
     if not (topic := persistence.get_topic_by_id(db, topic_id)):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such topic")
+        raise NO_SUCH_TOPIC
     # TODO: should check pteam topic???
     # TODO: should check topic tag?? -- should care about parent&child
 
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     if not command.check_tag_is_related_to_topic(db, tag, topic):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Tag mismatch")
@@ -988,7 +1130,7 @@ def set_pteam_topic_status(
             )
 
     ret = set_pteam_topic_status_internal(db, current_user, pteam, topic, tag, data)
-    ticket_manager.set_ticket_statuses(db, current_user, pteam, topic, tag, data)
+    ticket_manager.set_ticket_statuses_in_pteam(db, current_user, pteam, topic, tag, data)
 
     db.commit()
 
@@ -1017,7 +1159,7 @@ def get_pteam_topic_status(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     # TODO: should check pteam topic???
     # TODO: should check topic tag?? -- should care about parent&child
@@ -1261,7 +1403,7 @@ def fix_status_mismatch_tag(
     if not (tag := persistence.get_tag_by_id(db, tag_id)):
         raise NO_SUCH_TAG
     if tag not in pteam.tags:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam tag")
+        raise NO_SUCH_PTEAM_TAG
 
     for topic in command.get_auto_close_triable_pteam_topics(db, pteam, tag):
         pteamtag_try_auto_close_topic(db, pteam, tag, topic)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
@@ -425,7 +426,8 @@ def get_service_topic_status(
     if tag not in pteam.tags:
         raise NO_SUCH_PTEAM_TAG
 
-    firstest_status: models.TicketStatus | None = None
+    oldest_status: models.TicketStatus | None = None
+    oldest_updated_at: datetime | None = None
     for dependency in service.dependencies:
         if dependency.tag_id != str(tag_id):
             continue
@@ -434,17 +436,19 @@ def get_service_topic_status(
                 continue
             if not (current_ticket_status := ticket.current_ticket_status):
                 continue
+            if not (ticket_status := current_ticket_status.ticket_status):
+                continue
 
-            if ticket_status := current_ticket_status.ticket_status:
-                if (
-                    firstest_status is None
-                    or ticket_status.updated_at < firstest_status.current_ticket_status.updated_at
-                ):
-                    firstest_status = ticket_status
+            if oldest_status is None or (
+                oldest_updated_at is not None
+                and current_ticket_status.updated_at is not None
+                and current_ticket_status.updated_at < oldest_updated_at
+            ):
+                oldest_status = ticket_status
 
     return (
-        command.ticket_status_to_response(db, firstest_status)
-        if firstest_status is not None
+        command.ticket_status_to_response(db, oldest_status)
+        if oldest_status is not None
         else {
             "pteam_id": pteam_id,
             "service_id": service_id,

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -919,7 +919,7 @@ def get_pteam_topic_statuses_summary(
 
 
 @router.post(
-    "/{pteam_id}/topicstatus/{topic_id}/{tag_id}", response_model=schemas.TopicStatusResponse
+    "/{pteam_id}/topicstatus/{topic_id}/{tag_id}", response_model=schemas.PTeamTopicStatusResponse
 )
 def set_pteam_topic_status(
     pteam_id: UUID,
@@ -996,7 +996,7 @@ def set_pteam_topic_status(
 
 
 @router.get(
-    "/{pteam_id}/topicstatus/{topic_id}/{tag_id}", response_model=schemas.TopicStatusResponse
+    "/{pteam_id}/topicstatus/{topic_id}/{tag_id}", response_model=schemas.PTeamTopicStatusResponse
 )
 def get_pteam_topic_status(
     pteam_id: UUID,

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -446,10 +446,25 @@ class TopicStatusRequest(ORMModel):
     scheduled_at: datetime | None = None
 
 
+class PTeamTopicStatusResponse(ORMModel):
+    status_id: UUID | None = None  # None is the case no status is set yet
+    topic_id: UUID
+    pteam_id: UUID
+    tag_id: UUID
+    user_id: UUID | None = None
+    topic_status: TopicStatusType | None = None
+    created_at: datetime | None = None
+    assignees: list[UUID] = []
+    note: str | None = None
+    scheduled_at: datetime | None = None
+    action_logs: list[ActionLogResponse] = []
+
+
 class TopicStatusResponse(ORMModel):
     status_id: UUID | None = None  # None is the case no status is set yet
     topic_id: UUID
     pteam_id: UUID
+    service_id: UUID
     tag_id: UUID
     user_id: UUID | None = None
     topic_status: TopicStatusType | None = None

--- a/api/app/tests/integrations/test_autoclose.py
+++ b/api/app/tests/integrations/test_autoclose.py
@@ -1000,14 +1000,14 @@ class TestAutoClose:
             pteam: schemas.PTeamInfo,
             topic: schemas.Topic,
             tag: schemas.TagResponse,
-        ) -> schemas.TopicStatusResponse:
+        ) -> schemas.PTeamTopicStatusResponse:
             data = assert_200(
                 client.get(
                     f"/pteams/{pteam.pteam_id}/topicstatus/{topic.topic_id}/{tag.tag_id}",
                     headers=headers(USER1),
                 )
             )
-            return schemas.TopicStatusResponse(**data)
+            return schemas.PTeamTopicStatusResponse(**data)
 
         @staticmethod
         def gen_action_dict(**kwargs) -> dict:

--- a/api/app/tests/integrations/test_ticket_status.py
+++ b/api/app/tests/integrations/test_ticket_status.py
@@ -157,24 +157,21 @@ def test_TicketStatus_when_create_pteam_topicstatus(testdb: Session, threat_data
     ).all()
 
     assert len(ticket_statuses_list) == 2
-    for statuses_index in range(len(ticket_statuses_list)):
-        status = ticket_statuses_list[statuses_index]
+    for status in ticket_statuses_list:
         if status.note == "acknowledged":
             assert status.user_id == threat_data["assignees"][0]
             assert status.topic_status == models.TopicStatusType.acknowledged
             assert len(status.logging_ids) == 0
             assert len(status.assignees) == 2
-            for assignees_index in range(len(status.assignees)):
-                assert status.assignees[assignees_index] in threat_data["assignees"]
-                assert status.scheduled_at == datetime(2024, 5, 1)
+            assert all(assignee in threat_data["assignees"] for assignee in status.assignees)
+            assert status.scheduled_at == datetime(2024, 5, 1)
         elif status.note == "scheduled":
             assert status.user_id == threat_data["assignees"][1]
             assert status.topic_status == models.TopicStatusType.scheduled
             assert len(status.logging_ids) == 0
             assert len(status.assignees) == 2
-            for assignees_index in range(len(status.assignees)):
-                assert status.assignees[assignees_index] in threat_data["assignees"]
-                assert status.scheduled_at == datetime(2024, 5, 2)
+            assert all(assignee in threat_data["assignees"] for assignee in status.assignees)
+            assert status.scheduled_at == datetime(2024, 5, 2)
 
     # check CurrentTicketStatus
     current_tcket_status = testdb.scalars(
@@ -230,24 +227,21 @@ def test_TicketStatus_when_create_service_topicstatus(testdb: Session, threat_da
     ).all()
 
     assert len(ticket_statuses_list) == 2
-    for statuses_index in range(len(ticket_statuses_list)):
-        status = ticket_statuses_list[statuses_index]
+    for status in ticket_statuses_list:
         if status.note == "acknowledged":
             assert status.user_id == threat_data["assignees"][0]
             assert status.topic_status == models.TopicStatusType.acknowledged
             assert len(status.logging_ids) == 0
             assert len(status.assignees) == 2
-            for assignees_index in range(len(status.assignees)):
-                assert status.assignees[assignees_index] in threat_data["assignees"]
-                assert status.scheduled_at == datetime(2024, 5, 1)
+            assert all(assignee in threat_data["assignees"] for assignee in status.assignees)
+            assert status.scheduled_at == datetime(2024, 5, 1)
         elif status.note == "scheduled":
             assert status.user_id == threat_data["assignees"][1]
             assert status.topic_status == models.TopicStatusType.scheduled
             assert len(status.logging_ids) == 0
             assert len(status.assignees) == 2
-            for assignees_index in range(len(status.assignees)):
-                assert status.assignees[assignees_index] in threat_data["assignees"]
-                assert status.scheduled_at == datetime(2024, 5, 2)
+            assert all(assignee in threat_data["assignees"] for assignee in status.assignees)
+            assert status.scheduled_at == datetime(2024, 5, 2)
 
     # check CurrentTicketStatus
     current_tcket_status = testdb.scalars(

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -347,7 +347,7 @@ def compare_references(refs1: list[dict], refs2: list[dict]) -> bool:
 
 def create_topicstatus(
     user: dict, pteam_id: UUID, topic_id: UUID, tag_id: UUID, json: dict
-) -> schemas.TopicStatusResponse:
+) -> schemas.PTeamTopicStatusResponse:
     response = assert_200(
         client.post(
             f"/pteams/{pteam_id}/topicstatus/{topic_id}/{tag_id}",
@@ -355,7 +355,7 @@ def create_topicstatus(
             json=json,
         )
     )
-    return schemas.TopicStatusResponse(**response)
+    return schemas.PTeamTopicStatusResponse(**response)
 
 
 def common_put(user: dict, api_path: str, **kwargs) -> dict:

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -358,6 +358,17 @@ def create_topicstatus(
     return schemas.PTeamTopicStatusResponse(**response)
 
 
+def create_service_topicstatus(
+    user: dict, pteam_id: UUID, service_id: UUID, topic_id: UUID, tag_id: UUID, json: dict
+) -> schemas.TopicStatusResponse:
+    response = client.post(
+        f"/pteams/{pteam_id}/services/{service_id}/topicstatus/{topic_id}/{tag_id}",
+        headers=headers(user),
+        json=json,
+    )
+    return schemas.TopicStatusResponse(**response.json())
+
+
 def common_put(user: dict, api_path: str, **kwargs) -> dict:
     response = client.put(api_path, headers=headers(user), json=kwargs)
     if response.status_code != 200:

--- a/api/app/ticket_manager.py
+++ b/api/app/ticket_manager.py
@@ -68,7 +68,8 @@ def set_ticket_statuses_in_service(
     tag: models.Tag,  # should be PTeamTag, not TopicTag
     topicStatusRequest: schemas.TopicStatusRequest,
 ) -> schemas.TopicStatusResponse | None:
-    firstest_status: models.TicketStatus | None = None
+    oldest_status: models.TicketStatus | None = None
+    oldest_updated_at: datetime | None = None
 
     for dependency in service.dependencies:
         if dependency.tag_id != tag.tag_id:
@@ -79,16 +80,15 @@ def set_ticket_statuses_in_service(
             updated_at, ticket_status = set_ticket_status(
                 db, current_user, topic, ticket, topicStatusRequest
             )
-            if (
-                firstest_status is None
-                or updated_at < firstest_status.current_ticket_status.updated_at
+            if oldest_status is None or (
+                oldest_updated_at is not None
+                and updated_at is not None
+                and updated_at < oldest_updated_at
             ):
-                firstest_status = ticket_status
+                oldest_status = ticket_status
 
     return (
-        command.ticket_status_to_response(db, firstest_status)
-        if firstest_status is not None
-        else None
+        command.ticket_status_to_response(db, oldest_status) if oldest_status is not None else None
     )
 
 


### PR DESCRIPTION
## PR の目的
- 下記2件の、Service単位のステータス変更APIを追加する。
  - POST /pteams/{pteam_id}/services/{service_id}/topicstatus/{topic_id}/{tag_id}
  - GET /pteams/{pteam_id}/services/{service_id}/topicstatus/{topic_id}/{tag_id}

## 経緯・意図・意思決定
- 既存のPTeam単位のステータス変更APIは近日中に削除予定。
- 現在の仕様に合わせてGETは複数のTicketStatus のなかの1件だけを返すが、CurrentTicketStatus.updated_atが一番古いものを返す。
理由は、ユーザがステータス操作をした後、同じTopicに別Ticketが追加された場合、ユーザが操作済のステータスを表示したいため。