### PR TITLE
Topic/add get service tagged topic ids api in UI

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -367,11 +367,15 @@ def get_service_tagged_ticket_ids(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service tag")
 
     ## sovled
-    ticket_ids_soloved = get_sorted_solved_ticket_ids_by_service_tag_and_status(service, tag_id)
+    topic_ticket_ids_soloved = get_sorted_solved_ticket_ids_by_service_tag_and_status(
+        service, tag_id
+    )
     threat_impact_count_soloved = count_service_solved_tickets_per_threat_impact(service, tag_id)
 
     ## unsovled
-    ticket_ids_unsoloved = get_sorted_unsolved_ticket_ids_by_service_tag_and_status(service, tag_id)
+    topic_ticket_ids_unsoloved = get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
+        service, tag_id
+    )
     threat_impact_count_unsoloved = count_service_unsolved_tickets_per_threat_impact(
         service, tag_id
     )
@@ -382,14 +386,14 @@ def get_service_tagged_ticket_ids(
             "service_id": service_id,
             "tag_id": tag_id,
             "threat_impact_count": threat_impact_count_soloved,
-            "ticket_ids": ticket_ids_soloved,
+            "topic_ticket_ids": topic_ticket_ids_soloved,
         },
         "unsolved": {
             "pteam_id": pteam_id,
             "service_id": service_id,
             "tag_id": tag_id,
             "threat_impact_count": threat_impact_count_unsoloved,
-            "ticket_ids": ticket_ids_unsoloved,
+            "topic_ticket_ids": topic_ticket_ids_unsoloved,
         },
     }
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -597,7 +597,7 @@ class ServiceTaggedTopics(ORMModel):
     service_id: UUID
     tag_id: UUID
     threat_impact_count: dict[str, int]
-    ticket_ids: list[UUID]
+    topic_ticket_ids: list[dict]
 
 
 class ServiceTaggedTopicsSolvedUnsolved(ORMModel):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3533,14 +3533,17 @@ def test_get_service_tagged_ticket_ids(testdb):
     assert response["solved"]["service_id"] == ticket_response["service_id"]
     assert response["solved"]["tag_id"] == ticket_response["tag_id"]
     assert response["solved"]["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 0}
-    assert response["solved"]["ticket_ids"] == []
+    assert response["solved"]["topic_ticket_ids"] == []
 
     # unsolved
     assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
     assert response["unsolved"]["service_id"] == ticket_response["service_id"]
     assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
     assert response["unsolved"]["threat_impact_count"] == {"1": 1, "2": 0, "3": 0, "4": 0}
-    assert ticket_response["ticket_id"] in response["unsolved"]["ticket_ids"]
+    assert (
+        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+    )
+    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
 
 
 def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -23,10 +23,9 @@ import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
-  getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
   getPTeamTopicActions,
-  getPTeamUnsolvedTaggedTopicIds,
+  getPTeamServiceTaggedTicketIds,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import { updateTopic, createAction, updateAction, deleteAction } from "../utils/api";
@@ -46,6 +45,7 @@ export function PTeamEditAction(props) {
     presetActions,
     currentTagDict,
     pteamtag,
+    serviceId,
   } = props;
 
   const [errors, setErrors] = useState([]);
@@ -144,8 +144,13 @@ export function PTeamEditAction(props) {
     // update only if needed
     if (pteamId && presetTagId) {
       await Promise.all([
-        dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId })),
-        dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId })),
+        dispatch(
+          getPTeamServiceTaggedTicketIds({
+            pteamId: pteamId,
+            serviceId: serviceId,
+            tagId: presetTagId,
+          }),
+        ),
       ]);
     }
   };
@@ -390,4 +395,5 @@ PTeamEditAction.propTypes = {
   ),
   currentTagDict: PropTypes.object.isRequired,
   pteamtag: PropTypes.object.isRequired,
+  serviceId: PropTypes.string,
 };

--- a/web/src/components/PTeamStatusMenu.jsx
+++ b/web/src/components/PTeamStatusMenu.jsx
@@ -9,7 +9,7 @@ import { MdOutlineTopic } from "react-icons/md";
 import { TopicModal } from "../components/TopicModal";
 
 export function PTeamStatusMenu(props) {
-  const { presetTagId, presetParentTagId } = props;
+  const { presetTagId, presetParentTagId, serviceId } = props;
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -71,6 +71,7 @@ export function PTeamStatusMenu(props) {
         onSetOpen={setModalOpen}
         presetTagId={presetTagId}
         presetParentTagId={presetParentTagId}
+        serviceId={serviceId}
       />
     </>
   );
@@ -79,4 +80,5 @@ export function PTeamStatusMenu(props) {
 PTeamStatusMenu.propTypes = {
   presetTagId: PropTypes.string,
   presetParentTagId: PropTypes.string,
+  serviceId: PropTypes.string,
 };

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -2,14 +2,11 @@ import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
+import { useLocation } from "react-router-dom";
 
 import { WaitingModal } from "../components/WaitingModal";
-import {
-  getPTeamSolvedTaggedTopicIds,
-  getPTeamUnsolvedTaggedTopicIds,
-  getPTeamTagsSummary,
-} from "../slices/pteam";
+import { getPTeamServiceTaggedTicketIds, getPTeamTagsSummary } from "../slices/pteam";
 import { autoCloseTag } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
@@ -19,15 +16,22 @@ export function PTeamTagAutoClose(props) {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
-  const pteamId = useSelector((state) => state.pteam.pteamId);
+  const params = new URLSearchParams(useLocation().search);
+  const pteamId = params.get("pteamId");
+  const serviceId = params.get("serviceId");
 
   const handleSave = async () => {
     setIsOpenWaitingModal(true);
     await autoCloseTag(pteamId, tagId)
       .then(() => {
         enqueueSnackbar("Auto Close Accepted", { variant: "success" });
-        dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
-        dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
+        dispatch(
+          getPTeamServiceTaggedTicketIds({
+            pteamId: pteamId,
+            serviceId: serviceId,
+            tagId: tagId,
+          }),
+        );
         dispatch(getPTeamTagsSummary(pteamId));
         // TODO: topic.status is changed when a autocolse button is pressed.
       })

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -16,8 +16,8 @@ export function PTeamTagAutoClose(props) {
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
+  const pteamId = useSelector((state) => state.pteam.pteamId);
   const params = new URLSearchParams(useLocation().search);
-  const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
 
   const handleSave = async () => {

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -9,7 +9,7 @@ import { ThreatImpactCountChip } from "./ThreatImpactCountChip";
 import { TopicCard } from "./TopicCard";
 
 export function PTeamTaggedTopics(props) {
-  const { pteamId, tagId, isSolved, pteamtag } = props;
+  const { pteamId, tagId, serviceId, isSolved, pteamtag } = props;
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -23,7 +23,7 @@ export function PTeamTaggedTopics(props) {
     return <>Loading...</>;
   }
 
-  const targetTopicIds = targets.topic_ids.slice(perPage * (page - 1), perPage * page);
+  const targetTopicIds = targets.topic_ticket_ids.slice(perPage * (page - 1), perPage * page);
   const presetTagId = tagId;
   const presetParentTagId = allTags.find((tag) => tag.tag_id === tagId)?.parent_id;
 
@@ -32,7 +32,7 @@ export function PTeamTaggedTopics(props) {
       <Pagination
         shape="rounded"
         page={page}
-        count={Math.ceil(targets.topic_ids.length / perPage)}
+        count={Math.ceil(targets.topic_ticket_ids.length / perPage)}
         onChange={(event, value) => setPage(value)}
       />
       <Select
@@ -68,17 +68,22 @@ export function PTeamTaggedTopics(props) {
           />
         ))}
         <Box flexGrow={1} />
-        <PTeamStatusMenu presetTagId={presetTagId} presetParentTagId={presetParentTagId} />
+        <PTeamStatusMenu
+          presetTagId={presetTagId}
+          presetParentTagId={presetParentTagId}
+          serviceId={serviceId}
+        />
       </Box>
       {paginationRow}
       <List sx={{ p: 0 }}>
-        {targetTopicIds.map((topicId) => (
-          <ListItem key={topicId} sx={{ minHeight: "250px", p: 0 }}>
+        {targetTopicIds.map((ticketId_topicId) => (
+          <ListItem key={ticketId_topicId.topic_id} sx={{ minHeight: "250px", p: 0 }}>
             <TopicCard
-              key={topicId}
+              key={ticketId_topicId.topic_id}
               pteamId={pteamId}
-              topicId={topicId}
+              topicId={ticketId_topicId.topic_id}
               currentTagId={tagId}
+              serviceId={serviceId}
               pteamtag={pteamtag}
             />
           </ListItem>
@@ -91,6 +96,7 @@ export function PTeamTaggedTopics(props) {
 PTeamTaggedTopics.propTypes = {
   pteamId: PropTypes.string.isRequired,
   tagId: PropTypes.string.isRequired,
+  serviceId: PropTypes.string.isRequired,
   isSolved: PropTypes.bool.isRequired,
   pteamtag: PropTypes.object.isRequired,
 };

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -19,10 +19,9 @@ import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
-  getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
   getPTeamTopicStatus,
-  getPTeamUnsolvedTaggedTopicIds,
+  getPTeamServiceTaggedTicketIds,
 } from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
 
@@ -32,7 +31,7 @@ import { RecommendedStar } from "./RecommendedStar";
 import { UUIDTypography } from "./UUIDTypography";
 
 export function ReportCompletedActions(props) {
-  const { onConfirm, onSetShow, show, topicId, topicActions } = props;
+  const { onConfirm, onSetShow, show, topicId, topicActions, serviceId } = props;
 
   const [note, setNote] = useState("");
   const [selectedAction, setSelectedAction] = useState([]);
@@ -74,8 +73,9 @@ export function ReportCompletedActions(props) {
       setNote("");
       dispatch(getPTeamTagsSummary(pteamId));
       dispatch(getPTeamTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
-      dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
-      dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
+      dispatch(
+        getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
+      );
       enqueueSnackbar("Set topicstatus 'completed' succeeded", { variant: "success" });
     } catch (error) {
       enqueueSnackbar(`Operation failed: ${error}`, { variant: "error" });
@@ -247,4 +247,5 @@ ReportCompletedActions.propTypes = {
   show: PropTypes.bool.isRequired,
   topicId: PropTypes.string.isRequired,
   topicActions: PropTypes.array.isRequired,
+  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/components/TagReferences.jsx
+++ b/web/src/components/TagReferences.jsx
@@ -17,7 +17,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 export function TagReferences(props) {
-  const { references } = props;
+  const { references, serviceDict } = props;
 
   return (
     <Accordion
@@ -44,15 +44,18 @@ export function TagReferences(props) {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {references.map((ref) => (
-                  <TableRow key={ref.service + "-" + ref.target}>
-                    <TableCell component="th" scope="row">
-                      {ref.target}
-                    </TableCell>
-                    <TableCell>{ref.version}</TableCell>
-                    <TableCell>{ref.service}</TableCell>
-                  </TableRow>
-                ))}
+                {references.map(
+                  (ref) =>
+                    ref.service === serviceDict.service_name && (
+                      <TableRow key={ref.service + "-" + ref.target}>
+                        <TableCell component="th" scope="row">
+                          {ref.target}
+                        </TableCell>
+                        <TableCell>{ref.version}</TableCell>
+                        <TableCell>{ref.service}</TableCell>
+                      </TableRow>
+                    ),
+                )}
               </TableBody>
             </Table>
           </TableContainer>
@@ -64,4 +67,5 @@ export function TagReferences(props) {
 
 TagReferences.propTypes = {
   references: PropTypes.arrayOf(PropTypes.object).isRequired,
+  serviceDict: PropTypes.object.isRequired,
 };

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -49,7 +49,7 @@ import { UUIDTypography } from "./UUIDTypography";
 import { WarningTooltip } from "./WarningTooltip";
 
 export function TopicCard(props) {
-  const { pteamId, topicId, currentTagId, pteamtag } = props;
+  const { pteamId, topicId, currentTagId, serviceId, pteamtag } = props;
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [topicModalOpen, setTopicModalOpen] = useState(false);
@@ -254,6 +254,7 @@ export function TopicCard(props) {
           presetTagId={currentTagId}
           presetParentTagId={currentTagDict.parent_id}
           presetActions={pteamTopicActions[topicId]}
+          serviceId={serviceId}
         />
       </Box>
       <Divider />
@@ -496,6 +497,7 @@ export function TopicCard(props) {
             show={actionModalOpen}
             topicId={topicId}
             topicActions={topicActions}
+            serviceId={serviceId}
           />
           <PTeamEditAction
             open={pteamActionModalOpen}
@@ -506,6 +508,7 @@ export function TopicCard(props) {
             presetActions={pteamTopicActions[topicId]}
             currentTagDict={currentTagDict}
             pteamtag={pteamtag}
+            serviceId={serviceId}
           />
         </Box>
         <Divider flexItem={true} orientation="vertical" />
@@ -537,7 +540,7 @@ export function TopicCard(props) {
               </Typography>
               <Box display="flex" flexDirection="column">
                 <Box display="flex" alignItems="center">
-                  <TopicStatusSelector pteamId={pteamId} topicId={topicId} />
+                  <TopicStatusSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
                   {(ttStatus.topic_status ?? "alerted") === "alerted" && (
                     <WarningTooltip message="No one has acknowledged this topic" />
                   )}
@@ -582,5 +585,6 @@ TopicCard.propTypes = {
   pteamId: PropTypes.string.isRequired,
   topicId: PropTypes.string.isRequired,
   currentTagId: PropTypes.string.isRequired,
+  serviceId: PropTypes.string.isRequired,
   pteamtag: PropTypes.object.isRequired,
 };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -28,10 +28,9 @@ import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
-  getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
   getPTeamTopicActions,
-  getPTeamUnsolvedTaggedTopicIds,
+  getPTeamServiceTaggedTicketIds,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import {
@@ -54,7 +53,15 @@ import { TopicTagSelector } from "./TopicTagSelector";
 const steps = ["Import Flashsense", "Create topic"];
 
 export function TopicModal(props) {
-  const { open, onSetOpen, presetTopicId, presetTagId, presetParentTagId, presetActions } = props;
+  const {
+    open,
+    onSetOpen,
+    presetTopicId,
+    presetTagId,
+    presetParentTagId,
+    presetActions,
+    serviceId,
+  } = props;
 
   const [errors, setErrors] = useState([]);
   const [activeStep, setActiveStep] = useState(0);
@@ -167,8 +174,13 @@ export function TopicModal(props) {
     // update only if needed
     if (pteamId && presetTagId) {
       await Promise.all([
-        dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId })),
-        dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId })),
+        dispatch(
+          getPTeamServiceTaggedTicketIds({
+            pteamId: pteamId,
+            serviceId: serviceId,
+            tagId: presetTagId,
+          }),
+        ),
       ]);
     }
   };
@@ -322,8 +334,13 @@ export function TopicModal(props) {
 
   const handleDeleteTopic = () => {
     if (presetTagId) {
-      dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId }));
-      dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: presetTagId }));
+      dispatch(
+        getPTeamServiceTaggedTicketIds({
+          pteamId: pteamId,
+          serviceId: serviceId,
+          tagId: presetTagId,
+        }),
+      );
     }
   };
 
@@ -682,4 +699,5 @@ TopicModal.propTypes = {
       }),
     }),
   ),
+  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -27,17 +27,16 @@ import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
-  getPTeamSolvedTaggedTopicIds,
   getPTeamTagsSummary,
   getPTeamTopicStatus,
-  getPTeamUnsolvedTaggedTopicIds,
+  getPTeamServiceTaggedTicketIds,
 } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
 import { topicStatusProps } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
 
 export function TopicStatusSelector(props) {
-  const { pteamId, topicId } = props;
+  const { pteamId, topicId, serviceId } = props;
 
   const [open, setOpen] = useState(false);
   const [selectableItems, setSelectableItems] = useState([]);
@@ -87,8 +86,13 @@ export function TopicStatusSelector(props) {
           dispatch(getPTeamTagsSummary(pteamId));
         }
         if (ttStatus.topic_status === "completed") {
-          dispatch(getPTeamSolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
-          dispatch(getPTeamUnsolvedTaggedTopicIds({ pteamId: pteamId, tagId: tagId }));
+          dispatch(
+            getPTeamServiceTaggedTicketIds({
+              pteamId: pteamId,
+              serviceId: serviceId,
+              tagId: tagId,
+            }),
+          );
         }
         enqueueSnackbar("Change topic status succeeded", { variant: "success" });
       })
@@ -231,4 +235,5 @@ export function TopicStatusSelector(props) {
 TopicStatusSelector.propTypes = {
   pteamId: PropTypes.string.isRequired,
   topicId: PropTypes.string.isRequired,
+  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -19,7 +19,6 @@ export function Tag() {
   const [loadPTeamTag, setLoadPTeamTag] = useState(false);
   const [loadTopicList, setLoadTopicList] = useState(false);
 
-  const pteamId = useSelector((state) => state.pteam.pteamId);
   const members = useSelector((state) => state.pteam.members);
   const pteamtags = useSelector((state) => state.pteam.pteamtags);
   const taggedTopics = useSelector((state) => state.pteam.taggedTopics);
@@ -32,6 +31,7 @@ export function Tag() {
   const { enqueueSnackbar } = useSnackbar();
   const { tagId } = useParams();
   const params = new URLSearchParams(useLocation().search);
+  const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
 
   useEffect(() => {

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -19,6 +19,7 @@ export function Tag() {
   const [loadPTeamTag, setLoadPTeamTag] = useState(false);
   const [loadTopicList, setLoadTopicList] = useState(false);
 
+  const pteamId = useSelector((state) => state.pteam.pteamId);
   const members = useSelector((state) => state.pteam.members);
   const pteamtags = useSelector((state) => state.pteam.pteamtags);
   const taggedTopics = useSelector((state) => state.pteam.taggedTopics);
@@ -31,7 +32,6 @@ export function Tag() {
   const { enqueueSnackbar } = useSnackbar();
   const { tagId } = useParams();
   const params = new URLSearchParams(useLocation().search);
-  const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
 
   useEffect(() => {

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -5,8 +5,6 @@ import {
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
   getPTeamMembers as apiGetPTeamMembers,
-  getPTeamSolvedTaggedTopicIds as apiGetPTeamSolvedTaggedTopicIds,
-  getPTeamUnsolvedTaggedTopicIds as apiGetPTeamUnsolvedTaggedTopicIds,
   getPTeamServiceTaggedTicketIds as apiGetPTeamServiceTaggedTicketIds,
   getPTeamTag as apiGetPTeamTag,
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
@@ -70,26 +68,6 @@ export const getPTeamTag = createAsyncThunk(
         if (data.onError) data.onError(error);
         throw error;
       }),
-);
-
-export const getPTeamSolvedTaggedTopicIds = createAsyncThunk(
-  "pteam/getPTeamSolvedTaggedTopicIds",
-  async (data) =>
-    await apiGetPTeamSolvedTaggedTopicIds(data.pteamId, data.tagId).then((response) => ({
-      pteamId: data.pteamId,
-      tagId: data.tagId,
-      data: response.data,
-    })),
-);
-
-export const getPTeamUnsolvedTaggedTopicIds = createAsyncThunk(
-  "pteam/getPTeamUnsolvedTaggedTopicIds",
-  async (data) =>
-    await apiGetPTeamUnsolvedTaggedTopicIds(data.pteamId, data.tagId).then((response) => ({
-      pteamId: data.pteamId,
-      tagId: data.tagId,
-      data: response.data,
-    })),
 );
 
 export const getPTeamServiceTaggedTicketIds = createAsyncThunk(
@@ -218,26 +196,6 @@ const pteamSlice = createSlice({
           [action.payload.tagId]: action.payload.data,
         },
       }))
-      // .addCase(getPTeamSolvedTaggedTopicIds.fulfilled, (state, action) => ({
-      //   ...state,
-      //   taggedTopics: {
-      //     ...state.taggedTopics,
-      //     [action.payload.tagId]: {
-      //       ...state.taggedTopics[action.payload.tagId],
-      //       solved: action.payload.data,
-      //     },
-      //   },
-      // }))
-      // .addCase(getPTeamUnsolvedTaggedTopicIds.fulfilled, (state, action) => ({
-      //   ...state,
-      //   taggedTopics: {
-      //     ...state.taggedTopics,
-      //     [action.payload.tagId]: {
-      //       ...state.taggedTopics[action.payload.tagId],
-      //       unsolved: action.payload.data,
-      //     },
-      //   },
-      // }))
       .addCase(getPTeamServiceTaggedTicketIds.fulfilled, (state, action) => ({
         ...state,
         taggedTopics: {

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -7,6 +7,7 @@ import {
   getPTeamMembers as apiGetPTeamMembers,
   getPTeamSolvedTaggedTopicIds as apiGetPTeamSolvedTaggedTopicIds,
   getPTeamUnsolvedTaggedTopicIds as apiGetPTeamUnsolvedTaggedTopicIds,
+  getPTeamServiceTaggedTicketIds as apiGetPTeamServiceTaggedTicketIds,
   getPTeamTag as apiGetPTeamTag,
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
   getPTeamTopicActions as apiGetPTeamTopicActions,
@@ -89,6 +90,19 @@ export const getPTeamUnsolvedTaggedTopicIds = createAsyncThunk(
       tagId: data.tagId,
       data: response.data,
     })),
+);
+
+export const getPTeamServiceTaggedTicketIds = createAsyncThunk(
+  "pteam/getPTeamServiceTaggedTicketIds",
+  async (data) =>
+    await apiGetPTeamServiceTaggedTicketIds(data.pteamId, data.serviceId, data.tagId).then(
+      (response) => ({
+        pteamId: data.pteamId,
+        serviceId: data.serviceId,
+        tagId: data.tagId,
+        data: response.data,
+      }),
+    ),
 );
 
 export const getPTeamTagsSummary = createAsyncThunk(
@@ -204,23 +218,34 @@ const pteamSlice = createSlice({
           [action.payload.tagId]: action.payload.data,
         },
       }))
-      .addCase(getPTeamSolvedTaggedTopicIds.fulfilled, (state, action) => ({
+      // .addCase(getPTeamSolvedTaggedTopicIds.fulfilled, (state, action) => ({
+      //   ...state,
+      //   taggedTopics: {
+      //     ...state.taggedTopics,
+      //     [action.payload.tagId]: {
+      //       ...state.taggedTopics[action.payload.tagId],
+      //       solved: action.payload.data,
+      //     },
+      //   },
+      // }))
+      // .addCase(getPTeamUnsolvedTaggedTopicIds.fulfilled, (state, action) => ({
+      //   ...state,
+      //   taggedTopics: {
+      //     ...state.taggedTopics,
+      //     [action.payload.tagId]: {
+      //       ...state.taggedTopics[action.payload.tagId],
+      //       unsolved: action.payload.data,
+      //     },
+      //   },
+      // }))
+      .addCase(getPTeamServiceTaggedTicketIds.fulfilled, (state, action) => ({
         ...state,
         taggedTopics: {
           ...state.taggedTopics,
           [action.payload.tagId]: {
             ...state.taggedTopics[action.payload.tagId],
-            solved: action.payload.data,
-          },
-        },
-      }))
-      .addCase(getPTeamUnsolvedTaggedTopicIds.fulfilled, (state, action) => ({
-        ...state,
-        taggedTopics: {
-          ...state.taggedTopics,
-          [action.payload.tagId]: {
-            ...state.taggedTopics[action.payload.tagId],
-            unsolved: action.payload.data,
+            solved: action.payload.data.solved,
+            unsolved: action.payload.data.unsolved,
           },
         },
       }))

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -42,12 +42,6 @@ export const getPTeamTag = async (pteamId, tagId) => axios.get(`/pteams/${pteamI
 
 export const getPTeamTopics = async (pteamId) => axios.get(`/pteams/${pteamId}/topics`);
 
-export const getPTeamSolvedTaggedTopicIds = async (pteamId, tagId) =>
-  axios.get(`/pteams/${pteamId}/tags/${tagId}/solved_topic_ids`);
-
-export const getPTeamUnsolvedTaggedTopicIds = async (pteamId, tagId) =>
-  axios.get(`/pteams/${pteamId}/tags/${tagId}/unsolved_topic_ids`);
-
 export const getPTeamServiceTaggedTicketIds = async (pteamId, serviceId, tagId) =>
   axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/ticket_ids`);
 

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -48,6 +48,9 @@ export const getPTeamSolvedTaggedTopicIds = async (pteamId, tagId) =>
 export const getPTeamUnsolvedTaggedTopicIds = async (pteamId, tagId) =>
   axios.get(`/pteams/${pteamId}/tags/${tagId}/unsolved_topic_ids`);
 
+export const getPTeamServiceTaggedTicketIds = async (pteamId, serviceId, tagId) =>
+  axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/ticket_ids`);
+
 export const createPTeamInvitation = async (pteamId, data) =>
   axios.post(`/pteams/${pteamId}/invitation`, data);
 


### PR DESCRIPTION
## PR の目的
- TagごとのTopic一覧ページをserviceごとに切り替えるためのUI部分の修正
- 前スプリントで作成したAPI(https://github.com/nttcom/threatconnectome/pull/186) をUI側に繋ぎこみました。

## 経緯・意図・意思決定
### API
- responseでticket_idのみ返していたところをtopic_idも含めて返すようにしました。
- 変更前 
`"ticket_ids": [ticekt_id]`
- 変更後 
```
"topic_ticket_ids": [{
      "topic_id": topic_id,
      "ticket_ids": [ticket_id]
  }]
```
- get_sorted_unsolved_ticket_ids_by_service_tag_and_status, get_sorted_solved_ticket_ids_by_service_tag_and_statusのロジックを変更しました。1度{"topic_id": threat.topic_id, "ticket_id": _curent_ticket.ticket_id}で集めた後に、topic_idが同じでticekt_idが違うものをlistに入れるようにしました。
- apiのresponse変更に伴いtest_pteam.pyを修正しました。

### UI
- pteam.js, api.jsに作成したAPIを追加しました。
#### componet
- Tag.jsxにservice名を表示するようにしました。またrefrenceに該当するserviceのものだけを表示するようにしました。
- Tag.jsxでURLからservice_idを取得し、子コンポーネントにpropsでservice_idを渡すようにしました。
- dispatch(getPTeamSolvedTaggedTopicIds), dispatch(getPTeamUnsolvedTaggedTopicIds)していた部分を削除しdispatch(
getPTeamServiceTaggedTicketIds)するようにしました。
