### PR TITLE
fix relationship

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -373,9 +373,7 @@ class Threat(Base):
 
     topic = relationship("Topic", back_populates="threats")
     ticket = relationship("Ticket", uselist=False, back_populates="threat", cascade="all, delete")
-    dependency = relationship(
-        "Dependency", uselist=False, back_populates="threats", cascade="all, delete"
-    )
+    dependency = relationship("Dependency", uselist=False, back_populates="threats")
 
 
 class Ticket(Base):


### PR DESCRIPTION
## PR の目的
- threatテーブルにあるdependencyテーブルとのrelationshipを修正しました。
- cascade="all, delete"を削除しました。

## 経緯・意図・意思決定
- UI上でDelete Topicをすると、Status画面でDelete Topicをしたtagが消えてしまうバグが発生
- Delete Topic 実行 → topic_idが消える → CASCADEを設定しているためthreatテーブルのrowが消える(dependency_idが消える)
→ threatテーブルが消えるとdependencyテーブルが消える(threatテーブルにあるdependencyテーブルへのrelationship cascade="all, delete"があるため)



