### PR TITLE
remove pteam status with slice: pteam.tagsSummary

### DIFF
--- a/web/src/components/AssigneesSelector.jsx
+++ b/web/src/components/AssigneesSelector.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
-import { getPTeamTagsSummary, getPTeamTopicStatus } from "../slices/pteam";
+import { getPTeamTopicStatus } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
 
 export function AssigneesSelector(props) {
@@ -46,7 +46,6 @@ export function AssigneesSelector(props) {
       scheduled_at: ttStatus.scheduled_at,
     })
       .then(() => {
-        dispatch(getPTeamTagsSummary(pteamId));
         dispatch(getPTeamTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
         enqueueSnackbar("Change assignees succeeded", { variant: "success" });
       })

--- a/web/src/components/PTeamAutoClose.jsx
+++ b/web/src/components/PTeamAutoClose.jsx
@@ -1,16 +1,14 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import { WaitingModal } from "../components/WaitingModal";
-import { getPTeamTagsSummary } from "../slices/pteam";
 import { autoClose } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
 export function PTeamAutoClose() {
   const [isOpenWaitingModal, setIsOpenWaitingModal] = useState(false);
-  const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
@@ -20,7 +18,6 @@ export function PTeamAutoClose() {
     await autoClose(pteamId)
       .then(() => {
         enqueueSnackbar("Auto Close Accepted", { variant: "success" });
-        dispatch(getPTeamTagsSummary(pteamId));
       })
       .catch((error) => {
         const resp = error.response;

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -22,11 +22,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import {
-  getPTeamTagsSummary,
-  getPTeamTopicActions,
-  getPTeamServiceTaggedTicketIds,
-} from "../slices/pteam";
+import { getPTeamTopicActions, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import { updateTopic, createAction, updateAction, deleteAction } from "../utils/api";
 import { actionTypes } from "../utils/const";
@@ -138,7 +134,6 @@ export function PTeamEditAction(props) {
     // fix topic state
     await Promise.all([
       dispatch(getTopic(topicId)),
-      dispatch(getPTeamTagsSummary(pteamId)),
       dispatch(getPTeamTopicActions({ pteamId: pteamId, topicId: topicId })),
     ]);
     // update only if needed

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -16,7 +16,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { TabPanel } from "../components/TabPanel";
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getPTeam, getPTeamTagsSummary } from "../slices/pteam";
+import { getPTeam } from "../slices/pteam";
 import { a11yProps } from "../utils/func.js";
 
 import { PTeamAuthEditor } from "./PTeamAuthEditor";
@@ -38,7 +38,6 @@ export function PTeamSettingsModal(props) {
   const pteamId = useSelector((state) => state.pteam.pteamId); // dispatched by App or PTeamSelector
 
   const handleSBOMUploaded = () => {
-    dispatch(getPTeamTagsSummary(pteamId));
     dispatch(getPTeam(pteamId)); // update pteam.services
   };
 

--- a/web/src/components/PTeamTagAutoClose.jsx
+++ b/web/src/components/PTeamTagAutoClose.jsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
 import { WaitingModal } from "../components/WaitingModal";
-import { getPTeamServiceTaggedTicketIds, getPTeamTagsSummary } from "../slices/pteam";
+import { getPTeamServiceTaggedTicketIds } from "../slices/pteam";
 import { autoCloseTag } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
@@ -32,7 +32,6 @@ export function PTeamTagAutoClose(props) {
             tagId: tagId,
           }),
         );
-        dispatch(getPTeamTagsSummary(pteamId));
         // TODO: topic.status is changed when a autocolse button is pressed.
       })
       .catch((error) => {

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -18,11 +18,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import {
-  getPTeamTagsSummary,
-  getPTeamTopicStatus,
-  getPTeamServiceTaggedTicketIds,
-} from "../slices/pteam";
+import { getPTeamTopicStatus, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
 
 import { ActionTypeChip } from "./ActionTypeChip";
@@ -71,7 +67,6 @@ export function ReportCompletedActions(props) {
       handleClose();
       onConfirm();
       setNote("");
-      dispatch(getPTeamTagsSummary(pteamId));
       dispatch(getPTeamTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
       dispatch(
         getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -13,10 +13,8 @@ import { red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getPTeamTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
@@ -25,9 +23,6 @@ export function TopicDeleteModal(props) {
   const [open, setOpen] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
-
-  const pteamId = useSelector((state) => state.pteam.pteamId);
-  const dispatch = useDispatch();
 
   const operationError = (error) => {
     const resp = error.response ?? { status: "???", statusText: error.toString() };
@@ -40,7 +35,6 @@ export function TopicDeleteModal(props) {
     deleteTopic(topicId)
       .then(async () => {
         await Promise.all([
-          dispatch(getPTeamTagsSummary(pteamId)),
           onDelete && onDelete(),
           enqueueSnackbar("delete topic succeeded", { variant: "success" }),
         ]);

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -27,11 +27,7 @@ import uuid from "react-native-uuid";
 import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import {
-  getPTeamTagsSummary,
-  getPTeamTopicActions,
-  getPTeamServiceTaggedTicketIds,
-} from "../slices/pteam";
+import { getPTeamTopicActions, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import {
   createTopic,
@@ -168,7 +164,6 @@ export function TopicModal(props) {
     // fix topic state
     await Promise.all([
       dispatch(getTopic(topicId)),
-      dispatch(getPTeamTagsSummary(pteamId)),
       dispatch(getPTeamTopicActions({ pteamId: pteamId, topicId: topicId })),
     ]);
     // update only if needed

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -26,11 +26,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import {
-  getPTeamTagsSummary,
-  getPTeamTopicStatus,
-  getPTeamServiceTaggedTicketIds,
-} from "../slices/pteam";
+import { getPTeamTopicStatus, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
 import { topicStatusProps } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
@@ -83,7 +79,6 @@ export function TopicStatusSelector(props) {
       .then(() => {
         if (selectedStatus !== ttStatus.topicStatus) {
           dispatch(getPTeamTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
-          dispatch(getPTeamTagsSummary(pteamId));
         }
         if (ttStatus.topic_status === "completed") {
           dispatch(

--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -1,4 +1,4 @@
-import { Alert, Box } from "@mui/material";
+import { Box } from "@mui/material";
 import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
@@ -9,12 +9,12 @@ import { AppBar } from "../components/AppBar";
 import { Drawer } from "../components/Drawer";
 import { Main } from "../components/Main";
 import { setATeamId } from "../slices/ateam";
-import { getPTeamTagsSummary, setPTeamId } from "../slices/pteam";
+import { setPTeamId } from "../slices/pteam";
 import { setTeamMode } from "../slices/system";
 import { getTags } from "../slices/tags";
 import { getUser } from "../slices/user";
 import { getMyUserInfo, setToken } from "../utils/api";
-import { mainMaxWidth, threatImpactName, threatImpactProps } from "../utils/const";
+import { mainMaxWidth } from "../utils/const";
 
 import { authCookieName } from "./Login";
 
@@ -23,9 +23,6 @@ export function App() {
   const [cookies, _setCookie, _removeCookie] = useCookies([authCookieName]);
 
   const [loadTags, setLoadTags] = useState(false);
-  const [loadSummary, setLoadSummary] = useState(false);
-  const [prevPTeamId, setPrevPTeamId] = useState(undefined);
-  const [prevSummary, setPrevSummary] = useState(undefined);
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -33,8 +30,6 @@ export function App() {
   const system = useSelector((state) => state.system);
   const user = useSelector((state) => state.user.user);
   const allTags = useSelector((state) => state.tags.allTags);
-  const pteamId = useSelector((state) => state.pteam.pteamId);
-  const summary = useSelector((state) => state.pteam.tagsSummary);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -129,44 +124,6 @@ export function App() {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [loadTags]);
 
-  useEffect(() => {
-    if (!pteamId) return;
-    if (pteamId !== prevPTeamId) {
-      setPrevSummary(undefined);
-      setPrevPTeamId(pteamId);
-    }
-    if (loadSummary) {
-      setPrevSummary(summary);
-      dispatch(getPTeamTagsSummary(pteamId));
-      setLoadSummary(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, loadSummary, pteamId]);
-
-  const getWorst = (threatImpactCounts) =>
-    parseInt(Object.keys(threatImpactCounts).filter((key) => threatImpactCounts[key] > 0)[0] ?? 4);
-  const getThreatProp = (num) => threatImpactProps[threatImpactName[parseInt(num)]];
-
-  useEffect(() => {
-    if (!summary) setLoadSummary(true);
-    if (!pteamId || !prevPTeamId || pteamId !== prevPTeamId) return;
-    if (summary && prevSummary && summary !== prevSummary) {
-      const newThreatImpact = getWorst(summary.threat_impact_count ?? []);
-      const prevThreatImpact = getWorst(prevSummary.threat_impact_count ?? []);
-      if (newThreatImpact !== prevThreatImpact) {
-        enqueueSnackbar(
-          "Your pteam's Threat Impact got " +
-            (newThreatImpact > prevThreatImpact ? "better" : "worse") +
-            " to " +
-            getThreatProp(newThreatImpact).chipLabel,
-          { variant: newThreatImpact > prevThreatImpact ? "info" : "warning" },
-        );
-      }
-    }
-    setPrevSummary(summary);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, summary]);
-
   return (
     <>
       <Box flexGrow={1}>
@@ -176,11 +133,6 @@ export function App() {
       <Main open={system.drawerOpen}>
         <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" m={1}>
           <Box display="flex" flexDirection="column" flexGrow={1} maxWidth={mainMaxWidth}>
-            {summary && summary.threat_impact_count?.["1"] > 0 && (
-              <Box sx={{ width: 1 }} mb={3}>
-                <Alert severity="error">{threatImpactProps.immediate.alert}</Alert>
-              </Box>
-            )}
             <Outlet />
           </Box>
         </Box>

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -33,12 +33,7 @@ import { PTeamLabel } from "../components/PTeamLabel";
 import { PTeamServiceTabs } from "../components/PTeamServiceTabs";
 import { PTeamStatusCard } from "../components/PTeamStatusCard";
 import { SBOMDropArea } from "../components/SBOMDropArea";
-import {
-  getPTeam,
-  getPTeamServiceTagsSummary,
-  getPTeamTagsSummary,
-  setPTeamId,
-} from "../slices/pteam";
+import { getPTeam, getPTeamServiceTagsSummary, setPTeamId } from "../slices/pteam";
 import { noPTeamMessage, threatImpactName, threatImpactProps } from "../utils/const";
 const threatImpactCountMax = 99999;
 
@@ -144,7 +139,6 @@ export function Status() {
   }
 
   const handleSBOMUploaded = () => {
-    dispatch(getPTeamTagsSummary(pteamId));
     dispatch(getPTeam(pteamId));
   };
 

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -7,7 +7,6 @@ import {
   getPTeamMembers as apiGetPTeamMembers,
   getPTeamServiceTaggedTicketIds as apiGetPTeamServiceTaggedTicketIds,
   getPTeamTag as apiGetPTeamTag,
-  getPTeamTagsSummary as apiGetPTeamTagsSummary,
   getPTeamTopicActions as apiGetPTeamTopicActions,
   getPTeamTopicStatus as apiGetPTeamTopicStatus,
   getPTeamTopicStatusesSummary as apiGetPTeamTopicStatusesSummary,
@@ -83,15 +82,6 @@ export const getPTeamServiceTaggedTicketIds = createAsyncThunk(
     ),
 );
 
-export const getPTeamTagsSummary = createAsyncThunk(
-  "pteam/getPTeamTagsSummary",
-  async (pteamId) =>
-    await apiGetPTeamTagsSummary(pteamId).then((response) => ({
-      data: response.data,
-      pteamId: pteamId,
-    })),
-);
-
 export const getPTeamTopicStatusesSummary = createAsyncThunk(
   "pteam/getPTeamTopicStatusesSummary",
   async (data) =>
@@ -139,7 +129,6 @@ const _initialState = {
   authInfo: undefined,
   authorities: undefined,
   members: undefined,
-  tagsSummary: undefined,
   topicsSummary: undefined,
   pteamtags: {},
   taggedTopics: {},
@@ -180,10 +169,6 @@ const pteamSlice = createSlice({
       .addCase(getPTeamMembers.fulfilled, (state, action) => ({
         ...state,
         members: action.payload.data,
-      }))
-      .addCase(getPTeamTagsSummary.fulfilled, (state, action) => ({
-        ...state,
-        tagsSummary: action.payload.data,
       }))
       .addCase(getPTeamTopicStatusesSummary.fulfilled, (state, action) => ({
         ...state,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -36,8 +36,6 @@ export const getPTeamAuth = async (pteamId) => axios.get(`/pteams/${pteamId}/aut
 export const updatePTeamAuth = async (pteamId, data) =>
   axios.post(`/pteams/${pteamId}/authority`, data);
 
-export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
-
 export const getPTeamTag = async (pteamId, tagId) => axios.get(`/pteams/${pteamId}/tags/${tagId}`);
 
 export const getPTeamTopics = async (pteamId) => axios.get(`/pteams/${pteamId}/topics`);

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -82,7 +82,6 @@ export const threatImpactName = {
 
 export const threatImpactProps = {
   immediate: {
-    alert: "Your pteam has a Immediate. Please take actions immediately.",
     chipLabel: "Immediate",
     icon: RunningWithErrorsIcon,
     statusLabel: "Your pteam has a immediate",


### PR DESCRIPTION
## PR の目的

- pteam status を廃止
  - Immediate 時のページ上部への警告表示を廃止
  - team status の悪化・改善に伴うスナックバー表示を廃止
  - pteam スライスの tagsSummary および本データの取得処理を廃止
