### PR TITLE
topic/add sort function in solved and unsolved ticket_ids

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -516,9 +516,9 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
     # Sort topic_id according to threat_impact and updated_at
     topic_ticket_ids_sorted = sorted(
         topic_ticket_ids,
-        key=lambda topic_ticket_ids: (
-            topic_ticket_ids["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := topic_ticket_ids["topic_updated_at"]) else 0),
+        key=lambda x: (
+            x["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := x["topic_updated_at"]) else 0),
         ),
     )
 
@@ -573,9 +573,9 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
     # Sort topic_id according to threat_impact and updated_at
     topic_ticket_ids_sorted = sorted(
         topic_ticket_ids,
-        key=lambda topic_ticket_ids: (
-            topic_ticket_ids["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := topic_ticket_ids["topic_updated_at"]) else 0),
+        key=lambda x: (
+            x["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := x["topic_updated_at"]) else 0),
         ),
     )
 

--- a/api/app/common.py
+++ b/api/app/common.py
@@ -504,7 +504,7 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
                     topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
                 tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
 
-    # The contents of topic_ticket_ids_list are as follows
+    # The contents of topic_ticket_ids are as follows
     # [{
     #   "topic_id":xxxxx,
     #   "topic_threat_impact":xxxxx,
@@ -561,7 +561,7 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
                     topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
                 tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
 
-    # The contents of topic_ticket_ids_list are as follows
+    # The contents of topic_ticket_ids are as follows
     # [{
     #   "topic_id":xxxxx,
     #   "topic_threat_impact":xxxxx,

--- a/api/app/common.py
+++ b/api/app/common.py
@@ -490,30 +490,19 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
         for threat in dependency.threats:
             if not threat.ticket:
                 continue
-
             _curent_ticket = threat.ticket.current_ticket_status
-            if _curent_ticket.topic_status == _completed:
-                topic_ticket_ids.append(
-                    {
+            if _curent_ticket.topic_status != _completed:
+                if (
+                    tmp_topic_ticket_ids_dict := topic_ticket_ids_dict.get(threat.topic_id)
+                ) is None:
+                    tmp_topic_ticket_ids_dict = {
                         "topic_id": threat.topic_id,
                         "topic_threat_impact": threat.topic.threat_impact,
                         "topic_updated_at": threat.topic.updated_at,
-                        "ticket_id": _curent_ticket.ticket_id,
+                        "ticket_ids": [],
                     }
-                )
-
-    # Aggregate the same topic_id
-    for _topic_ticket_id in topic_ticket_ids:
-        if _topic_ticket_id["topic_id"] not in topic_ticket_ids_dict:
-            topic_ticket_ids_dict[_topic_ticket_id["topic_id"]] = {
-                "topic_id": _topic_ticket_id["topic_id"],
-                "topic_threat_impact": _topic_ticket_id["topic_threat_impact"],
-                "topic_updated_at": _topic_ticket_id["topic_updated_at"],
-                "ticket_ids": [],
-            }
-        topic_ticket_ids_dict[_topic_ticket_id["topic_id"]]["ticket_ids"].append(
-            _topic_ticket_id["ticket_id"]
-        )
+                    topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
+                tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
 
     # The contents of topic_ticket_ids_list are as follows
     # [{
@@ -522,19 +511,19 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
     #   "topic_updated_at":xxxxx,
     #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
     # }]
-    topic_ticket_ids_list = list(topic_ticket_ids_dict.values())
+    topic_ticket_ids = list(topic_ticket_ids_dict.values())
 
     # Sort topic_id according to threat_impact and updated_at
-    topic_ticket_ids_list_sorted = sorted(
-        topic_ticket_ids_list,
-        key=lambda topic_ticket_ids_list: (
-            topic_ticket_ids_list["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := topic_ticket_ids_list["topic_updated_at"]) else 0),
+    topic_ticket_ids_sorted = sorted(
+        topic_ticket_ids,
+        key=lambda topic_ticket_ids: (
+            topic_ticket_ids["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := topic_ticket_ids["topic_updated_at"]) else 0),
         ),
     )
 
     # delete topic_threat_impact and topic_updated_at
-    for _ in topic_ticket_ids_list_sorted:
+    for _ in topic_ticket_ids_sorted:
         del _["topic_threat_impact"]
         del _["topic_updated_at"]
         result.append(_)
@@ -558,30 +547,19 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
         for threat in dependency.threats:
             if not threat.ticket:
                 continue
-
             _curent_ticket = threat.ticket.current_ticket_status
             if _curent_ticket.topic_status != _completed:
-                topic_ticket_ids.append(
-                    {
+                if (
+                    tmp_topic_ticket_ids_dict := topic_ticket_ids_dict.get(threat.topic_id)
+                ) is None:
+                    tmp_topic_ticket_ids_dict = {
                         "topic_id": threat.topic_id,
                         "topic_threat_impact": threat.topic.threat_impact,
                         "topic_updated_at": threat.topic.updated_at,
-                        "ticket_id": _curent_ticket.ticket_id,
+                        "ticket_ids": [],
                     }
-                )
-
-    # Aggregate the same topic_id
-    for _topic_ticket_id in topic_ticket_ids:
-        if _topic_ticket_id["topic_id"] not in topic_ticket_ids_dict:
-            topic_ticket_ids_dict[_topic_ticket_id["topic_id"]] = {
-                "topic_id": _topic_ticket_id["topic_id"],
-                "topic_threat_impact": _topic_ticket_id["topic_threat_impact"],
-                "topic_updated_at": _topic_ticket_id["topic_updated_at"],
-                "ticket_ids": [],
-            }
-        topic_ticket_ids_dict[_topic_ticket_id["topic_id"]]["ticket_ids"].append(
-            _topic_ticket_id["ticket_id"]
-        )
+                    topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
+                tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
 
     # The contents of topic_ticket_ids_list are as follows
     # [{
@@ -590,19 +568,19 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
     #   "topic_updated_at":xxxxx,
     #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
     # }]
-    topic_ticket_ids_list = list(topic_ticket_ids_dict.values())
+    topic_ticket_ids = list(topic_ticket_ids_dict.values())
 
     # Sort topic_id according to threat_impact and updated_at
-    topic_ticket_ids_list_sorted = sorted(
-        topic_ticket_ids_list,
-        key=lambda topic_ticket_ids_list: (
-            topic_ticket_ids_list["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := topic_ticket_ids_list["topic_updated_at"]) else 0),
+    topic_ticket_ids_sorted = sorted(
+        topic_ticket_ids,
+        key=lambda topic_ticket_ids: (
+            topic_ticket_ids["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := topic_ticket_ids["topic_updated_at"]) else 0),
         ),
     )
 
     # delete topic_threat_impact and topic_updated_at
-    for _ in topic_ticket_ids_list_sorted:
+    for _ in topic_ticket_ids_sorted:
         del _["topic_threat_impact"]
         del _["topic_updated_at"]
         result.append(_)

--- a/api/app/common.py
+++ b/api/app/common.py
@@ -481,7 +481,9 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
     _completed = models.TopicStatusType.completed
     topic_ticket_ids: list[dict] = []
     topic_ticket_ids_dict: dict = {}
+    result: list = []
 
+    # Search for topic_id and ticket_id corresponding to service_id and tag_id
     for dependency in service.dependencies:
         if dependency.tag_id != str(tag_id):
             continue
@@ -492,20 +494,50 @@ def get_sorted_solved_ticket_ids_by_service_tag_and_status(
             _curent_ticket = threat.ticket.current_ticket_status
             if _curent_ticket.topic_status == _completed:
                 topic_ticket_ids.append(
-                    {"topic_id": threat.topic_id, "ticket_id": _curent_ticket.ticket_id}
+                    {
+                        "topic_id": threat.topic_id,
+                        "topic_threat_impact": threat.topic.threat_impact,
+                        "topic_updated_at": threat.topic.updated_at,
+                        "ticket_id": _curent_ticket.ticket_id,
+                    }
                 )
 
+    # Aggregate the same topic_id
     for _topic_ticket_id in topic_ticket_ids:
         if _topic_ticket_id["topic_id"] not in topic_ticket_ids_dict:
             topic_ticket_ids_dict[_topic_ticket_id["topic_id"]] = {
                 "topic_id": _topic_ticket_id["topic_id"],
+                "topic_threat_impact": _topic_ticket_id["topic_threat_impact"],
+                "topic_updated_at": _topic_ticket_id["topic_updated_at"],
                 "ticket_ids": [],
             }
         topic_ticket_ids_dict[_topic_ticket_id["topic_id"]]["ticket_ids"].append(
             _topic_ticket_id["ticket_id"]
         )
 
-    result = list(topic_ticket_ids_dict.values())
+    # The contents of topic_ticket_ids_list are as follows
+    # [{
+    #   "topic_id":xxxxx,
+    #   "topic_threat_impact":xxxxx,
+    #   "topic_updated_at":xxxxx,
+    #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
+    # }]
+    topic_ticket_ids_list = list(topic_ticket_ids_dict.values())
+
+    # Sort topic_id according to threat_impact and updated_at
+    topic_ticket_ids_list_sorted = sorted(
+        topic_ticket_ids_list,
+        key=lambda topic_ticket_ids_list: (
+            topic_ticket_ids_list["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := topic_ticket_ids_list["topic_updated_at"]) else 0),
+        ),
+    )
+
+    # delete topic_threat_impact and topic_updated_at
+    for _ in topic_ticket_ids_list_sorted:
+        del _["topic_threat_impact"]
+        del _["topic_updated_at"]
+        result.append(_)
 
     return result
 
@@ -517,7 +549,9 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
     _completed = models.TopicStatusType.completed
     topic_ticket_ids: list[dict] = []
     topic_ticket_ids_dict: dict = {}
+    result: list = []
 
+    # Search for topic_id and ticket_id corresponding to service_id and tag_id
     for dependency in service.dependencies:
         if dependency.tag_id != str(tag_id):
             continue
@@ -528,19 +562,49 @@ def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
             _curent_ticket = threat.ticket.current_ticket_status
             if _curent_ticket.topic_status != _completed:
                 topic_ticket_ids.append(
-                    {"topic_id": threat.topic_id, "ticket_id": _curent_ticket.ticket_id}
+                    {
+                        "topic_id": threat.topic_id,
+                        "topic_threat_impact": threat.topic.threat_impact,
+                        "topic_updated_at": threat.topic.updated_at,
+                        "ticket_id": _curent_ticket.ticket_id,
+                    }
                 )
 
+    # Aggregate the same topic_id
     for _topic_ticket_id in topic_ticket_ids:
         if _topic_ticket_id["topic_id"] not in topic_ticket_ids_dict:
             topic_ticket_ids_dict[_topic_ticket_id["topic_id"]] = {
                 "topic_id": _topic_ticket_id["topic_id"],
+                "topic_threat_impact": _topic_ticket_id["topic_threat_impact"],
+                "topic_updated_at": _topic_ticket_id["topic_updated_at"],
                 "ticket_ids": [],
             }
         topic_ticket_ids_dict[_topic_ticket_id["topic_id"]]["ticket_ids"].append(
             _topic_ticket_id["ticket_id"]
         )
 
-    result = list(topic_ticket_ids_dict.values())
+    # The contents of topic_ticket_ids_list are as follows
+    # [{
+    #   "topic_id":xxxxx,
+    #   "topic_threat_impact":xxxxx,
+    #   "topic_updated_at":xxxxx,
+    #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
+    # }]
+    topic_ticket_ids_list = list(topic_ticket_ids_dict.values())
+
+    # Sort topic_id according to threat_impact and updated_at
+    topic_ticket_ids_list_sorted = sorted(
+        topic_ticket_ids_list,
+        key=lambda topic_ticket_ids_list: (
+            topic_ticket_ids_list["topic_threat_impact"],
+            -(_dt.timestamp() if (_dt := topic_ticket_ids_list["topic_updated_at"]) else 0),
+        ),
+    )
+
+    # delete topic_threat_impact and topic_updated_at
+    for _ in topic_ticket_ids_list_sorted:
+        del _["topic_threat_impact"]
+        del _["topic_updated_at"]
+        result.append(_)
 
     return result


### PR DESCRIPTION
## PR の目的
- common.pyのget_sorted_solved_ticket_ids_by_service_tag_and_status, get_sorted_unsolved_ticket_ids_by_service_tag_and_statusにsortする機能が抜けていたので入れました。

## 経緯・意図・意思決定
- 従来通り、threat_impact, update_atの内容でsortするようにしました。
- threat_impactは昇順、update_atは降順になるようにしました。