### PR TITLE
topic/fix toggle button display

### DIFF
--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -251,14 +251,14 @@ export function PTeamNotificationSetting(props) {
             <AndroidSwitch checked={slackEnable} onChange={() => setSlackEnable(!slackEnable)} />
           }
           labelPlacement="start"
-          label="Email"
+          label="Slack"
         />
         <FormControlLabel
           control={
             <AndroidSwitch checked={mailEnable} onChange={() => setMailEnable(!mailEnable)} />
           }
           labelPlacement="start"
-          label="Slack"
+          label="Email"
         />
       </Box>
       <Divider />


### PR DESCRIPTION
## PR の目的
- pteam設定のところにあるnotificationのsend_byのtoggleボタンについて表示と内容が逆になっているため修正しました。
