### PR TITLE
Topic/api analysis by ticketstatus

### DIFF
--- a/api/app/routers/ateams.py
+++ b/api/app/routers/ateams.py
@@ -714,11 +714,6 @@ def get_topic_status(
 
     summary: list[dict] = []
     for row in rows:
-        if (
-            row.PTeamTopicTagStatus
-            and row.PTeamTopicTagStatus.topic_status == models.TopicStatusType.completed
-        ):
-            continue  # filter completed
         if len(summary) == 0 or summary[-1]["topic_id"] != row.topic_id:
             summary.append(
                 {
@@ -745,15 +740,13 @@ def get_topic_status(
         _pteam["statuses"].append(
             {
                 **(
-                    row.PTeamTopicTagStatus.__dict__
-                    if row.PTeamTopicTagStatus
-                    else {
-                        "topic_id": row.topic_id,
-                        "pteam_id": row.pteam_id,
-                        "topic_status": models.TopicStatusType.alerted,
-                    }
+                    row.TicketStatus.__dict__
+                    if row.TicketStatus
+                    else {"topic_status": models.TopicStatusType.alerted}
                 ),
-                # extended data not included in PTeamTopicTagStatus
+                # extended data not included in TicketStatus
+                "topic_id": row.topic_id,
+                "pteam_id": row.pteam_id,
                 "tag": row.Tag,
             }
         )

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -531,7 +531,7 @@ class FsServerInfo(ORMModel):
     api_url: str
 
 
-class PTeamTopicTagStatusSimple(ORMModel):
+class TicketStatusSimple(ORMModel):
     topic_id: UUID
     pteam_id: UUID
     tag: TagResponse
@@ -543,7 +543,7 @@ class PTeamTopicTagStatusSimple(ORMModel):
 class PTeamTopicStatuses(ORMModel):
     pteam_id: UUID
     pteam_name: str
-    statuses: list[PTeamTopicTagStatusSimple]
+    statuses: list[TicketStatusSimple]
 
 
 class ATeamTopicStatus(ORMModel):


### PR DESCRIPTION
## PR の目的

- Analysis ページに必要な ateams.py::get_topic_status を、廃止予定の PTeamTopicTagStatus に依存しないように改修
- test_get_topic_status() はテストコードの実装方針に即していないが、これは #210 で削除された項目を復帰＋調整したため
  - デグレチェックを優先して旧コードのまま復帰。テストコードの整理は別に行う

## 既知の問題

- 同一アーティファクトに対し、同一PTeamの複数Serviceが関連する場合に、UIのAnalysisページでServiceの個数の重複データが表示される。
  - Schema のデータ構造および UI のコードが、Service ごとのステータスに対応していないことが原因
  - 本 PR では「PTeamTopicTagStatus への依存性解消」が主目的であるため、この問題については別タスクで対応予定