### PR TITLE
topic/fix bug in status update

### DIFF
--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -18,7 +18,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getTopicStatus, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
+import {
+  getTopicStatus,
+  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTagsSummary,
+} from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
 
 import { ActionTypeChip } from "./ActionTypeChip";
@@ -73,6 +77,7 @@ export function ReportCompletedActions(props) {
       dispatch(
         getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
       );
+      dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
       enqueueSnackbar("Set topicstatus 'completed' succeeded", { variant: "success" });
     } catch (error) {
       enqueueSnackbar(`Operation failed: ${error}`, { variant: "error" });

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -13,21 +13,16 @@ import { red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getPTeamServiceTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
 export function TopicDeleteModal(props) {
-  const { topicId, onSetOpenTopicModal, onDelete, serviceId } = props;
+  const { topicId, onSetOpenTopicModal, onDelete } = props;
   const [open, setOpen] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
-
-  const pteamId = useSelector((state) => state.pteam.pteamId);
-  const dispatch = useDispatch();
 
   const operationError = (error) => {
     const resp = error.response ?? { status: "???", statusText: error.toString() };
@@ -40,7 +35,6 @@ export function TopicDeleteModal(props) {
     deleteTopic(topicId)
       .then(async () => {
         await Promise.all([
-          dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
           onDelete && onDelete(),
           enqueueSnackbar("delete topic succeeded", { variant: "success" }),
         ]);
@@ -96,5 +90,4 @@ TopicDeleteModal.propTypes = {
   topicId: PropTypes.string.isRequired,
   onSetOpenTopicModal: PropTypes.func.isRequired,
   onDelete: PropTypes.func,
-  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -13,16 +13,21 @@ import { red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
+import { getPTeamServiceTagsSummary } from "../slices/pteam";
 import { deleteTopic } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
 
 export function TopicDeleteModal(props) {
-  const { topicId, onSetOpenTopicModal, onDelete } = props;
+  const { topicId, onSetOpenTopicModal, onDelete, serviceId } = props;
   const [open, setOpen] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
+
+  const pteamId = useSelector((state) => state.pteam.pteamId);
+  const dispatch = useDispatch();
 
   const operationError = (error) => {
     const resp = error.response ?? { status: "???", statusText: error.toString() };
@@ -35,6 +40,7 @@ export function TopicDeleteModal(props) {
     deleteTopic(topicId)
       .then(async () => {
         await Promise.all([
+          dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
           onDelete && onDelete(),
           enqueueSnackbar("delete topic succeeded", { variant: "success" }),
         ]);
@@ -90,4 +96,5 @@ TopicDeleteModal.propTypes = {
   topicId: PropTypes.string.isRequired,
   onSetOpenTopicModal: PropTypes.func.isRequired,
   onDelete: PropTypes.func,
+  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -27,7 +27,11 @@ import uuid from "react-native-uuid";
 import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getPTeamTopicActions, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
+import {
+  getPTeamTopicActions,
+  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTagsSummary,
+} from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import {
   createTopic,
@@ -165,6 +169,7 @@ export function TopicModal(props) {
     await Promise.all([
       dispatch(getTopic(topicId)),
       dispatch(getPTeamTopicActions({ pteamId: pteamId, topicId: topicId })),
+      dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
     ]);
     // update only if needed
     if (pteamId && presetTagId) {
@@ -651,6 +656,7 @@ export function TopicModal(props) {
                     topicId={presetTopicId}
                     onSetOpenTopicModal={onSetOpen}
                     onDelete={handleDeleteTopic}
+                    serviceId={serviceId}
                   />
                 </Box>
               </Box>

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -342,6 +342,7 @@ export function TopicModal(props) {
         }),
       );
     }
+    dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
   };
 
   function ActionGeneratorModal() {
@@ -656,7 +657,6 @@ export function TopicModal(props) {
                     topicId={presetTopicId}
                     onSetOpenTopicModal={onSetOpen}
                     onDelete={handleDeleteTopic}
-                    serviceId={serviceId}
                   />
                 </Box>
               </Box>

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -26,7 +26,11 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getTopicStatus, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
+import {
+  getTopicStatus,
+  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTagsSummary,
+} from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
 import { topicStatusProps } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
@@ -78,7 +82,15 @@ export function TopicStatusSelector(props) {
     })
       .then(() => {
         if (selectedStatus !== ttStatus.topicStatus) {
-          dispatch(getTopicStatus({ pteamId: pteamId, topicId: topicId, tagId: tagId }));
+          dispatch(
+            getTopicStatus({
+              pteamId: pteamId,
+              serviceId: serviceId,
+              topicId: topicId,
+              tagId: tagId,
+            }),
+          );
+          dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
         }
         if (ttStatus.topic_status === "completed") {
           dispatch(


### PR DESCRIPTION
## PR の目的
- statu更新をしたときに、変更が画面上に反映されないバグを修正しました。

## 経緯・意図・意思決定
- completed な TopicCard で status をacknowledgeやschedulesに変更した後、TopicCard の内容が completed のまま更新されない問題
     -  原因としてはweb/src/components/TopicStatusSelector.jsxでdispatch(getTopicStatus)をする際にserviceIdが抜けていたためでした。
- Topic を completed にした後、Status ページに戻ると反映されていない問題
     - web/src/components/ReportCompletedActions.jsxで
     `dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }))`
     を入れていないためでした
- Topicを手動で作成し、statusページに戻ると反映されていない。またTopicを更新、削除した時も同様に起きている問題
     - web/src/components/TopicModal.jsx, web/src/components/TopicDeleteModal.jsxで
     `dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }))`
     を入れていないためでした