### PR TITLE
Topic/analysis topic status for each service

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -66,6 +66,8 @@ def get_ateam_topic_statuses(
             models.ATeamPTeam.ateam_id,
             models.PTeam.pteam_id,
             models.PTeam.pteam_name,
+            models.Service.service_id,
+            models.Service.service_name,
             models.Tag,
             models.Topic.topic_id,
             models.Topic.title,

--- a/api/app/routers/ateams.py
+++ b/api/app/routers/ateams.py
@@ -706,7 +706,6 @@ def get_topic_status(
     rows = command.get_ateam_topic_statuses(db, ateam_id, sort_key, search)
 
     # Caution:
-    #   rows includes completed. (how can i filter by query???)
     #   rows is already sorted by query based on query params. keep the order.
 
     def _pick_pteam(pteams_, pteam_id_):

--- a/api/app/routers/ateams.py
+++ b/api/app/routers/ateams.py
@@ -715,29 +715,29 @@ def get_topic_status(
     summary: list[dict] = []
     for row in rows:
         if len(summary) == 0 or summary[-1]["topic_id"] != row.topic_id:
-            summary.append(
+            summary.append(  # ATeamTopicStatus
                 {
                     "topic_id": row.topic_id,
                     "title": row.title,
                     "threat_impact": row.threat_impact,
                     "updated_at": row.updated_at,
                     "num_pteams": 0,
-                    "pteams": [],
+                    "pteam_statuses": [],
                 }
             )
         _topic = summary[-1]
-        _pteam = _pick_pteam(_topic["pteams"], row.pteam_id)
+        _pteam = _pick_pteam(_topic["pteam_statuses"], row.pteam_id)
         if _pteam is None:
-            _topic["pteams"].append(
+            _topic["pteam_statuses"].append(  # PTeamTopicStatus
                 {
                     "pteam_id": row.pteam_id,
                     "pteam_name": row.pteam_name,
-                    "statuses": [],
+                    "service_statuses": [],
                 }
             )
             _topic["num_pteams"] += 1
-            _pteam = _topic["pteams"][-1]
-        _pteam["statuses"].append(
+            _pteam = _topic["pteam_statuses"][-1]
+        _pteam["service_statuses"].append(  # ServiceTopicStatus
             {
                 **(
                     row.TicketStatus.__dict__
@@ -745,8 +745,8 @@ def get_topic_status(
                     else {"topic_status": models.TopicStatusType.alerted}
                 ),
                 # extended data not included in TicketStatus
-                "topic_id": row.topic_id,
-                "pteam_id": row.pteam_id,
+                "service_id": row.service_id,
+                "service_name": row.service_name,
                 "tag": row.Tag,
             }
         )

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -531,19 +531,19 @@ class FsServerInfo(ORMModel):
     api_url: str
 
 
-class TicketStatusSimple(ORMModel):
-    topic_id: UUID
-    pteam_id: UUID
+class ServiceTopicStatus(ORMModel):
+    service_id: UUID
+    service_name: str
     tag: TagResponse
     topic_status: TopicStatusType
     assignees: list[UUID] = []
     scheduled_at: datetime | None = None
 
 
-class PTeamTopicStatuses(ORMModel):
+class PTeamTopicStatus(ORMModel):
     pteam_id: UUID
     pteam_name: str
-    statuses: list[TicketStatusSimple]
+    service_statuses: list[ServiceTopicStatus]
 
 
 class ATeamTopicStatus(ORMModel):
@@ -552,7 +552,7 @@ class ATeamTopicStatus(ORMModel):
     threat_impact: int
     updated_at: datetime
     num_pteams: int
-    pteams: list[PTeamTopicStatuses]
+    pteam_statuses: list[PTeamTopicStatus]
 
 
 class ATeamTopicStatusResponse(ORMModel):

--- a/api/app/tests/medium/routers/test_ateams.py
+++ b/api/app/tests/medium/routers/test_ateams.py
@@ -1539,18 +1539,17 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC1["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic1.updated_at
     assert topic_statuses[0]["num_pteams"] == 1
-    assert len(topic_statuses[0]["pteams"]) == 1
-    pteam = topic_statuses[0]["pteams"][0]
-    assert UUID(pteam["pteam_id"]) == pteam1.pteam_id
-    assert pteam["pteam_name"] == PTEAM1["pteam_name"]
-    pteam_statuses = pteam["statuses"]
-    assert len(pteam_statuses) == 1
-    assert UUID(pteam_statuses[0]["topic_id"]) == topic1.topic_id
-    assert UUID(pteam_statuses[0]["pteam_id"]) == pteam1.pteam_id
-    assert pteam_statuses[0]["tag"] == schema_to_dict(tag1)
-    assert pteam_statuses[0]["topic_status"] == models.TopicStatusType.alerted
-    assert pteam_statuses[0]["assignees"] == []
-    assert pteam_statuses[0]["scheduled_at"] is None
+    assert len(topic_statuses[0]["pteam_statuses"]) == 1
+    pteam_status = topic_statuses[0]["pteam_statuses"][0]
+    assert UUID(pteam_status["pteam_id"]) == pteam1.pteam_id
+    assert pteam_status["pteam_name"] == PTEAM1["pteam_name"]
+    service_statuses = pteam_status["service_statuses"]
+    assert len(service_statuses) == 1
+    assert service_statuses[0]["service_name"] == SERVICE1
+    assert service_statuses[0]["tag"] == schema_to_dict(tag1)
+    assert service_statuses[0]["topic_status"] == models.TopicStatusType.alerted
+    assert service_statuses[0]["assignees"] == []
+    assert service_statuses[0]["scheduled_at"] is None
 
     # ack
     request = {
@@ -1568,18 +1567,17 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC1["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic1.updated_at
     assert topic_statuses[0]["num_pteams"] == 1
-    assert len(topic_statuses[0]["pteams"]) == 1
-    pteam = topic_statuses[0]["pteams"][0]
-    assert UUID(pteam["pteam_id"]) == pteam1.pteam_id
-    assert pteam["pteam_name"] == PTEAM1["pteam_name"]
-    pteam_statuses = pteam["statuses"]
-    assert len(pteam_statuses) == 1
-    assert UUID(pteam_statuses[0]["topic_id"]) == topic1.topic_id
-    assert UUID(pteam_statuses[0]["pteam_id"]) == pteam1.pteam_id
-    assert pteam_statuses[0]["tag"] == schema_to_dict(tag1)
-    assert pteam_statuses[0]["topic_status"] == models.TopicStatusType.acknowledged
-    assert set(map(UUID, pteam_statuses[0]["assignees"])) == set([user1.user_id])
-    assert pteam_statuses[0]["scheduled_at"] is None
+    assert len(topic_statuses[0]["pteam_statuses"]) == 1
+    pteam_status = topic_statuses[0]["pteam_statuses"][0]
+    assert UUID(pteam_status["pteam_id"]) == pteam1.pteam_id
+    assert pteam_status["pteam_name"] == PTEAM1["pteam_name"]
+    service_statuses = pteam_status["service_statuses"]
+    assert len(service_statuses) == 1
+    assert service_statuses[0]["service_name"] == SERVICE1
+    assert service_statuses[0]["tag"] == schema_to_dict(tag1)
+    assert service_statuses[0]["topic_status"] == models.TopicStatusType.acknowledged
+    assert set(map(UUID, service_statuses[0]["assignees"])) == set([user1.user_id])
+    assert service_statuses[0]["scheduled_at"] is None
 
     # schedule
     request = {
@@ -1599,17 +1597,16 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC1["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic1.updated_at
     assert topic_statuses[0]["num_pteams"] == 1
-    pteam = topic_statuses[0]["pteams"][0]
-    assert UUID(pteam["pteam_id"]) == pteam1.pteam_id
-    assert pteam["pteam_name"] == PTEAM1["pteam_name"]
-    pteam_statuses = pteam["statuses"]
-    assert len(pteam_statuses) == 1
-    assert UUID(pteam_statuses[0]["topic_id"]) == topic1.topic_id
-    assert UUID(pteam_statuses[0]["pteam_id"]) == pteam1.pteam_id
-    assert pteam_statuses[0]["tag"] == schema_to_dict(tag1)
-    assert pteam_statuses[0]["topic_status"] == models.TopicStatusType.scheduled
-    assert set(map(UUID, pteam_statuses[0]["assignees"])) == set([user1.user_id, user2.user_id])
-    assert datetime.fromisoformat(pteam_statuses[0]["scheduled_at"]) == datetime.fromisoformat(
+    pteam_status = topic_statuses[0]["pteam_statuses"][0]
+    assert UUID(pteam_status["pteam_id"]) == pteam1.pteam_id
+    assert pteam_status["pteam_name"] == PTEAM1["pteam_name"]
+    service_statuses = pteam_status["service_statuses"]
+    assert len(service_statuses) == 1
+    assert service_statuses[0]["service_name"] == SERVICE1
+    assert service_statuses[0]["tag"] == schema_to_dict(tag1)
+    assert service_statuses[0]["topic_status"] == models.TopicStatusType.scheduled
+    assert set(map(UUID, service_statuses[0]["assignees"])) == set([user1.user_id, user2.user_id])
+    assert datetime.fromisoformat(service_statuses[0]["scheduled_at"]) == datetime.fromisoformat(
         request["scheduled_at"]
     )
 
@@ -1651,44 +1648,44 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC1["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic1.updated_at
     assert topic_statuses[0]["num_pteams"] == 1
-    assert len(topic_statuses[0]["pteams"]) == 1
-    assert UUID(topic_statuses[0]["pteams"][0]["pteam_id"]) == pteam2.pteam_id
-    assert topic_statuses[0]["pteams"][0]["pteam_name"] == PTEAM2["pteam_name"]
-    assert len(topic_statuses[0]["pteams"][0]["statuses"]) == 1
-    assert UUID(topic_statuses[0]["pteams"][0]["statuses"][0]["topic_id"]) == topic1.topic_id
-    assert UUID(topic_statuses[0]["pteams"][0]["statuses"][0]["pteam_id"]) == pteam2.pteam_id
-    assert topic_statuses[0]["pteams"][0]["statuses"][0]["tag"] == schema_to_dict(tag1)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 1
+    assert UUID(topic_statuses[0]["pteam_statuses"][0]["pteam_id"]) == pteam2.pteam_id
+    assert topic_statuses[0]["pteam_statuses"][0]["pteam_name"] == PTEAM2["pteam_name"]
+    assert len(topic_statuses[0]["pteam_statuses"][0]["service_statuses"]) == 1
+    assert topic_statuses[0]["pteam_statuses"][0]["service_statuses"][0]["tag"] == schema_to_dict(
+        tag1
+    )
     assert (
-        topic_statuses[0]["pteams"][0]["statuses"][0]["topic_status"]
+        topic_statuses[0]["pteam_statuses"][0]["service_statuses"][0]["topic_status"]
         == models.TopicStatusType.alerted
     )
-    assert topic_statuses[0]["pteams"][0]["statuses"][0]["assignees"] == []
-    assert topic_statuses[0]["pteams"][0]["statuses"][0]["scheduled_at"] is None
+    assert topic_statuses[0]["pteam_statuses"][0]["service_statuses"][0]["assignees"] == []
+    assert topic_statuses[0]["pteam_statuses"][0]["service_statuses"][0]["scheduled_at"] is None
     # topic2
     assert UUID(topic_statuses[1]["topic_id"]) == topic2.topic_id
     assert topic_statuses[1]["title"] == TOPIC2["title"]
     assert topic_statuses[1]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[1]["updated_at"]) == topic2.updated_at
     assert topic_statuses[1]["num_pteams"] == 2
-    assert len(topic_statuses[1]["pteams"]) == 2
-    tmp1 = _pick_pteam(topic_statuses[1]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[1]["pteam_statuses"]) == 2
+    tmp1 = _pick_pteam(topic_statuses[1]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
+    assert len(tmp1["service_statuses"]) == 1
     # stXYZ = topicX + pteamY + tagZ
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.alerted
     assert st211["assignees"] == []
     assert st211["scheduled_at"] is None
-    tmp2 = _pick_pteam(topic_statuses[1]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[1]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 2
-    tmp221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 2
+    tmp221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert tmp221
     assert tmp221["topic_status"] == models.TopicStatusType.alerted
     assert tmp221["assignees"] == []
     assert tmp221["scheduled_at"] is None
-    tmp222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    tmp222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert tmp222
     assert tmp222["topic_status"] == models.TopicStatusType.alerted
     assert tmp222["assignees"] == []
@@ -1710,23 +1707,23 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.alerted
     assert st211["assignees"] == []
     assert st211["scheduled_at"] is None
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 2
-    st221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 2
+    st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.alerted
     assert st221["assignees"] == []
     assert st221["scheduled_at"] is None
-    st222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.alerted
     assert st222["assignees"] == []
     assert st222["scheduled_at"] is None
@@ -1747,25 +1744,25 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.alerted
     assert st211["assignees"] == []
     assert st211["scheduled_at"] is None
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 2
-    assert tmp2["statuses"][0]["topic_status"] == models.TopicStatusType.alerted  # worst first
-    assert tmp2["statuses"][1]["topic_status"] == models.TopicStatusType.acknowledged
-    st221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 2  # worst status first
+    assert tmp2["service_statuses"][0]["topic_status"] == models.TopicStatusType.alerted
+    assert tmp2["service_statuses"][1]["topic_status"] == models.TopicStatusType.acknowledged
+    st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.acknowledged
     assert st221["assignees"] == list(map(str, [user1.user_id]))
     assert st221["scheduled_at"] is None
-    st222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.alerted
     assert st222["assignees"] == []
     assert st222["scheduled_at"] is None
@@ -1787,27 +1784,27 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    assert UUID(topic_statuses[0]["pteams"][0]["pteam_id"]) == pteam1.pteam_id  # worst first
-    assert UUID(topic_statuses[0]["pteams"][1]["pteam_id"]) == pteam2.pteam_id
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2  # worst status first
+    assert UUID(topic_statuses[0]["pteam_statuses"][0]["pteam_id"]) == pteam1.pteam_id
+    assert UUID(topic_statuses[0]["pteam_statuses"][1]["pteam_id"]) == pteam2.pteam_id
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.alerted
     assert st211["assignees"] == []
     assert st211["scheduled_at"] is None
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 2
-    assert tmp2["statuses"][0]["topic_status"] == models.TopicStatusType.acknowledged  # worst first
-    assert tmp2["statuses"][1]["topic_status"] == models.TopicStatusType.scheduled
-    st221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 2  # worst status first
+    assert tmp2["service_statuses"][0]["topic_status"] == models.TopicStatusType.acknowledged
+    assert tmp2["service_statuses"][1]["topic_status"] == models.TopicStatusType.scheduled
+    st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.acknowledged
     assert st221["assignees"] == list(map(str, [user1.user_id]))
     assert st221["scheduled_at"] is None
-    st222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
     assert st222["assignees"] == []
     assert datetime.fromisoformat(st222["scheduled_at"]) == datetime.fromisoformat(
@@ -1831,29 +1828,29 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    assert UUID(topic_statuses[0]["pteams"][0]["pteam_id"]) == pteam2.pteam_id  # worst first
-    assert UUID(topic_statuses[0]["pteams"][1]["pteam_id"]) == pteam1.pteam_id
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2  # worst status first
+    assert UUID(topic_statuses[0]["pteam_statuses"][0]["pteam_id"]) == pteam2.pteam_id
+    assert UUID(topic_statuses[0]["pteam_statuses"][1]["pteam_id"]) == pteam1.pteam_id
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.scheduled
     assert st211["assignees"] == []
     assert datetime.fromisoformat(st211["scheduled_at"]) == datetime.fromisoformat(
         request["scheduled_at"]
     )
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 2
-    assert tmp2["statuses"][0]["topic_status"] == models.TopicStatusType.acknowledged  # worst first
-    assert tmp2["statuses"][1]["topic_status"] == models.TopicStatusType.scheduled
-    st221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 2  # worst status first
+    assert tmp2["service_statuses"][0]["topic_status"] == models.TopicStatusType.acknowledged
+    assert tmp2["service_statuses"][1]["topic_status"] == models.TopicStatusType.scheduled
+    st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.acknowledged
     assert st221["assignees"] == list(map(str, [user1.user_id]))
     assert st221["scheduled_at"] is None
-    st222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
     assert st222["assignees"] == []
 
@@ -1873,20 +1870,20 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    assert UUID(topic_statuses[0]["pteams"][0]["pteam_id"]) == pteam1.pteam_id  # later first(12/31)
-    assert UUID(topic_statuses[0]["pteams"][1]["pteam_id"]) == pteam2.pteam_id  # (3000/1/1)
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2  # later updated first(12/31)
+    assert UUID(topic_statuses[0]["pteam_statuses"][0]["pteam_id"]) == pteam1.pteam_id
+    assert UUID(topic_statuses[0]["pteam_statuses"][1]["pteam_id"]) == pteam2.pteam_id  # (3000/1/1)
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.scheduled
     assert st211["assignees"] == []
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 1
-    st222 = _pick_tag(tmp2["statuses"], tag2.tag_id)
+    assert len(tmp2["service_statuses"]) == 1
+    st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
     assert st222["assignees"] == []
 
@@ -1906,11 +1903,11 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 1
-    assert len(topic_statuses[0]["pteams"]) == 1
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 1
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211["topic_status"] == models.TopicStatusType.scheduled
     assert st211["assignees"] == []
 
@@ -1930,19 +1927,19 @@ def test_get_topic_status():
     assert topic_statuses[0]["threat_impact"] == TOPIC2["threat_impact"]
     assert datetime.fromisoformat(topic_statuses[0]["updated_at"]) == topic2.updated_at
     assert topic_statuses[0]["num_pteams"] == 2
-    assert len(topic_statuses[0]["pteams"]) == 2
-    assert UUID(topic_statuses[0]["pteams"][0]["pteam_id"]) == pteam2.pteam_id  # worst first
-    assert UUID(topic_statuses[0]["pteams"][1]["pteam_id"]) == pteam1.pteam_id
-    tmp1 = _pick_pteam(topic_statuses[0]["pteams"], pteam1.pteam_id)
+    assert len(topic_statuses[0]["pteam_statuses"]) == 2  # worst status first
+    assert UUID(topic_statuses[0]["pteam_statuses"][0]["pteam_id"]) == pteam2.pteam_id
+    assert UUID(topic_statuses[0]["pteam_statuses"][1]["pteam_id"]) == pteam1.pteam_id
+    tmp1 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam1.pteam_id)
     assert tmp1
-    assert len(tmp1["statuses"]) == 1
-    st211 = _pick_tag(tmp1["statuses"], tag1.tag_id)
+    assert len(tmp1["service_statuses"]) == 1
+    st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211["topic_status"] == models.TopicStatusType.scheduled
     assert st211["assignees"] == []
-    tmp2 = _pick_pteam(topic_statuses[0]["pteams"], pteam2.pteam_id)
+    tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
-    assert len(tmp2["statuses"]) == 1
-    st221 = _pick_tag(tmp2["statuses"], tag1.tag_id)
+    assert len(tmp2["service_statuses"]) == 1
+    st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.acknowledged
     assert st221["assignees"] == []
 

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -303,9 +303,9 @@ export function Analysis() {
           <Divider />
           {/* Topics */}
           <List sx={{ padding: 0 }} id="topicListElem">
-            {pageInfo.topic_statuses.map((topic, index) => (
+            {pageInfo.topic_statuses.map((topic) => (
               <ListItem
-                key={index}
+                key={topic.topic_id}
                 dense
                 disablePadding
                 divider={true}
@@ -325,7 +325,7 @@ export function Analysis() {
                           <Box display="flex" sx={{ color: grey[600] }}>
                             <GroupsIcon />
                             <Typography ml={1} fontWeight={900}>
-                              {topic.pteams.length}
+                              {topic.pteam_statuses.length /* FIXME: should count services? */}
                             </Typography>
                           </Box>
                         </Box>
@@ -333,12 +333,15 @@ export function Analysis() {
                           <Typography mt={1} mr={1} variant="caption">
                             {`Updated ${calcTimestampDiff(topic.updated_at)}`}
                           </Typography>
-                          {topic.pteams[0].statuses[0].topic_status === "scheduled" && (
+                          {topic.pteam_statuses[0]?.service_statuses[0]?.topic_status ===
+                            "scheduled" && (
                             <Box display="flex" alignItems="flex-end">
                               <CalendarMonthIcon fontSize="small" sx={{ color: grey[700] }} />
                               <Typography ml={0.5} variant="caption">
                                 {format(
-                                  utcStringToLocalDate(topic.pteams[0].statuses[0].scheduled_at),
+                                  utcStringToLocalDate(
+                                    topic.pteam_statuses[0].service_statuses[0].scheduled_at,
+                                  ),
                                   "yyyy/MM/dd",
                                 )}
                               </Typography>


### PR DESCRIPTION
## PR の目的

- Analysis ページ用の集計を Service 単位で束ねるように改修
  - ただし、Status は Ticket 単位で収集しているため、同一 Service+Tag が複数の Ticket に合致する場合、UI 上には同一Serviceが複数表示される
  - 副作用として pteams.py::get_pteamtag() に依存せずに済むようになっている