### PR TITLE
make get_pteamtag not rely on PTeamTopicTagStatus

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -223,18 +223,40 @@ def check_tag_is_related_to_topic(db: Session, tag: models.Tag, topic: models.To
     return row is not None and row.TopicTag is not None
 
 
-def get_last_updated_at_in_current_pteam_topic_tag_status(
+def get_last_updated_uncompleted_topic_by_pteam_id_and_tag_id(
     db: Session,
     pteam_id: UUID | str,
     tag_id: UUID | str,
-) -> datetime | None:
-    return db.scalars(
-        select(func.max(models.CurrentPTeamTopicTagStatus.updated_at)).where(
-            models.CurrentPTeamTopicTagStatus.pteam_id == str(pteam_id),
-            models.CurrentPTeamTopicTagStatus.tag_id == str(tag_id),
-            models.CurrentPTeamTopicTagStatus.topic_status != models.TopicStatusType.completed,
+) -> models.Topic | None:
+    last_updated_topic = db.scalars(
+        select(models.Topic)
+        .join(
+            models.Threat,
+            and_(
+                models.Threat.dependency_id.in_(
+                    select(models.Dependency.dependency_id).join(
+                        models.Service,
+                        and_(
+                            models.Dependency.tag_id == str(tag_id),
+                            models.Dependency.service_id == models.Service.service_id,
+                            models.Service.pteam_id == str(pteam_id),
+                        ),
+                    )
+                ),
+                models.Threat.topic_id == models.Topic.topic_id,
+            ),
         )
-    ).one()
+        .join(models.Ticket)
+        .join(
+            models.CurrentTicketStatus,
+            and_(
+                models.CurrentTicketStatus.ticket_id == models.Ticket.ticket_id,
+                models.CurrentTicketStatus.topic_status != models.TopicStatusType.completed,
+            ),
+        )
+        .order_by(models.Topic.updated_at.desc())
+    ).first()
+    return last_updated_topic
 
 
 def ticket_status_to_response(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -682,9 +682,10 @@ def get_pteamtag(
                     }
                 )
 
-    last_updated_at = command.get_last_updated_at_in_current_pteam_topic_tag_status(
+    last_updated_topic = command.get_last_updated_uncompleted_topic_by_pteam_id_and_tag_id(
         db, pteam_id, tag_id
     )
+    last_updated_at = last_updated_topic.updated_at if last_updated_topic else None
 
     return {
         "pteam_id": pteam_id,


### PR DESCRIPTION
## PR の目的

- pteams.py::get_pteamtag() を PTeamTopicTagStatus に依存しないように改修
  - 本メソッドを必要としているのは（ #216 により）Tag ページのみ。
    - 現状では Tag ページは Service 単位での情報を表示しているが、本メソッドでは PTeam 単位での最終更新日時を返しており、UI 表示的に適切でないと思われる。
    - 本メソッドを Service 指定に変更して解消することが望ましいが、本 PR では PTeamTopicTagStatus テーブルへの依存性排除を優先して対処しない
