### PR TITLE
Topic/obsolete updated at on tag page

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -170,9 +170,9 @@ def check_tag_is_related_to_topic(db: Session, tag: models.Tag, topic: models.To
     return row is not None and row.TopicTag is not None
 
 
-def get_last_updated_uncompleted_topic_by_pteam_id_and_tag_id(
+def get_last_updated_uncompleted_topic_by_service_id_and_tag_id(
     db: Session,
-    pteam_id: UUID | str,
+    service_id: UUID | str,
     tag_id: UUID | str,
 ) -> models.Topic | None:
     last_updated_topic = db.scalars(
@@ -181,13 +181,9 @@ def get_last_updated_uncompleted_topic_by_pteam_id_and_tag_id(
             models.Threat,
             and_(
                 models.Threat.dependency_id.in_(
-                    select(models.Dependency.dependency_id).join(
-                        models.Service,
-                        and_(
-                            models.Dependency.tag_id == str(tag_id),
-                            models.Dependency.service_id == models.Service.service_id,
-                            models.Service.pteam_id == str(pteam_id),
-                        ),
+                    select(models.Dependency.dependency_id).where(
+                        models.Dependency.tag_id == str(tag_id),
+                        models.Dependency.service_id == str(service_id),
                     )
                 ),
                 models.Threat.topic_id == models.Topic.topic_id,

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -170,38 +170,6 @@ def check_tag_is_related_to_topic(db: Session, tag: models.Tag, topic: models.To
     return row is not None and row.TopicTag is not None
 
 
-def get_last_updated_uncompleted_topic_by_service_id_and_tag_id(
-    db: Session,
-    service_id: UUID | str,
-    tag_id: UUID | str,
-) -> models.Topic | None:
-    last_updated_topic = db.scalars(
-        select(models.Topic)
-        .join(
-            models.Threat,
-            and_(
-                models.Threat.dependency_id.in_(
-                    select(models.Dependency.dependency_id).where(
-                        models.Dependency.tag_id == str(tag_id),
-                        models.Dependency.service_id == str(service_id),
-                    )
-                ),
-                models.Threat.topic_id == models.Topic.topic_id,
-            ),
-        )
-        .join(models.Ticket)
-        .join(
-            models.CurrentTicketStatus,
-            and_(
-                models.CurrentTicketStatus.ticket_id == models.Ticket.ticket_id,
-                models.CurrentTicketStatus.topic_status != models.TopicStatusType.completed,
-            ),
-        )
-        .order_by(models.Topic.updated_at.desc())
-    ).first()
-    return last_updated_topic
-
-
 def ticket_status_to_response(
     db: Session,
     status: models.TicketStatus,

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -249,6 +249,62 @@ def get_pteam_service_tags_summary(
     }
 
 
+@router.get(
+    "/{pteam_id}/services/{service_id}/tags/{tag_id}/last_updated_uncompleted_topic",
+    response_model=schemas.Topic,
+)
+def get_last_updated_uncompleted_topic_by_service_and_tag(
+    pteam_id: UUID,
+    service_id: UUID,
+    tag_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get last updated uncompleted topic matched with specified service and tag.
+    """
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(db, pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    if not next(filter(lambda x: x.service_id == str(service_id), pteam.services), None):
+        raise NO_SUCH_SERVICE
+    if not (tag := persistence.get_tag_by_id(db, tag_id)):
+        raise NO_SUCH_TAG
+    if tag not in pteam.tags:
+        raise NO_SUCH_PTEAM_TAG
+
+    last_updated_topic = command.get_last_updated_uncompleted_topic_by_service_id_and_tag_id(
+        db, service_id, tag_id
+    )
+    if not last_updated_topic:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No topic matched")
+
+    return last_updated_topic
+
+
+@router.get(
+    "/{pteam_id}/services/{service_id}/dependencies",
+    response_model=list[schemas.DependencyResponse],
+)
+def get_dependencies(
+    pteam_id: UUID,
+    service_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(db, pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    if not (
+        service := next(filter(lambda x: x.service_id == str(service_id), pteam.services), None)
+    ):
+        raise NO_SUCH_SERVICE
+
+    return service.dependencies
+
+
 @router.get("/{pteam_id}/tags", response_model=list[schemas.ExtTagResponse])
 def get_pteam_tags(
     pteam_id: UUID,
@@ -649,50 +705,6 @@ def get_pteam_auth(
         enums = models.PTeamAuthIntFlag(auth.authority).to_enums()
         response.append({"user_id": auth.user_id, "authorities": enums})
     return response
-
-
-@router.get("/{pteam_id}/tags/{tag_id}", response_model=schemas.PTeamtagExtResponse)
-def get_pteamtag(
-    pteam_id: UUID,
-    tag_id: UUID,
-    current_user: models.Account = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    Get detals of the pteam tag with last updated date.
-    """
-    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
-        raise NO_SUCH_PTEAM
-    if not check_pteam_membership(db, pteam, current_user):
-        raise NOT_A_PTEAM_MEMBER
-    if not (tag := persistence.get_tag_by_id(db, tag_id)):
-        raise NO_SUCH_TAG
-    if tag not in pteam.tags:
-        raise NO_SUCH_PTEAM_TAG
-
-    references = []
-    for service in pteam.services:
-        for dependency in service.dependencies:
-            if dependency.tag_id == str(tag_id):
-                references.append(
-                    {
-                        "service": service.service_name,
-                        "target": dependency.target,
-                        "version": dependency.version,
-                    }
-                )
-
-    last_updated_topic = command.get_last_updated_uncompleted_topic_by_pteam_id_and_tag_id(
-        db, pteam_id, tag_id
-    )
-    last_updated_at = last_updated_topic.updated_at if last_updated_topic else None
-
-    return {
-        "pteam_id": pteam_id,
-        "tag_id": tag_id,
-        "references": references,
-        "last_updated_at": last_updated_at,
-    }
 
 
 def _check_file_extention(file: UploadFile, extention: str):

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -250,40 +250,6 @@ def get_pteam_service_tags_summary(
 
 
 @router.get(
-    "/{pteam_id}/services/{service_id}/tags/{tag_id}/last_updated_uncompleted_topic",
-    response_model=schemas.Topic,
-)
-def get_last_updated_uncompleted_topic_by_service_and_tag(
-    pteam_id: UUID,
-    service_id: UUID,
-    tag_id: UUID,
-    current_user: models.Account = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    Get last updated uncompleted topic matched with specified service and tag.
-    """
-    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
-        raise NO_SUCH_PTEAM
-    if not check_pteam_membership(db, pteam, current_user):
-        raise NOT_A_PTEAM_MEMBER
-    if not next(filter(lambda x: x.service_id == str(service_id), pteam.services), None):
-        raise NO_SUCH_SERVICE
-    if not (tag := persistence.get_tag_by_id(db, tag_id)):
-        raise NO_SUCH_TAG
-    if tag not in pteam.tags:
-        raise NO_SUCH_PTEAM_TAG
-
-    last_updated_topic = command.get_last_updated_uncompleted_topic_by_service_id_and_tag_id(
-        db, service_id, tag_id
-    )
-    if not last_updated_topic:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No topic matched")
-
-    return last_updated_topic
-
-
-@router.get(
     "/{pteam_id}/services/{service_id}/dependencies",
     response_model=list[schemas.DependencyResponse],
 )

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -602,3 +602,11 @@ class ServiceTaggedTopics(ORMModel):
 class ServiceTaggedTopicsSolvedUnsolved(ORMModel):
     solved: ServiceTaggedTopics
     unsolved: ServiceTaggedTopics
+
+
+class DependencyResponse(ORMModel):
+    dependency_id: UUID
+    service_id: UUID
+    tag_id: UUID
+    version: str
+    target: str

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -40,7 +40,7 @@ export function PTeamEditAction(props) {
     presetParentTagId,
     presetActions,
     currentTagDict,
-    pteamtag,
+    references,
     serviceId,
   } = props;
 
@@ -233,8 +233,8 @@ export function PTeamEditAction(props) {
     (!action.ext?.vulnerable_versions?.[tagName]?.length > 0 ||
       parseVulnerableVersions(action.ext.vulnerable_versions[tagName]).some(
         (actionVersion) =>
-          !pteamtag.references?.length > 0 ||
-          pteamtag.references?.some((ref) =>
+          !references?.length > 0 ||
+          references?.some((ref) =>
             versionMatch(
               ref.version,
               actionVersion.ge,
@@ -389,6 +389,6 @@ PTeamEditAction.propTypes = {
     }),
   ),
   currentTagDict: PropTypes.object.isRequired,
-  pteamtag: PropTypes.object.isRequired,
+  references: PropTypes.array.isRequired,
   serviceId: PropTypes.string,
 };

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -9,7 +9,7 @@ import { ThreatImpactCountChip } from "./ThreatImpactCountChip";
 import { TopicCard } from "./TopicCard";
 
 export function PTeamTaggedTopics(props) {
-  const { pteamId, tagId, serviceId, isSolved, pteamtag } = props;
+  const { pteamId, tagId, serviceId, isSolved, references } = props;
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -84,7 +84,7 @@ export function PTeamTaggedTopics(props) {
               topicId={ticketId_topicId.topic_id}
               currentTagId={tagId}
               serviceId={serviceId}
-              pteamtag={pteamtag}
+              references={references}
             />
           </ListItem>
         ))}
@@ -98,5 +98,5 @@ PTeamTaggedTopics.propTypes = {
   tagId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
   isSolved: PropTypes.bool.isRequired,
-  pteamtag: PropTypes.object.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -49,7 +49,7 @@ import { UUIDTypography } from "./UUIDTypography";
 import { WarningTooltip } from "./WarningTooltip";
 
 export function TopicCard(props) {
-  const { pteamId, topicId, currentTagId, serviceId, pteamtag } = props;
+  const { pteamId, topicId, currentTagId, serviceId, references } = props;
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [topicModalOpen, setTopicModalOpen] = useState(false);
@@ -143,8 +143,8 @@ export function TopicCard(props) {
     (!action.ext?.vulnerable_versions?.[tagName]?.length > 0 ||
       parseVulnerableVersions(action.ext.vulnerable_versions[tagName]).some(
         (actionVersion) =>
-          !pteamtag.references?.length > 0 ||
-          pteamtag.references?.some((ref) =>
+          !references?.length > 0 ||
+          references?.some((ref) =>
             versionMatch(
               ref.version,
               actionVersion.ge,
@@ -204,7 +204,7 @@ export function TopicCard(props) {
       return pteamTopicActions[topicId]?.every((action) => {
         return parseVulnerableVersions(action.ext?.vulnerable_versions?.[tagName]).every(
           (actionVersion) => {
-            return pteamtag.references?.every((ref) => {
+            return references?.every((ref) => {
               return (
                 (actionVersion.ge === undefined || isComparable(ref.version, actionVersion.ge)) &&
                 (actionVersion.gt === undefined || isComparable(ref.version, actionVersion.gt)) &&
@@ -242,9 +242,9 @@ export function TopicCard(props) {
           </Box>
         </Box>
         <Box mt={3} mr={2} display="flex" flexDirection="row">
-          {pteamtag.references?.length === 0 && (
+          {references?.length === 0 && (
             <Alert severity="warning" ml={2}>
-              {"It cannot be auto-closed, because pteamtag reference is not set."}
+              {"It cannot be auto-closed, because reference is not set."}
             </Alert>
           )}
           {checkCompalable() === false && (
@@ -516,7 +516,7 @@ export function TopicCard(props) {
             presetParentTagId={currentTagDict.parent_id}
             presetActions={pteamTopicActions[topicId]}
             currentTagDict={currentTagDict}
-            pteamtag={pteamtag}
+            references={references}
             serviceId={serviceId}
           />
         </Box>
@@ -595,5 +595,5 @@ TopicCard.propTypes = {
   topicId: PropTypes.string.isRequired,
   currentTagId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
-  pteamtag: PropTypes.object.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -15,12 +15,10 @@ import {
   getPTeamMembers,
   getPTeamServiceTaggedTicketIds,
 } from "../slices/pteam";
-import { getLastUpdatedUncompletedTopicByServiceTag } from "../utils/api.js";
-import { a11yProps, calcTimestampDiff } from "../utils/func.js";
+import { a11yProps } from "../utils/func.js";
 
 export function Tag() {
   const [tabValue, setTabValue] = useState(0);
-  const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
 
   const user = useSelector((state) => state.user.user);
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by App
@@ -41,17 +39,6 @@ export function Tag() {
   const dependencies = serviceDependencies[serviceId];
   const currentTagDependencies = dependencies?.filter((dependency) => dependency.tag_id === tagId);
   const taggedTopics = taggedTopicsDict[tagId];
-
-  async function loadLastUpdatedAt(pteamId, serviceId, tagId) {
-    await getLastUpdatedUncompletedTopicByServiceTag(pteamId, serviceId, tagId)
-      .then((response) => {
-        const lastUpdatedTopic = response.data;
-        setLastUpdatedAt(lastUpdatedTopic.updated_at);
-      })
-      .catch((error) => {
-        setLastUpdatedAt(null);
-      });
-  }
 
   useEffect(() => {
     if (!user.user_id) return; // wait login completed
@@ -110,11 +97,6 @@ export function Tag() {
     }
   }, [dispatch, user.user_id, pteamId, members]);
 
-  useEffect(() => {
-    if (!pteamId || !serviceId || !tagId) return;
-    loadLastUpdatedAt(pteamId, serviceId, tagId);
-  }, [pteamId, serviceId, tagId]);
-
   if (!allTags || !pteam || !members || !currentTagDependencies || !taggedTopics) {
     return <>Now loading...</>;
   }
@@ -156,7 +138,6 @@ export function Tag() {
           </Box>
           <Typography mr={1} mb={1} variant="caption">
             <UUIDTypography sx={{ mr: 2 }}>{tagId}</UUIDTypography>
-            {`Updated ${calcTimestampDiff(lastUpdatedAt)}`}
           </Typography>
           <TagReferences references={references} serviceDict={serviceDict} />
         </Box>

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -1,12 +1,12 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 import {
+  getDependencies as apiGetDependencies,
   getPTeam as apiGetPTeam,
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
   getPTeamMembers as apiGetPTeamMembers,
   getPTeamServiceTaggedTicketIds as apiGetPTeamServiceTaggedTicketIds,
-  getPTeamTag as apiGetPTeamTag,
   getPTeamTopicActions as apiGetPTeamTopicActions,
   getTopicStatus as apiGetTopicStatus,
   getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
@@ -53,19 +53,14 @@ export const getPTeamMembers = createAsyncThunk(
     })),
 );
 
-export const getPTeamTag = createAsyncThunk(
-  "pteam/getPTeamTag",
+export const getDependencies = createAsyncThunk(
+  "pteam/getDependencies",
   async (data) =>
-    await apiGetPTeamTag(data.pteamId, data.tagId)
-      .then((response) => ({
-        pteamId: data.pteamId,
-        tagId: data.tagId,
-        data: response.data,
-      }))
-      .catch((error) => {
-        if (data.onError) data.onError(error);
-        throw error;
-      }),
+    await apiGetDependencies(data.pteamId, data.serviceId).then((response) => ({
+      pteamId: data.pteamId,
+      serviceId: data.serviceId,
+      data: response.data,
+    })),
 );
 
 export const getPTeamServiceTaggedTicketIds = createAsyncThunk(
@@ -121,7 +116,7 @@ const _initialState = {
   authInfo: undefined,
   authorities: undefined,
   members: undefined,
-  pteamtags: {},
+  serviceDependencies: {}, // dict[serviceId: list[dependency]]
   taggedTopics: {},
   topicStatus: {},
   topicActions: {},
@@ -161,11 +156,11 @@ const pteamSlice = createSlice({
         ...state,
         members: action.payload.data,
       }))
-      .addCase(getPTeamTag.fulfilled, (state, action) => ({
+      .addCase(getDependencies.fulfilled, (state, action) => ({
         ...state,
-        pteamtags: {
-          ...state.pteamtags,
-          [action.payload.tagId]: action.payload.data,
+        serviceDependencies: {
+          ...state.serviceDependencies,
+          [action.payload.serviceId]: action.payload.data,
         },
       }))
       .addCase(getPTeamServiceTaggedTicketIds.fulfilled, (state, action) => ({

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -36,8 +36,6 @@ export const getPTeamAuth = async (pteamId) => axios.get(`/pteams/${pteamId}/aut
 export const updatePTeamAuth = async (pteamId, data) =>
   axios.post(`/pteams/${pteamId}/authority`, data);
 
-export const getPTeamTag = async (pteamId, tagId) => axios.get(`/pteams/${pteamId}/tags/${tagId}`);
-
 export const getPTeamTopics = async (pteamId) => axios.get(`/pteams/${pteamId}/topics`);
 
 export const getPTeamServiceTaggedTicketIds = async (pteamId, serviceId, tagId) =>
@@ -85,6 +83,14 @@ export const uploadSBOMFile = async (pteamId, service, file, forceMode = true) =
 
 export const deletePTeamService = async (pteamId, service) =>
   axios.delete(`/pteams/${pteamId}/tags`, { params: { service: service } });
+
+export const getLastUpdatedUncompletedTopicByServiceTag = async (pteamId, serviceId, tagId) =>
+  axios.get(
+    `/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/last_updated_uncompleted_topic`,
+  );
+
+export const getDependencies = async (pteamId, serviceId) =>
+  axios.get(`/pteams/${pteamId}/services/${serviceId}/dependencies`);
 
 // ateams
 export const updateATeam = async (ateamId, data) => axios.put(`/ateams/${ateamId}`, data);

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -84,11 +84,6 @@ export const uploadSBOMFile = async (pteamId, service, file, forceMode = true) =
 export const deletePTeamService = async (pteamId, service) =>
   axios.delete(`/pteams/${pteamId}/tags`, { params: { service: service } });
 
-export const getLastUpdatedUncompletedTopicByServiceTag = async (pteamId, serviceId, tagId) =>
-  axios.get(
-    `/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/last_updated_uncompleted_topic`,
-  );
-
 export const getDependencies = async (pteamId, serviceId) =>
   axios.get(`/pteams/${pteamId}/services/${serviceId}/dependencies`);
 


### PR DESCRIPTION
## PR の目的

- Tag ページ上部（Tag 名の下）に表示されていた Updated の表示を廃止
  - 「選択中の Tag に関連し、選択中 Service が未解決なトピックの最終更新日時」を表示していた
  - 当該情報取得用の api も合わせて廃止。

前提となる #222 を先にマージしてください
