### PR TITLE
topic/leave search keywords when switching services

### DIFF
--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -221,6 +221,10 @@ export function Status() {
     const newParams = new URLSearchParams();
     newParams.set("pteamId", pteamId);
     newParams.set("serviceId", serviceId);
+    const params = new URLSearchParams(location.search);
+    if (params.get("word")) {
+      newParams.set("word", params.get("word"));
+    }
     navigate(location.pathname + "?" + newParams.toString());
   };
 

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -221,9 +221,8 @@ export function Status() {
     const newParams = new URLSearchParams();
     newParams.set("pteamId", pteamId);
     newParams.set("serviceId", serviceId);
-    const params = new URLSearchParams(location.search);
-    if (params.get("word")) {
-      newParams.set("word", params.get("word"));
+    if (searchWord) {
+      newParams.set("word", searchWord);
     }
     navigate(location.pathname + "?" + newParams.toString());
   };


### PR DESCRIPTION
## PR の目的
- pteamの画面で、serviceを切り替えた際に検索キーワードだけを引き継ぐようにしました

## 経緯・意図・意思決定
- URL上からwordを取ってきて、navigatに入れるようにしました
- wordがない時は入れないようにするため、条件分岐を入れました
