### PR TITLE
Topic/api tune get pteam service summary

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -442,3 +442,81 @@ def expire_ateam_watching_requests(db: Session) -> None:
         )
     )
     db.flush()
+
+
+def get_tags_summary_by_service_id(db: Session, service_id: UUID | str) -> list[dict]:
+    threat_impact = func.min(models.Topic.threat_impact).label("threat_impact")
+    updated_at = func.max(models.Topic.updated_at).label("updated_at")
+    summarize_stmt = (
+        select(
+            models.Tag.tag_id,
+            models.Tag.tag_name,
+            models.Tag.parent_id,
+            models.Tag.parent_name,
+            threat_impact,
+            updated_at,
+        )
+        .join(
+            models.Dependency,
+            and_(
+                models.Dependency.tag_id == models.Tag.tag_id,
+                models.Dependency.service_id == str(service_id),
+            ),
+        )
+        .outerjoin(models.Threat)
+        .outerjoin(models.Ticket)
+        .outerjoin(models.CurrentTicketStatus)
+        .outerjoin(
+            models.Topic,  # do not count completed topic
+            and_(
+                models.Topic.topic_id == models.Threat.topic_id,
+                models.CurrentTicketStatus.topic_status != models.TopicStatusType.completed,
+            ),
+        )
+        .group_by(models.Tag.tag_id)
+        .order_by(
+            func.coalesce(threat_impact, 4),
+            updated_at.desc().nullslast(),
+            models.Tag.tag_name,
+        )
+    )
+
+    count_status_stmt = (
+        select(
+            models.Tag.tag_id,
+            models.CurrentTicketStatus.topic_status,
+            func.count(models.CurrentTicketStatus.topic_status).label("num_status"),
+        )
+        .join(
+            models.Dependency,
+            and_(
+                models.Dependency.tag_id == models.Tag.tag_id,
+                models.Dependency.service_id == str(service_id),
+            ),
+        )
+        .join(models.Threat)
+        .join(models.Ticket)
+        .join(models.CurrentTicketStatus)
+        .group_by(models.Tag.tag_id, models.CurrentTicketStatus.topic_status)
+    )
+
+    status_count_dict = {
+        (row.tag_id, row.topic_status): row.num_status
+        for row in db.execute(count_status_stmt).all()
+    }
+    summary = [
+        {
+            "tag_id": row.tag_id,
+            "tag_name": row.tag_name,
+            "parent_id": row.parent_id,
+            "parent_name": row.parent_name,
+            "threat_impact": row.threat_impact,
+            "updated_at": row.updated_at,
+            "status_count": {
+                status_type.value: status_count_dict.get((row.tag_id, status_type.value), 0)
+                for status_type in list(models.TopicStatusType)
+            },
+        }
+        for row in db.execute(summarize_stmt).all()
+    ]
+    return summary

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -511,7 +511,6 @@ class PTeamServiceTagsSummary(ORMModel):
         tag_name: str
         parent_id: UUID | None
         parent_name: str | None
-        references: list[dict]
         threat_impact: int | None
         updated_at: datetime | None
         status_count: dict[str, int]  # TopicStatusType.value: tickets count

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2428,3 +2428,166 @@ def test_get_service_topic_status_with_ticket_status(testdb: Session):
     assert responsed_topicstatuses["user_id"] is not None
     assert responsed_topicstatuses["topic_status"] == set_request["topic_status"]
     assert responsed_topicstatuses["note"] == set_request["note"]
+
+
+class TestGetPTeamServiceTagsSummary:
+    @staticmethod
+    def _get_access_token(user: dict) -> str:
+        body = {
+            "username": user["email"],
+            "password": user["pass"],
+        }
+        response = client.post("/auth/token", data=body)
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        return data["access_token"]
+
+    @staticmethod
+    def _get_service_id_by_service_name(user: dict, pteam_id: UUID | str, service_name: str) -> str:
+        response = client.get(f"/pteams/{pteam_id}/services", headers=headers(user))
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        service = next(filter(lambda x: x["service_name"] == service_name, data))
+        return service["service_id"]
+
+    def test_returns_summary_even_if_no_topics(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+
+        # no topics, no threats, no tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_even_if_no_threats(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # create topic1
+        create_topic(USER1, TOPIC1)  # Tag1
+
+        # no threats nor tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_if_having_alerted_ticket(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        vulnerable_version = "1.2.0"  # vulnerable
+        refs0 = {tag1.tag_name: [(test_target, vulnerable_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # add actionable topic1
+        action1 = {
+            "action": "action one",
+            "action_type": "elimination",
+            "recommended": True,
+            "ext": {
+                "tags": [tag1.tag_name],
+                "vulnerable_versions": {
+                    tag1.tag_name: ["< 1.2.3"],  # > vulnerable_version
+                },
+            },
+        }
+        topic1 = create_topic(USER1, TOPIC1, actions=[action1])  # Tag1
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/services/{service_id1}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {
+            **{"1": 0, "2": 0, "3": 0, "4": 0},
+            str(topic1.threat_impact): 1,
+        }
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "threat_impact": topic1.threat_impact,
+                "updated_at": datetime.isoformat(topic1.updated_at),
+                "status_count": {
+                    **{status_type.value: 0 for status_type in list(models.TopicStatusType)},
+                    models.TopicStatusType.alerted.value: 1,  # default status is ALERTED
+                },
+            }
+        ]


### PR DESCRIPTION
## PR の目的

- get_pteam_service_tags_summary のチューニング
  - UI 側が references を参照しないように改修済のため、本メソッドのレスポンスから削除
  - サマリ生成に必要な処理のほぼ全てを DB に任せる形に改修
    - SQL ２発 ＋ Python 側での調整に ２ループ

