### PR TITLE
topic/add-test-in-test_pteams.py

### DIFF
--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -21,27 +21,18 @@ client = TestClient(app)
 
 
 @pytest.mark.parametrize(
-    "threat_impact, topic_status, solved_num, unsolved_num",
+    "topic_status, solved_num, unsolved_num",
     [
-        (1, models.TopicStatusType.acknowledged, 0, 1),
-        (2, models.TopicStatusType.acknowledged, 0, 1),
-        (3, models.TopicStatusType.acknowledged, 0, 1),
-        (4, models.TopicStatusType.acknowledged, 0, 1),
-        (1, models.TopicStatusType.completed, 1, 0),
-        (2, models.TopicStatusType.completed, 1, 0),
-        (3, models.TopicStatusType.completed, 1, 0),
-        (4, models.TopicStatusType.completed, 1, 0),
+        (models.TopicStatusType.acknowledged, 0, 1),
+        (models.TopicStatusType.scheduled, 0, 1),
+        (models.TopicStatusType.completed, 1, 0),
     ],
 )
-def test_get_service_tagged_ticket_ids(
-    testdb, threat_impact, topic_status, solved_num, unsolved_num
+def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
+    testdb, topic_status, solved_num, unsolved_num
 ):
-    topic = {
-        **TOPIC1,
-        "threat_impact": threat_impact,
-    }
 
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
 
     json_data = {
         "topic_status": topic_status,
@@ -71,33 +62,20 @@ def test_get_service_tagged_ticket_ids(
     assert response["solved"]["service_id"] == ticket_response["service_id"]
     assert response["solved"]["tag_id"] == ticket_response["tag_id"]
     assert len(response["solved"]["topic_ticket_ids"]) == solved_num
-    solved_threat_impact_count = {
-        "1": 0,
-        "2": 0,
-        "3": 0,
-        "4": 0,
-    }
+
     if solved_num == 1:
         assert (
             ticket_response["ticket_id"]
             in response["solved"]["topic_ticket_ids"][0]["ticket_ids"][0]
         )
         assert response["solved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-        solved_threat_impact_count[str(threat_impact)] += 1
-
-    assert response["solved"]["threat_impact_count"] == solved_threat_impact_count
 
     # unsolved
     assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
     assert response["unsolved"]["service_id"] == ticket_response["service_id"]
     assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
     assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
-    unsolved_threat_impact_count = {
-        "1": 0,
-        "2": 0,
-        "3": 0,
-        "4": 0,
-    }
+
     if unsolved_num == 1:
         assert (
             ticket_response["ticket_id"]
@@ -106,6 +84,65 @@ def test_get_service_tagged_ticket_ids(
         assert (
             response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
         )
-        unsolved_threat_impact_count[str(threat_impact)] += 1
 
-    assert response["unsolved"]["threat_impact_count"] == unsolved_threat_impact_count
+
+@pytest.mark.parametrize(
+    "threat_impact, threat_impact_count",
+    [
+        (1, {"1": 1, "2": 0, "3": 0, "4": 0}),
+        (2, {"1": 0, "2": 1, "3": 0, "4": 0}),
+        (3, {"1": 0, "2": 0, "3": 1, "4": 0}),
+        (4, {"1": 0, "2": 0, "3": 0, "4": 1}),
+    ],
+)
+def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
+    testdb, threat_impact, threat_impact_count
+):
+    topic = {
+        **TOPIC1,
+        "threat_impact": threat_impact,
+    }
+
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic, ACTION1)
+
+    json_data = {
+        "topic_status": models.TopicStatusType.acknowledged,
+        "note": "string",
+        "assignees": [],
+        "scheduled_at": str(datetime.now()),
+    }
+    create_service_topicstatus(
+        USER1,
+        ticket_response["pteam_id"],
+        ticket_response["service_id"],
+        ticket_response["topic_id"],
+        ticket_response["tag_id"],
+        json_data,
+    )
+
+    # create current_ticket_status table
+    response = client.get(
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        headers=headers(USER1),
+    )
+    assert response.status_code == 200
+    response = response.json()
+
+    # solved
+    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["solved"]["service_id"] == ticket_response["service_id"]
+    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["solved"]["topic_ticket_ids"]) == 0
+    assert response["solved"]["topic_ticket_ids"] == []
+    assert response["solved"]["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 0}
+
+    # unsolved
+    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
+    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["unsolved"]["topic_ticket_ids"]) == 1
+    assert (
+        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+    )
+    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
+    assert response["unsolved"]["threat_impact_count"] == threat_impact_count

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -1,0 +1,111 @@
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import models
+from app.main import app
+from app.tests.common import ticket_utils
+from app.tests.medium.constants import (
+    ACTION1,
+    PTEAM1,
+    TOPIC1,
+    USER1,
+)
+from app.tests.medium.utils import (
+    create_service_topicstatus,
+    headers,
+)
+
+client = TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "threat_impact, topic_status, solved_num, unsolved_num",
+    [
+        (1, models.TopicStatusType.acknowledged, 0, 1),
+        (2, models.TopicStatusType.acknowledged, 0, 1),
+        (3, models.TopicStatusType.acknowledged, 0, 1),
+        (4, models.TopicStatusType.acknowledged, 0, 1),
+        (1, models.TopicStatusType.completed, 1, 0),
+        (2, models.TopicStatusType.completed, 1, 0),
+        (3, models.TopicStatusType.completed, 1, 0),
+        (4, models.TopicStatusType.completed, 1, 0),
+    ],
+)
+def test_get_service_tagged_ticket_ids(
+    testdb, threat_impact, topic_status, solved_num, unsolved_num
+):
+    topic = {
+        **TOPIC1,
+        "threat_impact": threat_impact,
+    }
+
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic, ACTION1)
+
+    json_data = {
+        "topic_status": topic_status,
+        "note": "string",
+        "assignees": [],
+        "scheduled_at": str(datetime.now()),
+    }
+    create_service_topicstatus(
+        USER1,
+        ticket_response["pteam_id"],
+        ticket_response["service_id"],
+        ticket_response["topic_id"],
+        ticket_response["tag_id"],
+        json_data,
+    )
+
+    # create current_ticket_status table
+    response = client.get(
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        headers=headers(USER1),
+    )
+    assert response.status_code == 200
+    response = response.json()
+
+    # solved
+    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["solved"]["service_id"] == ticket_response["service_id"]
+    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["solved"]["topic_ticket_ids"]) == solved_num
+    solved_threat_impact_count = {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+    }
+    if solved_num == 1:
+        assert (
+            ticket_response["ticket_id"]
+            in response["solved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+        )
+        assert response["solved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
+        solved_threat_impact_count[str(threat_impact)] += 1
+
+    assert response["solved"]["threat_impact_count"] == solved_threat_impact_count
+
+    # unsolved
+    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
+    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
+    unsolved_threat_impact_count = {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+    }
+    if unsolved_num == 1:
+        assert (
+            ticket_response["ticket_id"]
+            in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+        )
+        assert (
+            response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
+        )
+        unsolved_threat_impact_count[str(threat_impact)] += 1
+
+    assert response["unsolved"]["threat_impact_count"] == unsolved_threat_impact_count

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -23,12 +23,10 @@ client = TestClient(app)
 @pytest.mark.parametrize(
     "topic_status, solved_num, unsolved_num",
     [
-        (models.TopicStatusType.acknowledged, 0, 1),
-        (models.TopicStatusType.scheduled, 0, 1),
         (models.TopicStatusType.completed, 1, 0),
     ],
 )
-def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
+def test_it_should_return_solved_number_based_on_ticket_status(
     testdb, topic_status, solved_num, unsolved_num
 ):
 
@@ -49,7 +47,58 @@ def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
         json_data,
     )
 
-    # create current_ticket_status table
+    response = client.get(
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        headers=headers(USER1),
+    )
+    assert response.status_code == 200
+    response = response.json()
+
+    # solved
+    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["solved"]["service_id"] == ticket_response["service_id"]
+    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["solved"]["topic_ticket_ids"]) == solved_num
+    assert (
+        ticket_response["ticket_id"] in response["solved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+    )
+    assert response["solved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
+
+    # unsolved
+    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
+    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
+    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
+    assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
+
+
+@pytest.mark.parametrize(
+    "topic_status, solved_num, unsolved_num",
+    [
+        (models.TopicStatusType.acknowledged, 0, 1),
+        (models.TopicStatusType.scheduled, 0, 1),
+    ],
+)
+def test_it_should_return_unsolved_number_based_on_ticket_status(
+    testdb, topic_status, solved_num, unsolved_num
+):
+
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+
+    json_data = {
+        "topic_status": topic_status,
+        "note": "string",
+        "assignees": [],
+        "scheduled_at": str(datetime.now()),
+    }
+    create_service_topicstatus(
+        USER1,
+        ticket_response["pteam_id"],
+        ticket_response["service_id"],
+        ticket_response["topic_id"],
+        ticket_response["tag_id"],
+        json_data,
+    )
+
     response = client.get(
         f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
         headers=headers(USER1),
@@ -63,27 +112,15 @@ def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
     assert response["solved"]["tag_id"] == ticket_response["tag_id"]
     assert len(response["solved"]["topic_ticket_ids"]) == solved_num
 
-    if solved_num == 1:
-        assert (
-            ticket_response["ticket_id"]
-            in response["solved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-        )
-        assert response["solved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-
     # unsolved
     assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
     assert response["unsolved"]["service_id"] == ticket_response["service_id"]
     assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
     assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
-
-    if unsolved_num == 1:
-        assert (
-            ticket_response["ticket_id"]
-            in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-        )
-        assert (
-            response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-        )
+    assert (
+        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
+    )
+    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
 
 
 @pytest.mark.parametrize(
@@ -139,7 +176,7 @@ def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
         ),
     ],
 )
-def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
+def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     testdb, threat_impact, topic_status, solved_threat_impact_count, unsolved_threat_impact_count
 ):
     topic = {
@@ -164,7 +201,6 @@ def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
         json_data,
     )
 
-    # create current_ticket_status table
     response = client.get(
         f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
         headers=headers(USER1),

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -87,16 +87,60 @@ def test_get_service_tagged_ticket_ids_when_change_the_topic_status_type(
 
 
 @pytest.mark.parametrize(
-    "threat_impact, threat_impact_count",
+    "threat_impact, topic_status, solved_threat_impact_count, unsolved_threat_impact_count",
     [
-        (1, {"1": 1, "2": 0, "3": 0, "4": 0}),
-        (2, {"1": 0, "2": 1, "3": 0, "4": 0}),
-        (3, {"1": 0, "2": 0, "3": 1, "4": 0}),
-        (4, {"1": 0, "2": 0, "3": 0, "4": 1}),
+        (
+            1,
+            models.TopicStatusType.completed,
+            {"1": 1, "2": 0, "3": 0, "4": 0},
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+        ),
+        (
+            2,
+            models.TopicStatusType.completed,
+            {"1": 0, "2": 1, "3": 0, "4": 0},
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+        ),
+        (
+            3,
+            models.TopicStatusType.completed,
+            {"1": 0, "2": 0, "3": 1, "4": 0},
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+        ),
+        (
+            4,
+            models.TopicStatusType.completed,
+            {"1": 0, "2": 0, "3": 0, "4": 1},
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+        ),
+        (
+            1,
+            models.TopicStatusType.acknowledged,
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+            {"1": 1, "2": 0, "3": 0, "4": 0},
+        ),
+        (
+            2,
+            models.TopicStatusType.acknowledged,
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+            {"1": 0, "2": 1, "3": 0, "4": 0},
+        ),
+        (
+            3,
+            models.TopicStatusType.acknowledged,
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+            {"1": 0, "2": 0, "3": 1, "4": 0},
+        ),
+        (
+            4,
+            models.TopicStatusType.acknowledged,
+            {"1": 0, "2": 0, "3": 0, "4": 0},
+            {"1": 0, "2": 0, "3": 0, "4": 1},
+        ),
     ],
 )
 def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
-    testdb, threat_impact, threat_impact_count
+    testdb, threat_impact, topic_status, solved_threat_impact_count, unsolved_threat_impact_count
 ):
     topic = {
         **TOPIC1,
@@ -106,7 +150,7 @@ def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
     ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic, ACTION1)
 
     json_data = {
-        "topic_status": models.TopicStatusType.acknowledged,
+        "topic_status": topic_status,
         "note": "string",
         "assignees": [],
         "scheduled_at": str(datetime.now()),
@@ -132,17 +176,10 @@ def test_get_service_tagged_ticket_ids_when_change_the_threat_impact(
     assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
     assert response["solved"]["service_id"] == ticket_response["service_id"]
     assert response["solved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["solved"]["topic_ticket_ids"]) == 0
-    assert response["solved"]["topic_ticket_ids"] == []
-    assert response["solved"]["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 0}
+    assert response["solved"]["threat_impact_count"] == solved_threat_impact_count
 
     # unsolved
     assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
     assert response["unsolved"]["service_id"] == ticket_response["service_id"]
     assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["unsolved"]["topic_ticket_ids"]) == 1
-    assert (
-        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-    )
-    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-    assert response["unsolved"]["threat_impact_count"] == threat_impact_count
+    assert response["unsolved"]["threat_impact_count"] == unsolved_threat_impact_count

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1932,50 +1932,6 @@ def test_upload_pteam_tags_file_with_unexist_tagnames():
         upload_pteam_tags(USER1, pteam1.pteam_id, "threatconnectome", refs, force_mode=False)
 
 
-def test_get_service_tagged_ticket_ids(testdb):
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
-
-    json_data = {
-        "topic_status": "acknowledged",
-        "note": "string",
-        "assignees": [],
-        "scheduled_at": str(datetime.now()),
-    }
-    create_service_topicstatus(
-        USER1,
-        ticket_response["pteam_id"],
-        ticket_response["service_id"],
-        ticket_response["topic_id"],
-        ticket_response["tag_id"],
-        json_data,
-    )
-
-    # create current_ticket_status table
-    response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
-        headers=headers(USER1),
-    )
-    assert response.status_code == 200
-    response = response.json()
-
-    # solved
-    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["solved"]["service_id"] == ticket_response["service_id"]
-    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
-    assert response["solved"]["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 0}
-    assert response["solved"]["topic_ticket_ids"] == []
-
-    # unsolved
-    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
-    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
-    assert response["unsolved"]["threat_impact_count"] == {"1": 1, "2": 0, "3": 0, "4": 0}
-    assert (
-        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-    )
-    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-
-
 def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):
     # create current_ticket_status table
     ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)


### PR DESCRIPTION
## PR の目的
- mainブランチにマージするに向けて、足りていないテストケースを追加しました.

## 経緯・意図・意思決定
- test_get_service_tagged_ticket_idsについて1つのテストケースしか試せていなかったので、@pytest.mark.parametrizeを用いて複数の値を入れて検証できるようにしました。
- テストの役割的にシステムの仕様を検証するものなので、requestディレクトリにあるtest_pteams.pyではなくintegrationsディレクトリに新しくtest_pteams.pyを作り、記述しました。
-以前のテストの内容では、get_service_tagged_ticket_ids APIを検証するにあたりunsolvedのものを1つ登録し正しい値が返ってくるかを検証していました。今回のテストではthreat_impact, topic_statusを変えて、solved、unsolvedともに正しい値が返ってくるかを検証しています。
