### PR TITLE
Topic/api patch get db for background tasks

### DIFF
--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2205,7 +2205,6 @@ def test_remove_watcher():
     assert len(data) == 0
 
 
-@pytest.mark.skip(reason="TODO: figure out how to test background tasks")
 def test_upload_pteam_sbom_file_with_syft():
     create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)
@@ -2228,7 +2227,6 @@ def test_upload_pteam_sbom_file_with_syft():
     assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
 
 
-@pytest.mark.skip(reason="TODO: figure out how to test background tasks")
 def test_upload_pteam_sbom_file_with_trivy():
     create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)
@@ -2290,7 +2288,7 @@ def test_upload_pteam_sbom_file_with_wrong_filename():
     assert data["detail"] == "Please upload a file with .json as extension"
 
 
-@pytest.mark.skip(reason="TODO: figure out how to test background tasks")
+@pytest.mark.skip(reason="TODO: need api to get background task status")
 def test_upload_pteam_sbom_file_wrong_content_format():
     create_user(USER1)
     pteam = create_pteam(USER1, PTEAM1)


### PR DESCRIPTION
## PR の目的

- BackgroundTasks 内から（open_db_session 経由で）呼ばれる get_db を、testdb を yield する関数で mock.patch するように調整
  - BackgroundTasks およびテストコードの両方が、同一の testdb を参照します。
- patch する関数（override_get_db）で握り潰していた sql_error を print するように調整
  - SQL の内容によっては非常に冗長かもしれませんが、ご容赦を。
  ```
  SQL ERROR: (psycopg2.errors.NotNullViolation) null value in column "pteam_name" of relation "pteam" violates not-null constraint
  DETAIL:  Failing row contains (40dbd7a6-964b-465c-9cbd-08f6a67d4d28, null, alpha@ml.com, 3).
  
  [SQL: INSERT INTO pteam (pteam_id, pteam_name, contact_info, alert_threat_impact) VALUES (%(pteam_id)s, %(pteam_name)s, %(contact_info)s, %(alert_threat_impact)s)]
  [parameters: {'pteam_id': '40dbd7a6-964b-465c-9cbd-08f6a67d4d28', 'pteam_name': None, 'contact_info': 'alpha@ml.com', 'alert_threat_impact': 3}]
  ```
