### PR TITLE
topic/add test get_service_tagged_ticket_ids

### DIFF
--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
@@ -6,14 +7,10 @@ from fastapi.testclient import TestClient
 from app import models
 from app.main import app
 from app.tests.common import ticket_utils
-from app.tests.medium.constants import (
-    ACTION1,
-    PTEAM1,
-    TOPIC1,
-    USER1,
-)
+from app.tests.medium.constants import PTEAM1, TOPIC1, USER1
 from app.tests.medium.utils import (
     create_service_topicstatus,
+    create_topic_with_versioned_actions,
     headers,
 )
 
@@ -30,7 +27,7 @@ def test_it_should_return_solved_number_based_on_ticket_status(
     testdb, topic_status, solved_num, unsolved_num
 ):
 
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": topic_status,
@@ -82,7 +79,7 @@ def test_it_should_return_unsolved_number_based_on_ticket_status(
     testdb, topic_status, solved_num, unsolved_num
 ):
 
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": topic_status,
@@ -184,7 +181,7 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
         "threat_impact": threat_impact,
     }
 
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic)
 
     json_data = {
         "topic_status": topic_status,
@@ -219,3 +216,301 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     assert response["unsolved"]["service_id"] == ticket_response["service_id"]
     assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
     assert response["unsolved"]["threat_impact_count"] == unsolved_threat_impact_count
+
+
+@pytest.mark.parametrize(
+    "_topic1, _topic2, _topic3, _topic4, sorted_titles",
+    [
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 2, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 4, "title": "topic four"},
+            ["topic one", "topic two", "topic three", "topic four"],
+        ),
+        (
+            {"threat_impact": 4, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 2, "title": "topic three"},
+            {"threat_impact": 1, "title": "topic four"},
+            ["topic four", "topic three", "topic two", "topic one"],
+        ),
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 2, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic one", "topic two", "topic four", "topic three"],
+        ),
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic one", "topic four", "topic three", "topic two"],
+        ),
+        (
+            {"threat_impact": 3, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic four", "topic three", "topic two", "topic one"],
+        ),
+    ],
+)
+def test_it_shoud_return_solved_sorted_title_based_on_threat_impact(
+    testdb, _topic1, _topic2, _topic3, _topic4, sorted_titles
+):
+    topic1 = {
+        **TOPIC1,
+        "title": _topic1["title"],
+        "threat_impact": _topic1["threat_impact"],
+    }
+    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic1)
+
+    topic2 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic2["title"],
+        "threat_impact": _topic2["threat_impact"],
+    }
+    topic3 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic3["title"],
+        "threat_impact": _topic3["threat_impact"],
+    }
+    topic4 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic4["title"],
+        "threat_impact": _topic4["threat_impact"],
+    }
+    topic_response2 = create_topic_with_versioned_actions(
+        USER1, topic2, [[ticket_response1["tag_name"]]]
+    )
+    topic_response3 = create_topic_with_versioned_actions(
+        USER1, topic3, [[ticket_response1["tag_name"]]]
+    )
+    topic_response4 = create_topic_with_versioned_actions(
+        USER1, topic4, [[ticket_response1["tag_name"]]]
+    )
+
+    json_data = {
+        "topic_status": models.TopicStatusType.completed,
+        "note": "string",
+        "assignees": [],
+        "scheduled_at": str(datetime.now()),
+    }
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        ticket_response1["topic_id"],
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response2.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response3.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response4.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+
+    response = client.get(
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/ticket_ids",
+        headers=headers(USER1),
+    )
+    assert response.status_code == 200
+    response_json = response.json()
+
+    # solved
+    assert response_json["solved"]["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["solved"]["service_id"] == ticket_response1["service_id"]
+    assert response_json["solved"]["tag_id"] == ticket_response1["tag_id"]
+    topic_title_list = []
+    for topic_ticket_id in response_json["solved"]["topic_ticket_ids"]:
+        response_topic = client.get(
+            f"/topics/{topic_ticket_id['topic_id']}",
+            headers=headers(USER1),
+        )
+        topic = response_topic.json()
+        topic_title_list.append(topic["title"])
+
+    assert topic_title_list == sorted_titles
+
+    # unsolved
+    assert response_json["unsolved"]["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["unsolved"]["service_id"] == ticket_response1["service_id"]
+    assert response_json["unsolved"]["tag_id"] == ticket_response1["tag_id"]
+    assert len(response_json["unsolved"]["topic_ticket_ids"]) == 0
+
+
+@pytest.mark.parametrize(
+    "_topic1, _topic2, _topic3, _topic4, sorted_titles",
+    [
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 2, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 4, "title": "topic four"},
+            ["topic one", "topic two", "topic three", "topic four"],
+        ),
+        (
+            {"threat_impact": 4, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 2, "title": "topic three"},
+            {"threat_impact": 1, "title": "topic four"},
+            ["topic four", "topic three", "topic two", "topic one"],
+        ),
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 2, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic one", "topic two", "topic four", "topic three"],
+        ),
+        (
+            {"threat_impact": 1, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic one", "topic four", "topic three", "topic two"],
+        ),
+        (
+            {"threat_impact": 3, "title": "topic one"},
+            {"threat_impact": 3, "title": "topic two"},
+            {"threat_impact": 3, "title": "topic three"},
+            {"threat_impact": 3, "title": "topic four"},
+            ["topic four", "topic three", "topic two", "topic one"],
+        ),
+    ],
+)
+def test_it_shoud_return_unsolved_sorted_title_based_on_threat_impact(
+    testdb, _topic1, _topic2, _topic3, _topic4, sorted_titles
+):
+    topic1 = {
+        **TOPIC1,
+        "title": _topic1["title"],
+        "threat_impact": _topic1["threat_impact"],
+    }
+    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic1)
+
+    topic2 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic2["title"],
+        "threat_impact": _topic2["threat_impact"],
+    }
+    topic3 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic3["title"],
+        "threat_impact": _topic3["threat_impact"],
+    }
+    topic4 = {
+        **TOPIC1,
+        "topic_id": uuid4(),
+        "tag_name": ticket_response1["tag_name"],
+        "title": _topic4["title"],
+        "threat_impact": _topic4["threat_impact"],
+    }
+    topic_response2 = create_topic_with_versioned_actions(
+        USER1, topic2, [[ticket_response1["tag_name"]]]
+    )
+    topic_response3 = create_topic_with_versioned_actions(
+        USER1, topic3, [[ticket_response1["tag_name"]]]
+    )
+    topic_response4 = create_topic_with_versioned_actions(
+        USER1, topic4, [[ticket_response1["tag_name"]]]
+    )
+
+    json_data = {
+        "topic_status": models.TopicStatusType.acknowledged,
+        "note": "string",
+        "assignees": [],
+        "scheduled_at": str(datetime.now()),
+    }
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        ticket_response1["topic_id"],
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response2.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response3.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+    create_service_topicstatus(
+        USER1,
+        ticket_response1["pteam_id"],
+        ticket_response1["service_id"],
+        topic_response4.topic_id,
+        ticket_response1["tag_id"],
+        json_data,
+    )
+
+    response = client.get(
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/ticket_ids",
+        headers=headers(USER1),
+    )
+    assert response.status_code == 200
+    response_json = response.json()
+
+    # solved
+    assert response_json["solved"]["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["solved"]["service_id"] == ticket_response1["service_id"]
+    assert response_json["solved"]["tag_id"] == ticket_response1["tag_id"]
+    assert len(response_json["solved"]["topic_ticket_ids"]) == 0
+
+    # unsolved
+    assert response_json["unsolved"]["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["unsolved"]["service_id"] == ticket_response1["service_id"]
+    assert response_json["unsolved"]["tag_id"] == ticket_response1["tag_id"]
+    topic_title_list = []
+    for topic_ticket_id in response_json["unsolved"]["topic_ticket_ids"]:
+        response_topic = client.get(
+            f"/topics/{topic_ticket_id['topic_id']}",
+            headers=headers(USER1),
+        )
+        topic = response_topic.json()
+        topic_title_list.append(topic["title"])
+
+    assert topic_title_list == sorted_titles

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1934,7 +1934,7 @@ def test_upload_pteam_tags_file_with_unexist_tagnames():
 
 def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):
     # create current_ticket_status table
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": "acknowledged",
@@ -1963,7 +1963,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):
 
 def test_service_tagged_ticket_ids_with_wrong_pteam_member(testdb):
     # create current_ticket_status table
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": "acknowledged",
@@ -1992,7 +1992,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_member(testdb):
 
 def test_service_tagged_ticket_ids_with_wrong_service_id(testdb):
     # create current_ticket_status table
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": "acknowledged",
@@ -2021,8 +2021,8 @@ def test_service_tagged_ticket_ids_with_wrong_service_id(testdb):
 
 def test_service_tagged_ticket_ids_with_service_not_in_pteam(testdb):
     # create current_ticket_status table
-    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
-    ticket_response2 = ticket_utils.create_ticket(testdb, USER2, PTEAM2, TOPIC2, ACTION2)
+    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
+    ticket_response2 = ticket_utils.create_ticket(testdb, USER2, PTEAM2, TOPIC2)
 
     json_data = {
         "topic_status": "acknowledged",
@@ -2050,7 +2050,7 @@ def test_service_tagged_ticket_ids_with_service_not_in_pteam(testdb):
 
 def test_service_tagged_tikcet_ids_with_wrong_tag_id(testdb):
     # create current_ticket_status table
-    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": "acknowledged",
@@ -2079,7 +2079,7 @@ def test_service_tagged_tikcet_ids_with_wrong_tag_id(testdb):
 
 def test_service_tagged_ticket_ids_with_valid_but_not_service_tag(testdb):
     # create current_ticket_status table
-    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1, ACTION1)
+    ticket_response1 = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
 
     json_data = {
         "topic_status": "acknowledged",


### PR DESCRIPTION
## PR の目的
- get_service_tagged_ticket_ids API(unsolved, solved)に関してのテストを追加しました。
- 今まで単一登録のテストしかなかったので、複数登録のテストを追加しました。

## 経緯・意図・意思決定
### テストの内容について
- get_service_tagged_ticket_idsが返すレスポンス内にあるtopic_idの順番が正しいソートの順番になっているかを検証しています。ソートの順番はthreat_impactの値の昇順、threat_impactが同じ場合update_atが新しいものが先に来るようになっています。
参考箇所
https://github.com/nttcom/threatconnectome/blob/1ee639f88b2c09abd9539f83f28990ac73b38970/api/app/common.py#L344

- パラメタライズに topicのthreat_impactとtitleを指定しています。
- テストの流れはtopicを4つ登録し、get_service_tagged_ticket_ids APIでtopic_idのリストを取得しています。取得したtopic_idとget_topic APIを使ってtopic_titleを取得します。topic_titleがパラメタライズで指定したものと同じになっているかを検証しています。(topic_id比較だと分かりずらいと思い、titleを比較するようにしています)
- 上記の内容をsolved, unsolvedを2つのテストに分けて実施しています。

### api/app/tests/common/ticket_utils.pyの変更
- api/app/tests/common/ticket_utils.pyでtopicとactionを登録していた部分をcreate_topic_with_versioned_actions関数で置き換えました。それに伴い引数に入れていたactionが必要無くなったため消しました。
