### PR TITLE
fix namespace delimiter in package name

### DIFF
--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -120,7 +120,7 @@ class TrivyCDXParser(SBOMParser):
             if not self.purl:
                 return None
             pkg_name = (
-                self.group + ":" + self.name if self.group else self.name
+                self.group + "/" + self.name if self.group else self.name
             )  # given by trivy. may include namespace in some case.
             pkg_info = self.purl.type
             pkg_mgr = ""
@@ -313,7 +313,7 @@ class SyftCDXParser(SBOMParser):
             if not self.purl:
                 return None
             pkg_name = (
-                self.group + ":" + self.name if self.group else self.name
+                self.group + "/" + self.name if self.group else self.name
             )  # given by syft. may include namespace in some case.
             distro = (
                 self.purl.qualifiers.get("distro")

--- a/scripts/trivy_tags.py
+++ b/scripts/trivy_tags.py
@@ -132,7 +132,7 @@ def main() -> None:
         tag_class = result.get("Class")  # package category
         tag_packages = result.get("Packages")
         for package in tag_packages:
-            tag_package_name = package.get("Name")
+            tag_package_name = package.get("Name", "").replace(":", "/")
             tag_package_version = package.get("Version")
             new_tag = create_tag(metadata, tag_class, tag_type, tag_package_name)
             tags.append(new_tag)

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -351,7 +351,7 @@ def vuln_info(repos, txs):
             for pattern in vuln_filter:
                 if pattern in vuln_id:
                     vuln_dict["vuln_id"] = vuln_id
-                    vuln_dict["pkg_name"] = pkg.decode()
+                    vuln_dict["pkg_name"] = pkg.decode().replace(":", "/")
                     vuln_content = pkg_bucket.get(vuln).decode()
                     if vuln_content:
                         vuln_dict["version_details"] = json.loads(vuln_content)


### PR DESCRIPTION
## PR の目的

- タグ名生成時の namespace(group) と name を `:` でなく `/` で結合するように改修
  - trivydb2tc, trivy_tags で参照する、trivy が命名した（namespace 込みの）name の `:` も `/` に置換するように調整
