### PR TITLE
Fix/use serviceid to access tag page directly

### DIFF
--- a/e2etests/api_utils.py
+++ b/e2etests/api_utils.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 from uuid import UUID
 
 import requests
+
 from exceptions import HTTPError
 
 base_url = os.getenv("BASE_URL", "http://localhost")

--- a/e2etests/api_utils.py
+++ b/e2etests/api_utils.py
@@ -5,7 +5,6 @@ from urllib.parse import urljoin
 from uuid import UUID
 
 import requests
-
 from exceptions import HTTPError
 
 base_url = os.getenv("BASE_URL", "http://localhost")
@@ -104,6 +103,16 @@ def upload_pteam_tags(
                 params=params,
                 files={"file": bfile},
             )
+    if response.status_code != 200:
+        raise HTTPError(response)
+    return response.json()
+
+
+def get_pteam_services(user: dict, pteam_id: UUID | str):
+    response = requests.get(
+        f"{api_url}/pteams/{pteam_id}/services",
+        headers=file_upload_headers(user),
+    )
     if response.status_code != 200:
         raise HTTPError(response)
     return response.json()

--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -2,10 +2,9 @@ import os
 import re
 from urllib.parse import urlencode, urljoin
 
-from playwright.sync_api import Page, expect
-
-from api_utils import create_pteam, create_topic, upload_pteam_tags
+from api_utils import create_pteam, create_topic, get_pteam_services, upload_pteam_tags
 from constants import ACTION1, ACTION2, PTEAM1, TAG1, TOPIC1, TOPIC2, USER1
+from playwright.sync_api import Page, expect
 
 base_url = os.getenv("BASE_URL", "http://localhost")
 
@@ -62,8 +61,12 @@ def test_show_tag_page_directly(page: Page):
     create_topic(USER1, TOPIC1, actions=[ACTION1, ACTION2])
     create_topic(USER1, TOPIC2, actions=[ACTION1, ACTION2])
 
+    # get service id
+    services = get_pteam_services(USER1, pteam1["pteam_id"])
+    service_id = services[0]["service_id"]
+
     # goto tag page directly
-    params = urlencode({"pteamId": pteam1["pteam_id"]})
+    params = urlencode({"pteamId": pteam1["pteam_id"], "serviceId": service_id})
     path = "/tags/" + etags[0]["tag_id"]
     url = urljoin(base_url, path) + "?" + params
     page.goto(url)

--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -2,9 +2,10 @@ import os
 import re
 from urllib.parse import urlencode, urljoin
 
+from playwright.sync_api import Page, expect
+
 from api_utils import create_pteam, create_topic, get_pteam_services, upload_pteam_tags
 from constants import ACTION1, ACTION2, PTEAM1, TAG1, TOPIC1, TOPIC2, USER1
-from playwright.sync_api import Page, expect
 
 base_url = os.getenv("BASE_URL", "http://localhost")
 

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -5,7 +5,7 @@ server {
 
     location / {
         root /usr/share/nginx/html;
-        index index.html;
+        try_files $uri /index.html;
         error_page 404 /;
     }
 }


### PR DESCRIPTION
## PR の目的

- tagページの場合、service_id を指定しないとStatusのトップページにリダイレクトされるため、テストが失敗していました。service_id を取得して使用するようにe2eテストを変更しました
  - service_idはアラート通知のURLにも付与されているため、service_id を付与した状態でアクセスするのが妥当なユースケースと考えられる
- nginxの設定を変更し、　`try_files` を用いるように変更した。これにより、e2eテストで発生していた404エラーが抑止される見込み

## 経緯・意図・意思決定

## 参考文献
https://stackoverflow.com/questions/43951720/react-router-and-nginx
