### PR TITLE
topic/fixed team switching on topic screen

### DIFF
--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -169,7 +169,7 @@ export function TopicManagement() {
     if (!user?.user_id) return;
     evalSearchTopics();
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [page, perPage, searchConditions, user, checkedPteam, checkedAteam]);
+  }, [page, perPage, searchConditions, user, checkedPteam, checkedAteam, pteamId, ateamId]);
 
   const paramsToSearchQuery = (params) => {
     const delimiter = "|";


### PR DESCRIPTION
## PR の目的
- Topic一覧画面でチーム切り替えをした際に、URL上にあるpteam_idの値を用いてtopic一覧画面が出力されない問題を修正しました

## 経緯・意図・意思決定
- SearchTopics APIを呼び出している関数をuseEffectしているところにpteam_idとateam_idを追加しました。