### PR TITLE
bugfix/fix transition from topic detail screen

### DIFF
--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -45,9 +45,11 @@ function TopicManagementTableRow(props) {
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const topics = useSelector((state) => state.topics.topics);
   const actions = useSelector((state) => state.topics.actions);
+  const params = new URLSearchParams(location.search);
 
   useEffect(() => {
     if (topics?.[topicId] === undefined) dispatch(getTopic(topicId));
@@ -76,7 +78,7 @@ function TopicManagementTableRow(props) {
         "&:hover": { bgcolor: grey[100] },
         borderLeft: `solid 5px ${difficultyColors[difficulty[topic.threat_impact - 1]]}`,
       }}
-      onClick={() => navigate(`/topics/${topic.topic_id}`)}
+      onClick={() => navigate(`/topics/${topic.topic_id}?${params.toString()}`)}
     >
       <TableCell>
         <FormattedDateTimeWithTooltip utcString={topic.updated_at} />
@@ -169,7 +171,7 @@ export function TopicManagement() {
     if (!user?.user_id) return;
     evalSearchTopics();
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [page, perPage, searchConditions, user, checkedPteam, checkedAteam]);
+  }, [page, perPage, searchConditions, user, checkedPteam, checkedAteam, pteamId, ateamId]);
 
   const paramsToSearchQuery = (params) => {
     const delimiter = "|";


### PR DESCRIPTION
## PR の目的
- Topic詳細画面からstatu画面やteam画面に遷移した時、pteam_idが引き継がれずpteamの状態が異なるため修正しました。

## 経緯・意図・意思決定

![スクリーンショット 2024-07-10 15 14 18（2）](https://github.com/nttcom/threatconnectome/assets/142189177/bc08dcfa-ac2e-48d2-8916-309822a119ab)
 
- 上記の画像のようにTopic詳細画面のURLにはpteam_idやateam_idがなくなるため、statu画面やteam画面などに遷移したときに一番上のpteam_idが自動で入ります。そのため元々いたpteamから別のpteamに移動してしまいます。
- URLを指定するところにクエリパラメータを入れるように修正しました。

