### PR TITLE
change pteam tab width

### DIFF
--- a/web/src/components/PTeamServiceTabs.jsx
+++ b/web/src/components/PTeamServiceTabs.jsx
@@ -32,7 +32,7 @@ export function PTeamServiceTabs(props) {
               textTransform: "none",
               border: `1px solid ${grey[300]}`,
               borderRadius: "0.5rem 0.5rem 0 0",
-              width: "10%",
+              width: "20%",
               mt: 1,
             }}
           />
@@ -45,7 +45,7 @@ export function PTeamServiceTabs(props) {
             textTransform: "none",
             border: `1px solid ${grey[300]}`,
             borderRadius: "0.5rem 0.5rem 0 0",
-            width: "10%",
+            width: "20%",
             mt: 1,
           }}
         />


### PR DESCRIPTION
## PR の目的
-  サービスタグの横幅を広げる
    - サービス名「threatconnectome」が見切れており、見栄えが悪かった。
    - 一般的なサービス名は20文字以内のため、20文字を表示できるサイズとする。
