### PR TITLE
topic/add-service-name-length-limit

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -695,6 +695,12 @@ async def upload_pteam_sbom_file(
     """
     upload sbom file
     """
+    if len(service) > 255:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Length of Service name exceeds 255 characters",
+        )
+
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM
     if not check_pteam_membership(db, pteam, current_user):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1,6 +1,4 @@
 import json
-import random
-import string
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -2290,14 +2288,12 @@ def test_upload_pteam_sbom_file_with_wrong_filename():
     assert data["detail"] == "Please upload a file with .json as extension"
 
 
-def test_upload_pteam_sbom_file_with_service_name_length_exceed_max_characters():
+def test_it_should_return_422_when_upload_sbom_with_over_255_char_servicename():
     create_user(USER1)
     pteam = create_pteam(USER1, PTEAM1)
 
     # create random 256 alphanumeric characters
-    service_name = ""
-    for i in range(256):
-        service_name += random.choice(string.ascii_letters + string.digits)
+    service_name = "a" * 256
 
     params = {"service": service_name, "force_mode": True}
     sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"


### PR DESCRIPTION
## PR の目的
- サービス名の長さ制限を追加しました。

## 経緯・意図・意思決定
### API
- serviceの長さが255を超えた場合、422のエラーを出すようにしました
- エラー文の内容はLength of Service name exceeds 255 charactersにしました

### テストについて
- ランダムな英数字を256文字作成して、serive_nameとして登録します。その時に正しくエラーが表示されるかを検証しています

### ひらがな、漢字について
service tableのservice_nameを確認したところ、character varying(255)で設定されていました。PostgreSQL はcharacter varying(n) n文字登録できます(バイト数では無い)。そのため英数字、ひらがな、漢字ともに255文字まで登録できました。

utf-8だと英数字 1バイト、ひらがなや漢字は3バイトです。
英数字: 1 * 255 = 255バイト
ひらがな、漢字: 3* 255 = 765バイト
上記のようにバイト数が異なっていますが、PostgreSQL のフィールド最大長は 1GBらしくバイト数が異なっていても問題がなく同じ文字数登録できるようでした。

## 参考文献
- https://www.postgresql.jp/docs/9.4/datatype-character.html
- https://www.postgresql.jp/document/13/html/limits.html
