### PR TITLE
Topic/api notify SBOM upload ended

### DIFF
--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -1,5 +1,5 @@
 import os
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 from uuid import UUID
 
 from email_validator import validate_email
@@ -38,7 +38,9 @@ def _pteam_tag_page_link(pteam_id: UUID | str, tag_id: UUID | str) -> str:
 def _pteam_service_tab_link(pteam_id: UUID | str, service_id: UUID | str) -> str:
     baseurl = os.getenv("WEBUI_URL", "http://localhost")
     baseurl += "" if baseurl.endswith("/") else "/"
-    return urljoin(baseurl, f"?pteamId={pteam_id}&serviceId={service_id}")
+    params = {"pteamId": str(pteam_id), "serviceId": str(service_id)}
+    encoded_params = urlencode(params)
+    return urljoin(baseurl, f"?{encoded_params}")
 
 
 def create_mail_alert_for_new_topic(

--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -7,7 +7,12 @@ from email_validator import validate_email
 from app import models
 from app.constants import SYSTEM_EMAIL
 from app.sendgrid import ready_to_send_email, send_email
-from app.slack import create_slack_pteam_alert_blocks_for_new_topic, send_slack
+from app.slack import (
+    create_slack_blocks_to_notify_sbom_upload_failed,
+    create_slack_blocks_to_notify_sbom_upload_succeeded,
+    create_slack_pteam_alert_blocks_for_new_topic,
+    send_slack,
+)
 
 
 def _ready_alert_by_email() -> bool:
@@ -28,6 +33,12 @@ def _pteam_tag_page_link(pteam_id: UUID | str, tag_id: UUID | str) -> str:
         os.getenv("WEBUI_URL", "http://localhost"),
         f"/tags/{str(tag_id)}?pteam_id={str(pteam_id)}",
     )
+
+
+def _pteam_service_tab_link(pteam_id: UUID | str, service_id: UUID | str) -> str:
+    baseurl = os.getenv("WEBUI_URL", "http://localhost")
+    baseurl += "" if baseurl.endswith("/") else "/"
+    return urljoin(baseurl, f"?pteamId={pteam_id}&serviceId={service_id}")
 
 
 def create_mail_alert_for_new_topic(
@@ -113,6 +124,99 @@ def send_alert_to_pteam(alert: models.Alert) -> None:
                 tag.tag_name,
                 tag.tag_id,
                 [service.service_name],  # WORKAROUND
+            )
+            send_email(pteam.alert_mail.address, SYSTEM_EMAIL, mail_subject, mail_body)
+        except Exception:
+            pass
+
+
+def create_mail_to_notify_sbom_upload_succeeded(
+    pteam_id: UUID | str,
+    pteam_name: str,
+    service_id: UUID | str,
+    service_name: str,
+    filename: str | None,
+) -> tuple[str, str]:  # subject, body
+    # TODO
+    # this mail-spacific-method should be divided away from this file, but to where?
+    subject = f"[Tc Info] SBOM uploaded as a service: {service_name}"
+    body = "<br>".join(
+        [
+            "SBOM upload successfully ended.",
+            "",
+            f"PTeamName: {pteam_name}",
+            f"ServiceName: {service_name}",
+            "",
+            f"<a href={_pteam_service_tab_link(pteam_id, service_id)}>Link to the service tab</a>",
+            "",
+            f"UploadedFilename: {filename or '(unknown)'}",
+        ]
+    )
+    return subject, body
+
+
+def create_mail_to_notify_sbom_upload_failed(
+    service_name: str,
+    filename: str | None,
+) -> tuple[str, str]:  # subject, body
+    # TODO
+    # this mail-spacific-method should be divided away from this file, but to where?
+    subject = f"[Tc Error] SBOM upload failed as a service: {service_name}"
+    body = "<br>".join(
+        [
+            "SBOM upload failed.",
+            "",
+            f"ServiceName: {service_name}",
+            f"UploadedFilename: {filename or '(unknown)'}",
+        ]
+    )
+    return subject, body
+
+
+def notify_sbom_upload_ended(
+    service: models.Service,
+    filename: str | None,
+    succeeded: bool,
+) -> None:
+    pteam = service.pteam
+
+    # check alert settings
+    send_by_slack = pteam.alert_slack.enable and pteam.alert_slack.webhook_url
+    send_by_mail = _ready_alert_by_email() and pteam.alert_mail.enable and pteam.alert_mail.address
+    if not send_by_slack and not send_by_mail:
+        return None
+
+    if send_by_slack:
+        try:
+            slack_message_blocks = (
+                create_slack_blocks_to_notify_sbom_upload_succeeded(
+                    pteam.pteam_id,
+                    pteam.pteam_name,
+                    service.service_id,
+                    service.service_name,
+                    filename,
+                )
+                if succeeded
+                else create_slack_blocks_to_notify_sbom_upload_failed(
+                    service.service_name, filename
+                )
+            )
+            send_slack(pteam.alert_slack.webhook_url, slack_message_blocks)
+        except Exception:
+            pass
+
+    if send_by_mail:
+        try:
+            mail_subject, mail_body = (
+                create_mail_to_notify_sbom_upload_succeeded(
+                    pteam.pteam_id,
+                    pteam.pteam_name,
+                    service.service_id,
+                    service.service_name,
+                    filename,
+                )
+                if succeeded
+                else create_mail_to_notify_sbom_upload_failed(service.service_name, filename)
             )
             send_email(pteam.alert_mail.address, SYSTEM_EMAIL, mail_subject, mail_body)
         except Exception:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -9,6 +9,7 @@ from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from app import command, models, persistence, schemas, ticket_manager
+from app.alert import notify_sbom_upload_ended
 from app.auth import get_current_user
 from app.common import (
     check_pteam_auth,
@@ -651,20 +652,19 @@ def _json_loads(s: str | bytes | bytearray):
 
 
 def bg_create_tags_from_sbom_json(
-    sbom_json,
-    pteam_id,
-    service_name,
-    force_mode,
+    sbom_json: dict,
+    pteam_id: UUID | str,
+    service_name: str,
+    force_mode: bool,
+    filename: str | None,
 ):
     # TODO
     #   functions for background tasks should be divided to another source file.
-    #   Note: background tasks cannot rely on Depends(get_db) and cannot override by
-    #         app.dependency_overrides[]. how to test us? hummm...
 
     with open_db_session() as db:
         if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
-            # TODO notify failure to the caller
-            raise NO_SUCH_PTEAM
+            # TODO: cannot notify error without pteam
+            raise ValueError(f"Invalid pteam_id: {pteam_id}")
         if not (
             service := next(filter(lambda x: x.service_name == service_name, pteam.services), None)
         ):
@@ -675,11 +675,13 @@ def bg_create_tags_from_sbom_json(
         try:
             json_lines = sbom_json_to_artifact_json_lines(sbom_json)
             apply_service_tags(db, pteam, service, json_lines, auto_create_tags=force_mode)
-        except ValueError as err:
-            # TODO notify failure to the caller
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(err))
+        except ValueError:
+            notify_sbom_upload_ended(service, filename, False)
+            return
 
         db.commit()
+
+        notify_sbom_upload_ended(service, filename, True)
 
 
 @router.post("/{pteam_id}/upload_sbom_file")
@@ -729,7 +731,7 @@ async def upload_pteam_sbom_file(
         ) from error
 
     background_tasks.add_task(
-        bg_create_tags_from_sbom_json, sbom_json, pteam_id, service, force_mode
+        bg_create_tags_from_sbom_json, sbom_json, pteam_id, service, force_mode, file.filename
     )
     return ret
 

--- a/api/app/slack.py
+++ b/api/app/slack.py
@@ -1,6 +1,6 @@
 import os
 from typing import Sequence
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 from fastapi import HTTPException, status
 from slack_sdk.errors import SlackApiError
@@ -98,7 +98,9 @@ def create_slack_blocks_to_notify_sbom_upload_succeeded(
     blocks: list[dict[str, str | dict | list]] = _block_header(
         text=f":white_check_mark: SBOM uploaded as a service: {service_name}"
     )
-    service_url = f"{STATUS_URL}?pteamId={pteam_id}&serviceId={service_id}"
+    params = {"pteamId": pteam_id, "serviceId": service_id}
+    encoded_params = urlencode(params)
+    service_url = urljoin(WEBUI_URL, f"?{encoded_params}")
     blocks.extend(
         [
             {


### PR DESCRIPTION
## PR の目的

- SBOM アップロードの非同期処理の終了時に通知する機能を実装
  - 通知先は pteam の通知設定（slack, mail）を利用
  - pteam に依存するため、pteam が存在しないなど一部のエラー時には通知されない（できない）
- urllib.parse.urljoin の使い方が適切でない部分があり、本 PR に関係する箇所を調整
  - baseurl がサブパスを持つ場合、末尾に "/" が無いと urljoin で意図しない結果になる
    - `urljoin("http://hostname/foo", "bar") == "http://hostname/bar" `  (NG)
    -  `urljoin("http://hostname/foo/", "bar") == "http://hostname/foo/bar" `  (OK)
  - urljoin の第二引数は相対パスにすべき（絶対パスだとサブパスが全て無視される）
    -  `urljoin("http://a/b/c/", "/d") == "http://a/d" `
  - これらは本PRの範囲を逸脱するので、別タスクで統括的に対処したい
    - 類似の定義が散らばっているので constants.py か webui.py辺りにまとめたい気もする

![sbom_upload_failed](https://github.com/user-attachments/assets/2acb871b-4b68-4f6d-b9b4-3415f88a1c5d)
![sbom_upload_succeeded](https://github.com/user-attachments/assets/70ff25b8-5545-4a0d-8b52-ab531733c719)
