### PR TITLE
Topic/add get pteam tags summary api

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -583,7 +583,6 @@ def get_tags_summary_by_pteam_id(db: Session, pteam_id: UUID | str) -> list[dict
     threat_impact = func.min(models.Topic.threat_impact).label("threat_impact")
     updated_at = func.max(models.Topic.updated_at).label("updated_at")
     service_ids = func.array_agg(
-        # distinct(aggregate_order_by(models.Service, models.Service.service_name))
         models.Service.service_id.distinct()
     ).label("service_ids")
     summarize_stmt = (

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -582,9 +582,7 @@ def get_tags_summary_by_service_id(db: Session, service_id: UUID | str) -> list[
 def get_tags_summary_by_pteam_id(db: Session, pteam_id: UUID | str) -> list[dict]:
     threat_impact = func.min(models.Topic.threat_impact).label("threat_impact")
     updated_at = func.max(models.Topic.updated_at).label("updated_at")
-    service_ids = func.array_agg(
-        models.Service.service_id.distinct()
-    ).label("service_ids")
+    service_ids = func.array_agg(models.Service.service_id.distinct()).label("service_ids")
     summarize_stmt = (
         select(
             models.Tag.tag_id,

--- a/api/app/common.py
+++ b/api/app/common.py
@@ -630,3 +630,10 @@ def fix_threats_for_dependency(db: Session, dependency: models.Dependency):
                 persistence.delete_ticket(db, threat.ticket)
         elif current_threat:
             persistence.delete_threat(db, current_threat)
+
+
+def count_threat_impact_from_summary(tags_summary: list[dict]):
+    threat_impact_count: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
+    for tag_summary in tags_summary:
+        threat_impact_count[str(tag_summary["threat_impact"] or 4)] += 1
+    return threat_impact_count

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -194,6 +194,33 @@ def get_pteam_service_tags_summary(
     }
 
 
+@router.get("/{pteam_id}/tags/summary", response_model=schemas.PTeamTagsSummary)
+def get_pteam_tags_summary(
+    pteam_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get tags summary of the pteam service.
+    """
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(db, pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+
+    tags_summary = command.get_tags_summary_by_pteam_id(db, pteam_id)
+
+    # count tags threat_impact
+    threat_impact_count: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
+    for tag_summary in tags_summary:
+        threat_impact_count[str(tag_summary["threat_impact"] or 4)] += 1
+
+    return {
+        "threat_impact_count": threat_impact_count,
+        "tags": tags_summary,
+    }
+
+
 @router.get(
     "/{pteam_id}/services/{service_id}/dependencies",
     response_model=list[schemas.DependencyResponse],

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -16,6 +16,7 @@ from app.common import (
     check_pteam_membership,
     count_service_solved_tickets_per_threat_impact,
     count_service_unsolved_tickets_per_threat_impact,
+    count_threat_impact_from_summary,
     fix_threats_for_dependency,
     get_or_create_topic_tag,
     get_pteam_ext_tags,
@@ -183,10 +184,7 @@ def get_pteam_service_tags_summary(
 
     tags_summary = command.get_tags_summary_by_service_id(db, service_id)
 
-    # count tags threat_impact
-    threat_impact_count: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
-    for tag_summary in tags_summary:
-        threat_impact_count[str(tag_summary["threat_impact"] or 4)] += 1
+    threat_impact_count = count_threat_impact_from_summary(tags_summary)
 
     return {
         "threat_impact_count": threat_impact_count,
@@ -201,7 +199,7 @@ def get_pteam_tags_summary(
     db: Session = Depends(get_db),
 ):
     """
-    Get tags summary of the pteam service.
+    Get tags summary of the pteam.
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM
@@ -210,10 +208,7 @@ def get_pteam_tags_summary(
 
     tags_summary = command.get_tags_summary_by_pteam_id(db, pteam_id)
 
-    # count tags threat_impact
-    threat_impact_count: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
-    for tag_summary in tags_summary:
-        threat_impact_count[str(tag_summary["threat_impact"] or 4)] += 1
+    threat_impact_count = count_threat_impact_from_summary(tags_summary)
 
     return {
         "threat_impact_count": threat_impact_count,

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -500,8 +500,7 @@ class PTeamTagSummary(ORMModel):
     tag_name: str
     parent_id: UUID | None
     parent_name: str | None
-    service_id: UUID
-    service_name: str
+    service_ids: list[UUID]
     threat_impact: int | None = None
     updated_at: datetime | None = None
     status_count: dict[str, int]

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -495,7 +495,13 @@ class FsTopicSummary(ORMModel):
     actions: list[FsAction]
 
 
-class PTeamTagSummary(ExtTagResponse):
+class PTeamTagSummary(ORMModel):
+    tag_id: UUID
+    tag_name: str
+    parent_id: UUID | None
+    parent_name: str | None
+    service_id: UUID
+    service_name: str
     threat_impact: int | None = None
     updated_at: datetime | None = None
     status_count: dict[str, int]

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2657,8 +2657,7 @@ class TestGetPTeamTagsSummary:
                 "tag_name": tag1.tag_name,
                 "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
                 "parent_name": tag1.parent_name if tag1.parent_name else None,
-                "service_id": service_id1,
-                "service_name": test_service,
+                "service_ids": [service_id1],
                 "threat_impact": None,
                 "updated_at": None,
                 "status_count": {
@@ -2702,8 +2701,7 @@ class TestGetPTeamTagsSummary:
                 "tag_name": tag1.tag_name,
                 "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
                 "parent_name": tag1.parent_name if tag1.parent_name else None,
-                "service_id": service_id1,
-                "service_name": test_service,
+                "service_ids": [service_id1],
                 "threat_impact": None,
                 "updated_at": None,
                 "status_count": {
@@ -2759,8 +2757,7 @@ class TestGetPTeamTagsSummary:
                 "tag_name": tag1.tag_name,
                 "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
                 "parent_name": tag1.parent_name if tag1.parent_name else None,
-                "service_id": service_id1,
-                "service_name": test_service,
+                "service_ids": [service_id1],
                 "threat_impact": topic1.threat_impact,
                 "updated_at": datetime.isoformat(topic1.updated_at),
                 "status_count": {

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2292,7 +2292,7 @@ def test_it_should_return_422_when_upload_sbom_with_over_255_char_servicename():
     create_user(USER1)
     pteam = create_pteam(USER1, PTEAM1)
 
-    # create random 256 alphanumeric characters
+    # create 256 alphanumeric characters
     service_name = "a" * 256
 
     params = {"service": service_name, "force_mode": True}
@@ -2592,6 +2592,175 @@ class TestGetPTeamServiceTagsSummary:
                 "tag_name": tag1.tag_name,
                 "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
                 "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "threat_impact": topic1.threat_impact,
+                "updated_at": datetime.isoformat(topic1.updated_at),
+                "status_count": {
+                    **{status_type.value: 0 for status_type in list(models.TopicStatusType)},
+                    models.TopicStatusType.alerted.value: 1,  # default status is ALERTED
+                },
+            }
+        ]
+
+
+class TestGetPTeamTagsSummary:
+    @staticmethod
+    def _get_access_token(user: dict) -> str:
+        body = {
+            "username": user["email"],
+            "password": user["pass"],
+        }
+        response = client.post("/auth/token", data=body)
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        return data["access_token"]
+
+    @staticmethod
+    def _get_service_id_by_service_name(user: dict, pteam_id: UUID | str, service_name: str) -> str:
+        response = client.get(f"/pteams/{pteam_id}/services", headers=headers(user))
+        if response.status_code != 200:
+            raise HTTPError(response)
+        data = response.json()
+        service = next(filter(lambda x: x["service_name"] == service_name, data))
+        return service["service_id"]
+
+    def test_returns_summary_even_if_no_topics(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+
+        # no topics, no threats, no tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "service_id": service_id1,
+                "service_name": test_service,
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_even_if_no_threats(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "test version"
+        refs0 = {tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # create topic1
+        create_topic(USER1, TOPIC1)  # Tag1
+
+        # no threats nor tickets
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {"1": 0, "2": 0, "3": 0, "4": 1}
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "service_id": service_id1,
+                "service_name": test_service,
+                "threat_impact": None,
+                "updated_at": None,
+                "status_count": {
+                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                },
+            }
+        ]
+
+    def test_returns_summary_if_having_alerted_ticket(self):
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+        tag1 = create_tag(USER1, TAG1)
+        # add test_service to pteam1
+        test_service = "test_service"
+        test_target = "test target"
+        vulnerable_version = "1.2.0"  # vulnerable
+        refs0 = {tag1.tag_name: [(test_target, vulnerable_version)]}
+        upload_pteam_tags(USER1, pteam1.pteam_id, test_service, refs0)
+        service_id1 = self._get_service_id_by_service_name(USER1, pteam1.pteam_id, test_service)
+        # add actionable topic1
+        action1 = {
+            "action": "action one",
+            "action_type": "elimination",
+            "recommended": True,
+            "ext": {
+                "tags": [tag1.tag_name],
+                "vulnerable_versions": {
+                    tag1.tag_name: ["< 1.2.3"],  # > vulnerable_version
+                },
+            },
+        }
+        topic1 = create_topic(USER1, TOPIC1, actions=[action1])  # Tag1
+
+        # get summary
+        url = f"/pteams/{pteam1.pteam_id}/tags/summary"
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        response = client.get(url, headers=_headers)
+        assert response.status_code == 200
+
+        summary = response.json()
+        assert summary["threat_impact_count"] == {
+            **{"1": 0, "2": 0, "3": 0, "4": 0},
+            str(topic1.threat_impact): 1,
+        }
+        assert summary["tags"] == [
+            {
+                "tag_id": str(tag1.tag_id),
+                "tag_name": tag1.tag_name,
+                "parent_id": str(tag1.parent_id) if tag1.parent_id else None,
+                "parent_name": tag1.parent_name if tag1.parent_name else None,
+                "service_id": service_id1,
+                "service_name": test_service,
                 "threat_impact": topic1.threat_impact,
                 "updated_at": datetime.isoformat(topic1.updated_at),
                 "status_count": {


### PR DESCRIPTION
## PR の目的
- UI上でALL Servicesのtoggleボタンをオンにした際に、Pteam内にあるtagを全て表示するようなAPIを作成
- Service単位でsummaryを取ってくるAPI(pteams.py::get_pteam_service_tags_summary)がありましたが、Pteam単位ではなかったため作成しました 

## 経緯・意図・意思決定
### APIについて
- get_pteam_service_tags_summaryを参考にしてget_pteam_tags_summaryを作成しました。
- リクエストにはクエリパラメータにpteam_idだけ指定してsummaryを取ってきます。
- レスポンスは以下のようになっています。get_pteam_service_tags_summaryのレスポンスにservice_idとservice_nameを付け加えました。
```
threat_impact_count: dict[str, int]
tags: list[
     {
          tag_id: UUID
          tag_name: str
          parent_id: UUID | None
          parent_name: str | None
          threat_impact: int | None = None
          updated_at: datetime | None = None
          status_count: dict[str, int]
          service_ids: list[UUID]
       }
]
```

### テストについて
- TestGetPTeamServiceTagsSummaryを参考にしてTestGetPTeamTagsSummaryを作成しました。
- テストは合計で3つです。topicがない時、threatがない時、tikcetがありalertedになっている時をそれぞれ検証しました。