### PR TITLE
topic/add pteam tags summary in frontend

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -1,8 +1,9 @@
-import { Box, Stack, TableCell, TableRow, Tooltip, Typography } from "@mui/material";
+import { Box, Chip, Stack, TableCell, TableRow, Tooltip, Typography } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 import React from "react";
+import { useSelector } from "react-redux";
 
 import { topicStatusProps } from "../utils/const";
 import { calcTimestampDiff } from "../utils/func";
@@ -109,7 +110,19 @@ StatusRatioGraph.propTypes = {
 };
 
 export function PTeamStatusCard(props) {
-  const { onHandleClick, tag } = props;
+  const { onHandleClick, tag, isActiveAllServicesMode, serviceIds } = props;
+  const pteam = useSelector((state) => state.pteam.pteam);
+
+  const services = [];
+  if (isActiveAllServicesMode) {
+    for (const service of pteam.services) {
+      for (const serviceId of serviceIds) {
+        if (service.service_id === serviceId) {
+          services.push(service);
+        }
+      }
+    }
+  }
 
   return (
     <TableRow
@@ -130,6 +143,8 @@ export function PTeamStatusCard(props) {
         <Typography variant="subtitle1" sx={{ overflowWrap: "anywhere" }}>
           {tag.tag_name}
         </Typography>
+        {isActiveAllServicesMode &&
+          services.map((service) => <Chip key={service.service_id} label={service.service_name} />)}
       </TableCell>
       <TableCell align="right" style={{ width: "30%" }}>
         <Box display="flex" flexDirection="column">
@@ -156,4 +171,6 @@ PTeamStatusCard.propTypes = {
     updated_at: PropTypes.string,
     status_count: PropTypes.object,
   }).isRequired,
+  isActiveAllServicesMode: PropTypes.bool,
+  serviceIds: PropTypes.array.isRequired,
 };

--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -113,17 +113,6 @@ export function PTeamStatusCard(props) {
   const { onHandleClick, tag, isActiveAllServicesMode, serviceIds } = props;
   const pteam = useSelector((state) => state.pteam.pteam);
 
-  const services = [];
-  if (isActiveAllServicesMode) {
-    for (const service of pteam.services) {
-      for (const serviceId of serviceIds) {
-        if (service.service_id === serviceId) {
-          services.push(service);
-        }
-      }
-    }
-  }
-
   return (
     <TableRow
       onClick={onHandleClick}
@@ -144,7 +133,10 @@ export function PTeamStatusCard(props) {
           {tag.tag_name}
         </Typography>
         {isActiveAllServicesMode &&
-          services.map((service) => <Chip key={service.service_id} label={service.service_name} />)}
+          pteam.services
+            .filter((service) => serviceIds.includes(service.service_id))
+            .sort((a, b) => a.service_name.localeCompare(b.service_name))
+            .map((service) => <Chip key={service.service_id} label={service.service_name} />)}
       </TableCell>
       <TableCell align="right" style={{ width: "30%" }}>
         <Box display="flex" flexDirection="column">

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -10,6 +10,7 @@ import {
   getPTeamTopicActions as apiGetPTeamTopicActions,
   getTopicStatus as apiGetTopicStatus,
   getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
+  getPTeamTagsSummary as apiGetPTeamTagsSummary,
 } from "../utils/api";
 
 export const getPTeam = createAsyncThunk(
@@ -110,6 +111,15 @@ export const getPTeamServiceTagsSummary = createAsyncThunk(
     })),
 );
 
+export const getPTeamTagsSummary = createAsyncThunk(
+  "pteam/getPTeamTagsSummary",
+  async (data) =>
+    await apiGetPTeamTagsSummary(data.pteamId).then((response) => ({
+      data: response.data,
+      pteamId: data.pteamId,
+    })),
+);
+
 const _initialState = {
   pteamId: undefined,
   pteam: undefined,
@@ -121,6 +131,7 @@ const _initialState = {
   topicStatus: {},
   topicActions: {},
   serviceTagsSummaries: {},
+  pteamTagsSummaries: {},
 };
 
 const pteamSlice = createSlice({
@@ -206,6 +217,13 @@ const pteamSlice = createSlice({
         serviceTagsSummaries: {
           ...state.serviceTagsSummaries,
           [action.payload.serviceId]: action.payload.data,
+        },
+      }))
+      .addCase(getPTeamTagsSummary.fulfilled, (state, action) => ({
+        ...state,
+        pteamTagsSummaries: {
+          ...state.pteamTagsSummaries,
+          [action.payload.pteamId]: action.payload.data,
         },
       }));
   },

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -68,6 +68,8 @@ export const removeWatcherATeam = async (pteamId, ateamId) =>
 export const getPTeamServiceTagsSummary = async (pteamId, serviceId) =>
   axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/summary`);
 
+export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
+
 export const uploadSBOMFile = async (pteamId, service, file, forceMode = true) => {
   const formData = new FormData();
   formData.append("file", file);


### PR DESCRIPTION
## PR の目的
- サービスを横断してtagを確認できる機能をUIに追加しました

## 経緯・意図・意思決定
- https://github.com/nttcom/threatconnectome/commit/b4647e62e36d64ebda41c832903a97db5433f260 と https://github.com/nttcom/threatconnectome/commit/6a7f1e5e42ce551bb1e8e36432375c91af58747a  でオミットされていたところを元に戻し　https://github.com/nttcom/threatconnectome/pull/254 で作成したAPIとUIを繋ぎこみました
- 新しく作成したAPIをweb/src/utils/api.js に記述しました。またAPIで取得したpteam全体のsummaryをpteamTagsSummaryとしてweb/src/slices/pteam.jsに追加しました。
- isActiveAllServicesModeの値がtrueの時、pteamTagsSummaryの内容を表示させて、falseの時serviceTagsSummaryの内容を表示させるようにしています。web/src/pages/Status.jsx
- pteamTagsSummaryにあるserviceIdsとstoreのpteamにあるservceId,serviceNameをマッチングさせて、serviceNameを取ってきています。web/src/components/PTeamStatusCard.jsx

未完成の部分
~~- service_nameのソートがまだできていません。別PRで行う予定です~~
- 本PRにソートを含めました

## tagの詳細画面への遷移について
- All ServicesのtoggleボタンがONになっている状態で、tagのボタンを押してもtagの詳細画面に遷移しないようにしています。
- 元に戻すときはweb/src/pages/Status.jsxの421行目でコメントアウトしている部分を元に戻してください
