### PR TITLE
Topic/reduce db access on upload SBOM

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -149,22 +149,7 @@ def get_or_create_topic_tag(db: Session, tag_name: str) -> models.Tag:
     if tag := persistence.get_tag_by_name(db, tag_name):  # already exists
         return tag
 
-    tag = models.Tag(tag_name=tag_name, parent_id=None, parent_name=None)
-    if not (parent_name := _pick_parent_tag(tag_name)):  # no parent: e.g. "tag1"
-        persistence.create_tag(db, tag)
-        return tag
-
-    if parent_name == tag_name:  # parent is myself
-        tag.parent_id = tag.tag_id
-        tag.parent_name = tag_name
-    else:
-        parent = get_or_create_topic_tag(db, parent_name)
-        tag.parent_id = parent.tag_id
-        tag.parent_name = parent.tag_name
-
-    persistence.create_tag(db, tag)
-
-    return tag
+    return create_topic_tag(db, tag_name)
 
 
 def create_topic_tag(db: Session, tag_name: str) -> models.Tag:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -17,8 +17,8 @@ from app.common import (
     count_service_solved_tickets_per_threat_impact,
     count_service_unsolved_tickets_per_threat_impact,
     count_threat_impact_from_summary,
+    create_topic_tag,
     fix_threats_for_dependency,
-    get_or_create_topic_tag,
     get_pteam_ext_tags,
     get_sorted_solved_ticket_ids_by_service_tag_and_status,
     get_sorted_topics,
@@ -827,7 +827,7 @@ def apply_service_tags(
             raise ValueError("Missing target and|or version")
         if not (_tag := persistence.get_tag_by_name(db, _tag_name)):
             if auto_create_tags:
-                _tag = get_or_create_topic_tag(db, _tag_name)  # FIXME!!
+                _tag = create_topic_tag(db, _tag_name)
             else:
                 missing_tags.add(_tag_name)
         if _tag:


### PR DESCRIPTION
## PR の目的
SBOMアップロード時のDBアクセスを減らす改修をしました

## 経緯・意図・意思決定
- `get_or_create_topic_tag` -> `create_topic_tag`
  - getとcreateの機能を持っていたため、存在しないことが確認されたtagでもgetを行う処理が入っていました
  - get の責務を分離し、createのみを行うようにしました

## 参考文献
