### PR TITLE
ステータス詳細画面のチケット管理UIのモック作成

### DIFF
--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -176,9 +176,9 @@ export function ATeamNotificationSetting(props) {
           sx={{ marginRight: "10px", minWidth: "800px" }}
           size="small"
         >
-          {Object.keys(threatImpactName).map((key) => (
+          {Object.keys(threatImpactNames).map((key) => (
             <MenuItem key={key} value={key}>
-              {key}: {threatImpactProps[threatImpactName[key]].chipLabel}
+              {key}: {threatImpactProps[threatImpactNames[key]].chipLabel}
             </MenuItem>
           ))}
         </Select>

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -47,7 +47,7 @@ import {
   getATeamTopicComments as apiGetATeamTopicComments,
   updateATeamTopicComment as apiUpdateATeamTopicComment,
 } from "../utils/api";
-import { rootPrefix, threatImpactName } from "../utils/const";
+import { rootPrefix, threatImpactNames } from "../utils/const";
 import { a11yProps, dateTimeFormat, tagsMatched } from "../utils/func.js";
 
 export function AnalysisTopic(props) {
@@ -178,7 +178,7 @@ export function AnalysisTopic(props) {
         <Box m={3}>
           <Box display="flex">
             <ThreatImpactChip
-              threatImpact={threatImpactName[topicDetail.threat_impact]}
+              threatImpact={threatImpactNames[topicDetail.threat_impact]}
               sx={{ marginRight: "10px" }}
             />
             <Typography variant="h6" fontWeight={900} mr={1}>

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -31,7 +31,7 @@ import {
   checkSlack as postCheckSlack,
   checkMail as postCheckMail,
 } from "../utils/api";
-import { threatImpactName, threatImpactProps, modalCommonButtonStyle } from "../utils/const";
+import { threatImpactNames, threatImpactProps, modalCommonButtonStyle } from "../utils/const";
 
 import { CheckButton } from "./CheckButton";
 
@@ -181,9 +181,9 @@ export function PTeamNotificationSetting(props) {
           sx={{ marginRight: "10px", minWidth: "800px" }}
           size="small"
         >
-          {Object.keys(threatImpactName).map((key) => (
+          {Object.keys(threatImpactNames).map((key) => (
             <MenuItem key={key} value={key}>
-              {key}: {threatImpactProps[threatImpactName[key]].chipLabel}
+              {key}: {threatImpactProps[threatImpactNames[key]].chipLabel}
             </MenuItem>
           ))}
         </Select>

--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { topicStatusProps } from "../utils/const";
+import { threatImpactNames, topicStatusProps } from "../utils/const";
 import { calcTimestampDiff } from "../utils/func";
 
 import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
@@ -113,6 +113,12 @@ export function PTeamStatusCard(props) {
   const { onHandleClick, tag, serviceIds } = props;
   const pteam = useSelector((state) => state.pteam.pteam);
 
+  const threatImpactNum = tag.threat_impact ?? 4;
+  const threatImpactName =
+    threatImpactNum === 4 && tag.status_count["completed"] > 0
+      ? "safe" // solved all and at least 1 tickets
+      : threatImpactNames[threatImpactNum];
+
   return (
     <TableRow
       onClick={onHandleClick}
@@ -123,10 +129,7 @@ export function PTeamStatusCard(props) {
       }}
     >
       <TableCell component="th" scope="row" style={{ width: "5%" }}>
-        <ThreatImpactStatusChip
-          threatImpact={tag.threat_impact ?? 4}
-          statusCounts={tag.status_count ?? []}
-        />
+        <ThreatImpactStatusChip threatImpactName={threatImpactName} />
       </TableCell>
       <TableCell component="th" scope="row" style={{ maxWidth: 0 }}>
         <Typography variant="subtitle1" sx={{ overflowWrap: "anywhere" }}>

--- a/web/src/components/ThreatImpactChip.jsx
+++ b/web/src/components/ThreatImpactChip.jsx
@@ -2,14 +2,14 @@ import { Chip } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { threatImpactName, threatImpactProps } from "../utils/const";
+import { threatImpactNames, threatImpactProps } from "../utils/const";
 
 export function ThreatImpactChip(props) {
   const { threatImpact, reverse, sx } = props;
 
   const impactName = Object.keys(threatImpactProps).includes(threatImpact)
     ? threatImpact
-    : threatImpactName[threatImpact];
+    : threatImpactNames[threatImpact];
   const baseStyle = threatImpactProps[impactName].style;
   const fixedSx = {
     ...(reverse

--- a/web/src/components/ThreatImpactCountChip.jsx
+++ b/web/src/components/ThreatImpactCountChip.jsx
@@ -2,7 +2,7 @@ import { Box, Paper, Tooltip, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { threatImpactName, threatImpactProps } from "../utils/const";
+import { threatImpactNames, threatImpactProps } from "../utils/const";
 
 const countMax = 99;
 
@@ -11,7 +11,7 @@ export function ThreatImpactCountChip(props) {
 
   const impactName = Object.keys(threatImpactProps).includes(threatImpact)
     ? threatImpact
-    : threatImpactName[threatImpact];
+    : threatImpactNames[threatImpact];
   const Icon = threatImpactProps[impactName].icon;
   const baseSx = threatImpactProps[impactName].style;
   const fixedSx = {

--- a/web/src/components/ThreatImpactStatusChip.jsx
+++ b/web/src/components/ThreatImpactStatusChip.jsx
@@ -3,25 +3,23 @@ import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { threatImpactName, threatImpactProps } from "../utils/const";
+import { threatImpactProps } from "../utils/const";
 
 export function ThreatImpactStatusChip(props) {
-  const { statusCounts, threatImpact } = props;
-  const impactName =
-    threatImpact === 4 && statusCounts["completed"] > 0 ? "safe" : threatImpactName[threatImpact];
-  const Icon = threatImpactProps[impactName].icon;
+  const { threatImpactName } = props;
+  const Icon = threatImpactProps[threatImpactName].icon;
 
   const StyledTooltip = styled((styledProps) => (
     <Tooltip classes={{ popper: styledProps.className }} {...styledProps} />
   ))`
     & .MuiTooltip-tooltip {
-      background-color: ${threatImpactProps[impactName].style.bgcolor};
-      color: ${threatImpactProps[impactName].style.color};
+      background-color: ${threatImpactProps[threatImpactName].style.bgcolor};
+      color: ${threatImpactProps[threatImpactName].style.color};
     }
   `;
 
   return (
-    <StyledTooltip title={threatImpactProps[impactName].statusLabel}>
+    <StyledTooltip title={threatImpactProps[threatImpactName].statusLabel}>
       <Paper
         variant="outlined"
         sx={{
@@ -29,7 +27,7 @@ export function ThreatImpactStatusChip(props) {
           alignItems: "center",
           justifyContent: "center",
           padding: "4px",
-          ...threatImpactProps[impactName].style,
+          ...threatImpactProps[threatImpactName].style,
         }}
       >
         <Icon style={{ color: "white", fontSize: "20px" }} />
@@ -39,6 +37,5 @@ export function ThreatImpactStatusChip(props) {
 }
 
 ThreatImpactStatusChip.propTypes = {
-  statusCounts: PropTypes.object,
-  threatImpact: PropTypes.number.isRequired,
+  threatImpactName: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -544,7 +544,7 @@ export function TopicCard(props) {
                       <ThreatImpactStatusChip threatImpact={1} />
                     </Box>
                     <Box>
-                      django-webdjango-webdjango-webdjango-webdjango-webdjango-webdjango-web
+                      /usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA
                     </Box>
                   </Box>
                 </AccordionSummary>

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -4,7 +4,6 @@ import {
   Edit as EditIcon,
   Update as UpdateIcon,
 } from "@mui/icons-material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   Alert,
   Box,
@@ -26,9 +25,6 @@ import {
   Typography,
   Paper,
   Popper,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
@@ -43,16 +39,11 @@ import { dateTimeFormat } from "../utils/func";
 import { isComparable, parseVulnerableVersions, versionMatch } from "../utils/versions";
 
 import { ActionItem } from "./ActionItem";
-import { AssigneesSelector } from "./AssigneesSelector";
 import { PTeamEditAction } from "./PTeamEditAction";
 import { ReportCompletedActions } from "./ReportCompletedActions";
-import { ThreatImpactChip } from "./ThreatImpactChip";
-import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
 import { TopicModal } from "./TopicModal";
-import { TopicStatusSelector } from "./TopicStatusSelector";
 import { TopicTicketAccordion } from "./TopicTicketAccordion";
 import { UUIDTypography } from "./UUIDTypography";
-import { WarningTooltip } from "./WarningTooltip";
 
 export function TopicCard(props) {
   const { pteamId, topicId, currentTagId, serviceId, references } = props;

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -533,7 +533,7 @@ export function TopicCard(props) {
             justifyContent="baseline"
             sx={{ width: "320px", overflowY: "scroll" }}
           >
-            {[...Array(4)].map((_, i) => (
+            {[...Array(3)].map((_, i) => (
               <Accordion key={i} disableGutters defaultExpanded={i === 0 ? true : false}>
                 <AccordionSummary
                   expandIcon={<ExpandMoreIcon />}
@@ -549,12 +549,12 @@ export function TopicCard(props) {
                   </Box>
                 </AccordionSummary>
                 <AccordionDetails>
-                  <Box display="flex" alignItems="baseline" p={2}>
+                  {/* <Box display="flex" alignItems="baseline" p={2}>
                     <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
                       Threat impact
                     </Typography>
                     <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
-                  </Box>
+                  </Box> */}
                   <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
                     <Typography
                       mr={1}

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -264,7 +264,7 @@ export function TopicCard(props) {
         />
       </Box>
       <Divider />
-      <Box display="flex">
+      <Box display="flex" sx={{ height: "350px" }}>
         <Box flexGrow={1} display="flex" flexDirection="column" justifyContent="space-between">
           <CardContent>
             {ttStatus.topic_status !== "completed" ? (

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -4,6 +4,7 @@ import {
   Edit as EditIcon,
   Update as UpdateIcon,
 } from "@mui/icons-material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   Alert,
   Box,
@@ -25,6 +26,9 @@ import {
   Typography,
   Paper,
   Popper,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
@@ -521,50 +525,76 @@ export function TopicCard(props) {
           />
         </Box>
         <Divider flexItem={true} orientation="vertical" />
-        <Box display="flex" flexDirection="column">
+        <Box display="flex" flexDirection="column" sx={{ maxHeight: "300px" }}>
           <Box
             display="flex"
             flexDirection="column"
             justifyContent="baseline"
-            mb={8}
-            sx={{ minWidth: "320px" }}
+            // mb={8}
+            sx={{ minWidth: "320px", maxWidth: "480px", overflowY: "scroll" }}
           >
-            <Box display="flex" alignItems="baseline" p={2}>
-              <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
-                Threat impact
-              </Typography>
-              <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
-            </Box>
-            <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                Assignees
-              </Typography>
-              <Box sx={{ maxWidth: 200 }}>
-                <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
-              </Box>
-            </CardActions>
-            <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
-              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                Status
-              </Typography>
-              <Box display="flex" flexDirection="column">
-                <Box display="flex" alignItems="center">
-                  <TopicStatusSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
-                  {(ttStatus.topic_status ?? "alerted") === "alerted" && (
-                    <WarningTooltip message="No one has acknowledged this topic" />
-                  )}
-                </Box>
-                {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
-                  ttStatus.scheduled_at && (
-                    <Box display="flex" alignItems="flex-end">
-                      <Typography ml={0.5} variant="caption">
-                        <CalendarMonthIcon fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
-                        {dateTimeFormat(ttStatus.scheduled_at)}
-                      </Typography>
+            {[...Array(10)].map((i) => (
+              <Accordion key={i} disableGutters>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>django-web</AccordionSummary>
+                <AccordionDetails>
+                  <Box display="flex" alignItems="baseline" p={2}>
+                    <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
+                      Threat impact
+                    </Typography>
+                    <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
+                  </Box>
+                  <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
+                    <Typography
+                      mr={1}
+                      variant="subtitle2"
+                      sx={{ fontWeight: 900, minWidth: "110px" }}
+                    >
+                      Assignees
+                    </Typography>
+                    <Box sx={{ maxWidth: 200 }}>
+                      <AssigneesSelector
+                        pteamId={pteamId}
+                        topicId={topicId}
+                        serviceId={serviceId}
+                      />
                     </Box>
-                  )}
-              </Box>
-            </Box>
+                  </CardActions>
+                  <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
+                    <Typography
+                      mr={1}
+                      variant="subtitle2"
+                      sx={{ fontWeight: 900, minWidth: "110px" }}
+                    >
+                      Status
+                    </Typography>
+                    <Box display="flex" flexDirection="column">
+                      <Box display="flex" alignItems="center">
+                        <TopicStatusSelector
+                          pteamId={pteamId}
+                          topicId={topicId}
+                          serviceId={serviceId}
+                        />
+                        {(ttStatus.topic_status ?? "alerted") === "alerted" && (
+                          <WarningTooltip message="No one has acknowledged this topic" />
+                        )}
+                      </Box>
+                      {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
+                        ttStatus.scheduled_at && (
+                          <Box display="flex" alignItems="flex-end">
+                            <Typography ml={0.5} variant="caption">
+                              <CalendarMonthIcon
+                                fontSize="small"
+                                sx={{ color: grey[700], mb: -0.7 }}
+                              />
+                              {dateTimeFormat(ttStatus.scheduled_at)}
+                            </Typography>
+                          </Box>
+                        )}
+                    </Box>
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            ))}
           </Box>
           {(ttStatus.topic_status ?? "alerted") !== "alerted" && (
             <Box

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -483,6 +483,7 @@ export function TopicCard(props) {
                               </MenuItem>
                             ))}
                           </MenuList>
+                          z
                         </ClickAwayListener>
                       </Paper>
                     </Grow>
@@ -512,7 +513,13 @@ export function TopicCard(props) {
           />
         </Box>
         <Divider flexItem={true} orientation="vertical" />
-        <Box display="flex" flexDirection="column">
+        <Box
+          sx={{
+            overflowY: "auto",
+            minWidth: "320px",
+            maxWidth: "350px",
+          }}
+        >
           {tickets.map((ticket, index) => (
             <TopicTicketAccordion
               key={ticket.ticket_id}

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -47,6 +47,7 @@ import { AssigneesSelector } from "./AssigneesSelector";
 import { PTeamEditAction } from "./PTeamEditAction";
 import { ReportCompletedActions } from "./ReportCompletedActions";
 import { ThreatImpactChip } from "./ThreatImpactChip";
+import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
 import { TopicModal } from "./TopicModal";
 import { TopicStatusSelector } from "./TopicStatusSelector";
 import { UUIDTypography } from "./UUIDTypography";
@@ -525,17 +526,28 @@ export function TopicCard(props) {
           />
         </Box>
         <Divider flexItem={true} orientation="vertical" />
-        <Box display="flex" flexDirection="column" sx={{ maxHeight: "300px" }}>
+        <Box display="flex" flexDirection="column" sx={{ height: "350px" }}>
           <Box
             display="flex"
             flexDirection="column"
             justifyContent="baseline"
-            // mb={8}
-            sx={{ minWidth: "320px", maxWidth: "480px", overflowY: "scroll" }}
+            sx={{ width: "320px", overflowY: "scroll" }}
           >
-            {[...Array(10)].map((i) => (
-              <Accordion key={i} disableGutters>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>django-web</AccordionSummary>
+            {[...Array(4)].map((_, i) => (
+              <Accordion key={i} disableGutters defaultExpanded={i === 0 ? true : false}>
+                <AccordionSummary
+                  expandIcon={<ExpandMoreIcon />}
+                  sx={{ backgroundColor: grey[50] }}
+                >
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Box sx={{ mr: 1 }}>
+                      <ThreatImpactStatusChip threatImpact={1} />
+                    </Box>
+                    <Box>
+                      django-webdjango-webdjango-webdjango-webdjango-webdjango-webdjango-web
+                    </Box>
+                  </Box>
+                </AccordionSummary>
                 <AccordionDetails>
                   <Box display="flex" alignItems="baseline" p={2}>
                     <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -526,6 +526,7 @@ export function TopicCard(props) {
           dateTimeFormat={dateTimeFormat}
           systemAccount={systemAccount}
           members={members}
+          threat_impact={topic.threat_impact}
         />
       </Box>
     </Card>

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -1,6 +1,5 @@
 import {
   ArrowDropDown as ArrowDropDownIcon,
-  CalendarMonth as CalendarMonthIcon,
   Edit as EditIcon,
   Update as UpdateIcon,
 } from "@mui/icons-material";

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -50,6 +50,7 @@ import { ThreatImpactChip } from "./ThreatImpactChip";
 import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
 import { TopicModal } from "./TopicModal";
 import { TopicStatusSelector } from "./TopicStatusSelector";
+import { TopicTicketAccordion } from "./TopicTicketAccordion";
 import { UUIDTypography } from "./UUIDTypography";
 import { WarningTooltip } from "./WarningTooltip";
 
@@ -526,107 +527,15 @@ export function TopicCard(props) {
           />
         </Box>
         <Divider flexItem={true} orientation="vertical" />
-        <Box display="flex" flexDirection="column" sx={{ height: "350px" }}>
-          <Box
-            display="flex"
-            flexDirection="column"
-            justifyContent="baseline"
-            sx={{ width: "320px", overflowY: "scroll" }}
-          >
-            {[...Array(3)].map((_, i) => (
-              <Accordion key={i} disableGutters defaultExpanded={i === 0 ? true : false}>
-                <AccordionSummary
-                  expandIcon={<ExpandMoreIcon />}
-                  sx={{ backgroundColor: grey[50] }}
-                >
-                  <Box sx={{ display: "flex", alignItems: "center" }}>
-                    <Box sx={{ mr: 1 }}>
-                      <ThreatImpactStatusChip threatImpact={1} />
-                    </Box>
-                    <Box>
-                      /usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA
-                    </Box>
-                  </Box>
-                </AccordionSummary>
-                <AccordionDetails>
-                  {/* <Box display="flex" alignItems="baseline" p={2}>
-                    <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
-                      Threat impact
-                    </Typography>
-                    <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
-                  </Box> */}
-                  <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-                    <Typography
-                      mr={1}
-                      variant="subtitle2"
-                      sx={{ fontWeight: 900, minWidth: "110px" }}
-                    >
-                      Assignees
-                    </Typography>
-                    <Box sx={{ maxWidth: 200 }}>
-                      <AssigneesSelector
-                        pteamId={pteamId}
-                        topicId={topicId}
-                        serviceId={serviceId}
-                      />
-                    </Box>
-                  </CardActions>
-                  <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
-                    <Typography
-                      mr={1}
-                      variant="subtitle2"
-                      sx={{ fontWeight: 900, minWidth: "110px" }}
-                    >
-                      Status
-                    </Typography>
-                    <Box display="flex" flexDirection="column">
-                      <Box display="flex" alignItems="center">
-                        <TopicStatusSelector
-                          pteamId={pteamId}
-                          topicId={topicId}
-                          serviceId={serviceId}
-                        />
-                        {(ttStatus.topic_status ?? "alerted") === "alerted" && (
-                          <WarningTooltip message="No one has acknowledged this topic" />
-                        )}
-                      </Box>
-                      {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
-                        ttStatus.scheduled_at && (
-                          <Box display="flex" alignItems="flex-end">
-                            <Typography ml={0.5} variant="caption">
-                              <CalendarMonthIcon
-                                fontSize="small"
-                                sx={{ color: grey[700], mb: -0.7 }}
-                              />
-                              {dateTimeFormat(ttStatus.scheduled_at)}
-                            </Typography>
-                          </Box>
-                        )}
-                    </Box>
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
-            ))}
-          </Box>
-          {(ttStatus.topic_status ?? "alerted") !== "alerted" && (
-            <Box
-              p={1.5}
-              display="flex"
-              flexDirection="row"
-              justifyContent="flex-end"
-              sx={{ color: grey[600] }}
-            >
-              <Box display="flex" alignItems="flex-end">
-                <Typography variant="caption">Last updated by</Typography>
-                <Typography ml={0.5} variant="caption" fontWeight={900}>
-                  {ttStatus.user_id === systemAccount.uuid
-                    ? systemAccount.email
-                    : members[ttStatus.user_id]?.email ?? "not a pteam member"}
-                </Typography>
-              </Box>
-            </Box>
-          )}
-        </Box>
+        <TopicTicketAccordion
+          pteamId={pteamId}
+          topicId={topicId}
+          serviceId={serviceId}
+          ttStatus={ttStatus}
+          dateTimeFormat={dateTimeFormat}
+          systemAccount={systemAccount}
+          members={members}
+        />
       </Box>
     </Card>
   );

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -21,89 +21,67 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useEffect, useRef, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import React, { useRef, useState } from "react";
+import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
-  getTopicStatus,
   getPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary,
   getPTeamTagsSummary,
+  getTicketsRelatedToServiceTopicTag,
 } from "../slices/pteam";
-import { createTopicStatus } from "../utils/api";
+import { setTicketStatus } from "../utils/api";
 import { topicStatusProps } from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
 
 export function TopicStatusSelector(props) {
-  const { pteamId, topicId, serviceId } = props;
+  const { pteamId, serviceId, topicId, tagId, ticketId, currentStatus } = props;
 
   const [open, setOpen] = useState(false);
-  const [selectableItems, setSelectableItems] = useState([]);
   const anchorRef = useRef(null);
   const [datepickerOpen, setDatepickerOpen] = useState(false);
   const [schedule, setSchedule] = useState(null); // Date object
 
-  const { tagId } = useParams();
   const { enqueueSnackbar } = useSnackbar();
-
-  const topicStatus = useSelector((state) => state.pteam.topicStatus); // dispatched by parent
-  const topics = useSelector((state) => state.topics.topics); // dispatched by parent
-
   const dispatch = useDispatch();
 
   const dateFormat = "yyyy/MM/dd HH:mm";
+  const selectableItems = [
+    {
+      display: "Acknowledge",
+      rawStatus: "acknowledged",
+      disabled: currentStatus.topic_status === "acknowledged",
+    },
+    { display: "Schedule", rawStatus: "scheduled", disabled: false },
+  ];
 
-  useEffect(() => {
-    if (!pteamId || !topicId) return;
-    if (!topicStatus[serviceId]?.[topicId]?.[tagId]) return; // resolved by parent
-    const ttStatus = topicStatus[serviceId][topicId][tagId];
-    const current = ttStatus.topic_status ?? "alerted";
-    const items = [
-      { display: "Acknowledge", rawStatus: "acknowledged", disabled: current === "acknowledged" },
-      { display: "Schedule", rawStatus: "scheduled", disabled: false },
-    ];
-    setSelectableItems(items);
-    setSchedule(
-      ttStatus?.scheduled_at // scheduled_at(UTC) -> schedule(local)
-        ? dateTimeFormat(ttStatus.scheduled_at)
-        : null,
-    );
-  }, [tagId, pteamId, serviceId, topicId, topicStatus]);
-
-  const modifyTopicStatus = async (selectedStatus) => {
-    const ttStatus = topicStatus[serviceId][topicId][tagId];
-    await createTopicStatus(pteamId, serviceId, topicId, tagId, {
-      topic_status: selectedStatus,
-      logging_ids: ttStatus.logging_ids ?? [],
-      assignees: ttStatus.assignees ?? [],
-      note: ttStatus.note,
-      scheduled_at: selectedStatus === "scheduled" ? schedule.toISOString() : null,
-    })
+  const modifyTicketStatus = async (selectedStatus) => {
+    let requestParams = { topic_status: selectedStatus };
+    if (selectedStatus === "scheduled") {
+      if (!schedule) return;
+      requestParams["scheduled_at"] = schedule.toISOString();
+    }
+    await setTicketStatus(pteamId, serviceId, ticketId, requestParams)
       .then(() => {
-        if (selectedStatus !== ttStatus.topicStatus) {
-          dispatch(
-            getTopicStatus({
-              pteamId: pteamId,
-              serviceId: serviceId,
-              topicId: topicId,
-              tagId: tagId,
-            }),
-          );
-          dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
-          dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
-        }
-        if (ttStatus.topic_status === "completed") {
-          dispatch(
-            getPTeamServiceTaggedTopicIds({
-              pteamId: pteamId,
-              serviceId: serviceId,
-              tagId: tagId,
-            }),
-          );
-        }
-        enqueueSnackbar("Change topic status succeeded", { variant: "success" });
+        dispatch(
+          getTicketsRelatedToServiceTopicTag({
+            pteamId: pteamId,
+            serviceId: serviceId,
+            topicId: topicId,
+            tagId: tagId,
+          }),
+        );
+        dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
+        dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
+        dispatch(
+          getPTeamServiceTaggedTopicIds({
+            pteamId: pteamId,
+            serviceId: serviceId,
+            tagId: tagId,
+          }),
+        );
+        enqueueSnackbar("Change ticket status succeeded", { variant: "success" });
       })
       .catch((error) => {
         const resp = error.response;
@@ -113,19 +91,17 @@ export function TopicStatusSelector(props) {
         );
       });
   };
-
   const handleUpdateStatus = async (event, item) => {
     setOpen(false);
     if (item.rawStatus === "scheduled") {
       setDatepickerOpen(true);
       return;
     }
-    modifyTopicStatus(item.rawStatus);
+    modifyTicketStatus(item.rawStatus);
   };
-
   const handleUpdateSchedule = async () => {
     setDatepickerOpen(false);
-    modifyTopicStatus("scheduled");
+    modifyTicketStatus("scheduled");
   };
 
   const handleClose = (event) => {
@@ -133,124 +109,123 @@ export function TopicStatusSelector(props) {
     setOpen(false);
   };
 
-  return (() => {
-    if (!pteamId || !topicId || !topics[topicId] || !topicStatus[serviceId]?.[topicId]?.[tagId])
-      return <></>;
-    const ttStatus = topicStatus[serviceId][topicId][tagId];
-    const currentStatus = ttStatus.topic_status ?? "alerted";
+  if (!pteamId || !serviceId || !topicId || !tagId || !currentStatus) return <></>;
 
-    const handleHideDatepicker = () => {
-      setSchedule(ttStatus.scheduled_at ? dateTimeFormat(ttStatus.scheduled_at) : null);
-      setDatepickerOpen(false);
-    };
-    const now = new Date();
-    return (
-      <>
-        <Button
-          endIcon={<ArrowDropDownIcon />}
-          sx={{
-            ...topicStatusProps[currentStatus].buttonStyle,
-            fontSize: 12,
-            padding: "1px 3px",
-            minHeight: "25px",
-            maxHeight: "25px",
-            textTransform: "none",
-            fontWeight: 900,
+  const handleHideDatepicker = () => {
+    setSchedule(currentStatus.scheduled_at ? dateTimeFormat(currentStatus.scheduled_at) : null);
+    setDatepickerOpen(false);
+  };
+  const now = new Date();
+
+  return (
+    <>
+      <Button
+        endIcon={<ArrowDropDownIcon />}
+        sx={{
+          ...topicStatusProps[currentStatus.topic_status].buttonStyle,
+          fontSize: 12,
+          padding: "1px 3px",
+          minHeight: "25px",
+          maxHeight: "25px",
+          textTransform: "none",
+          fontWeight: 900,
+          borderStyle: "none",
+          mr: 1,
+          "&:hover": {
             borderStyle: "none",
-            mr: 1,
-            "&:hover": {
-              borderStyle: "none",
-            },
-          }}
-          aria-controls={open ? "status-menu" : undefined}
-          aria-expanded={open ? "true" : undefined}
-          aria-haspopup="menu"
-          onClick={() => setOpen(!open)}
-          ref={anchorRef}
-        >
-          {topicStatusProps[currentStatus].chipLabelCapitalized}
-        </Button>
-        <Popper
-          open={open}
-          anchorEl={anchorRef.current}
-          role={undefined}
-          transition
-          disablePortal
-          sx={{ zIndex: 1 }}
-        >
-          {({ TransitionProps, placement }) => (
-            <Grow
-              {...TransitionProps}
-              style={{
-                transformOrigin: placement === "bottom" ? "center top" : "center bottom",
-              }}
-            >
-              <Paper>
-                <ClickAwayListener onClickAway={handleClose}>
-                  <MenuList autoFocusItem>
-                    {selectableItems.map((item) => (
-                      <MenuItem
-                        key={item.rawStatus}
-                        selected={ttStatus?.topic_status === item.rawStatus}
-                        disabled={item.disabled}
-                        onClick={(event) => handleUpdateStatus(event, item)}
-                        dense={true}
-                      >
-                        {item.display}
-                      </MenuItem>
-                    ))}
-                  </MenuList>
-                </ClickAwayListener>
-              </Paper>
-            </Grow>
-          )}
-        </Popper>
-        <Dialog open={datepickerOpen} onClose={handleHideDatepicker} fullWidth>
-          <DialogTitle>
-            <Box alignItems="center" display="flex" flexDirection="row">
-              <Typography flexGrow={1} className={dialogStyle.dialog_title}>
-                Set schedule
-              </Typography>
-              <IconButton onClick={handleHideDatepicker}>
-                <CloseIcon />
-              </IconButton>
-            </Box>
-          </DialogTitle>
-          <DialogContent>
-            <Box sx={{ mt: 3 }}>
-              <LocalizationProvider dateAdapter={AdapterDateFns}>
-                <DateTimePicker
-                  inputFormat={dateFormat}
-                  label="Schedule Date (future date)"
-                  mask="____/__/__ __:__"
-                  minDateTime={now}
-                  value={schedule}
-                  onChange={(newDate) => setSchedule(newDate)}
-                  renderInput={(params) => (
-                    <TextField fullWidth margin="dense" required {...params} />
-                  )}
-                  sx={{ width: "100%" }}
-                />
-              </LocalizationProvider>
-            </Box>
-          </DialogContent>
-          <DialogActions className={dialogStyle.action_area}>
-            <Button
-              onClick={handleUpdateSchedule}
-              disabled={!isBefore(now, schedule)}
-              className={dialogStyle.submit_btn}
-            >
-              Schedule
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </>
-    );
-  })();
+          },
+        }}
+        aria-controls={open ? "status-menu" : undefined}
+        aria-expanded={open ? "true" : undefined}
+        aria-haspopup="menu"
+        onClick={() => setOpen(!open)}
+        ref={anchorRef}
+      >
+        {topicStatusProps[currentStatus.topic_status].chipLabelCapitalized}
+      </Button>
+      <Popper
+        open={open}
+        anchorEl={anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+        sx={{ zIndex: 1 }}
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin: placement === "bottom" ? "center top" : "center bottom",
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList autoFocusItem>
+                  {selectableItems.map((item) => (
+                    <MenuItem
+                      key={item.rawStatus}
+                      selected={currentStatus.topic_status === item.rawStatus}
+                      disabled={item.disabled}
+                      onClick={(event) => handleUpdateStatus(event, item)}
+                      dense={true}
+                    >
+                      {item.display}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+      <Dialog open={datepickerOpen} onClose={handleHideDatepicker} fullWidth>
+        <DialogTitle>
+          <Box alignItems="center" display="flex" flexDirection="row">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+              Set schedule
+            </Typography>
+            <IconButton onClick={handleHideDatepicker}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent>
+          <Box sx={{ mt: 3 }}>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+              <DateTimePicker
+                inputFormat={dateFormat}
+                label="Schedule Date (future date)"
+                mask="____/__/__ __:__"
+                minDateTime={now}
+                value={schedule}
+                onChange={(newDate) => setSchedule(newDate)}
+                renderInput={(params) => (
+                  <TextField fullWidth margin="dense" required {...params} />
+                )}
+                sx={{ width: "100%" }}
+              />
+            </LocalizationProvider>
+          </Box>
+        </DialogContent>
+        <DialogActions className={dialogStyle.action_area}>
+          <Button
+            onClick={handleUpdateSchedule}
+            disabled={!isBefore(now, schedule)}
+            className={dialogStyle.submit_btn}
+          >
+            Schedule
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
 }
 
 TopicStatusSelector.propTypes = {
   pteamId: PropTypes.string.isRequired,
-  topicId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
+  topicId: PropTypes.string.isRequired,
+  tagId: PropTypes.string.isRequired,
+  ticketId: PropTypes.string.isRequired,
+  currentStatus: PropTypes.object.isRequired,
 };

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -168,7 +168,14 @@ export function TopicStatusSelector(props) {
         >
           {topicStatusProps[currentStatus].chipLabelCapitalized}
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
+        <Popper
+          open={open}
+          anchorEl={anchorRef.current}
+          role={undefined}
+          transition
+          disablePortal
+          sx={{ zIndex: 1 }}
+        >
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -28,7 +28,6 @@ export const TopicTicketAccordion = (props) => {
     members,
     threat_impact,
   } = props;
-  console.log(typeof systemAccount);
   return (
     <Box>
       <Box sx={{ width: "320px", height: "350px", overflowY: "scroll" }}>
@@ -110,9 +109,9 @@ TopicTicketAccordion.propTypes = {
   pteamId: PropTypes.string.isRequired,
   topicId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
-  ttStatus: PropTypes.any.isRequired,
-  dateTimeFormat: PropTypes.any.isRequired,
-  systemAccount: PropTypes.any.isRequired,
-  members: PropTypes.any.isRequired,
-  threat_impact: PropTypes.any.isRequired,
+  ttStatus: PropTypes.object.isRequired,
+  dateTimeFormat: PropTypes.func.isRequired,
+  systemAccount: PropTypes.object.isRequired,
+  members: PropTypes.object.isRequired,
+  threat_impact: PropTypes.number.isRequired,
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -18,70 +18,71 @@ import { TopicStatusSelector } from "./TopicStatusSelector";
 import { WarningTooltip } from "./WarningTooltip";
 
 export const TopicTicketAccordion = (props) => {
-  const { pteamId, topicId, serviceId, ttStatus, dateTimeFormat, systemAccount, members } = props;
+  const {
+    pteamId,
+    topicId,
+    serviceId,
+    ttStatus,
+    dateTimeFormat,
+    systemAccount,
+    members,
+    threat_impact,
+  } = props;
   console.log(typeof systemAccount);
   return (
-    <Box display="flex" flexDirection="column" sx={{ height: "350px" }}>
-      <Box
-        display="flex"
-        flexDirection="column"
-        justifyContent="baseline"
-        sx={{ width: "320px", overflowY: "scroll" }}
-      >
-        {[...Array(3)].map((_, i) => (
-          <Accordion key={i} disableGutters defaultExpanded={i === 0 ? true : false}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
-              <Box sx={{ display: "flex", alignItems: "center" }}>
-                <Box sx={{ mr: 1 }}>
-                  <ThreatImpactStatusChip threatImpact={1} />
-                </Box>
-                <Box>/usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA</Box>
+    <Box>
+      <Box sx={{ width: "320px", height: "350px", overflowY: "scroll" }}>
+        <Accordion
+          disableGutters
+          defaultExpanded
+          sx={{
+            border: 1,
+            borderColor: "divider",
+            "&:not(:last-child)": { borderBottom: 0 },
+            "&::before": { display: "none" },
+          }}
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <Box sx={{ mr: 1 }}>
+                <ThreatImpactStatusChip threatImpact={threat_impact} />
               </Box>
-            </AccordionSummary>
-            <AccordionDetails>
-              {/* <Box display="flex" alignItems="baseline" p={2}>
-                <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
-                  Threat impact
-                </Typography>
-                <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
-              </Box> */}
-              <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-                <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                  Assignees
-                </Typography>
-                <Box sx={{ maxWidth: 200 }}>
-                  <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
-                </Box>
-              </CardActions>
-              <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
-                <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                  Status
-                </Typography>
-                <Box display="flex" flexDirection="column">
-                  <Box display="flex" alignItems="center">
-                    <TopicStatusSelector
-                      pteamId={pteamId}
-                      topicId={topicId}
-                      serviceId={serviceId}
-                    />
-                    {(ttStatus.topic_status ?? "alerted") === "alerted" && (
-                      <WarningTooltip message="No one has acknowledged this topic" />
-                    )}
-                  </Box>
-                  {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
-                    ttStatus.scheduled_at && (
-                      <Box display="flex" alignItems="flex-end">
-                        <Typography ml={0.5} variant="caption">
-                          <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
-                          {dateTimeFormat(ttStatus.scheduled_at)}
-                        </Typography>
-                      </Box>
-                    )}
-                </Box>
+              <Box>/usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA</Box>
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails>
+            <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
+              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+                Assignees
+              </Typography>
+              <Box sx={{ maxWidth: 200 }}>
+                <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
               </Box>
-            </AccordionDetails>
-          </Accordion>
-        ))}
+            </CardActions>
+            <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
+              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+                Status
+              </Typography>
+              <Box display="flex" flexDirection="column">
+                <Box display="flex" alignItems="center">
+                  <TopicStatusSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
+                  {(ttStatus.topic_status ?? "alerted") === "alerted" && (
+                    <WarningTooltip message="No one has acknowledged this topic" />
+                  )}
+                </Box>
+                {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
+                  ttStatus.scheduled_at && (
+                    <Box display="flex" alignItems="flex-end">
+                      <Typography ml={0.5} variant="caption">
+                        <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
+                        {dateTimeFormat(ttStatus.scheduled_at)}
+                      </Typography>
+                    </Box>
+                  )}
+              </Box>
+            </Box>
+          </AccordionDetails>
+        </Accordion>
       </Box>
       {(ttStatus.topic_status ?? "alerted") !== "alerted" && (
         <Box
@@ -113,4 +114,5 @@ TopicTicketAccordion.propTypes = {
   dateTimeFormat: PropTypes.any.isRequired,
   systemAccount: PropTypes.any.isRequired,
   members: PropTypes.any.isRequired,
+  threat_impact: PropTypes.any.isRequired,
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -29,8 +29,11 @@ const ssvcPriorityToThreatImpact = (ssvcPriority) =>
   })[ssvcPriority];
 
 export const TopicTicketAccordion = (props) => {
-  const { pteamId, serviceId, topicId, tagId, ticket, members, defaultExpanded } = props;
+  const { pteamId, dependency, topicId, ticket, members, defaultExpanded } = props;
 
+  const serviceId = dependency.service_id;
+  const tagId = dependency.tag_id;
+  const target = dependency.target;
   const ticketStatus = ticket.current_ticket_status;
   const threatImpact = ssvcPriorityToThreatImpact(ticket.ssvc_deployer_priority);
 
@@ -53,7 +56,7 @@ export const TopicTicketAccordion = (props) => {
               <Box sx={{ mr: 1 }}>
                 <ThreatImpactStatusChip threatImpact={threatImpact} />
               </Box>
-              <Box>/usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA</Box>
+              <Box>{target}</Box>
             </Box>
           </AccordionSummary>
           <AccordionDetails>
@@ -129,9 +132,8 @@ export const TopicTicketAccordion = (props) => {
 
 TopicTicketAccordion.propTypes = {
   pteamId: PropTypes.string.isRequired,
-  serviceId: PropTypes.string.isRequired,
+  dependency: PropTypes.object.isRequired,
   topicId: PropTypes.string.isRequired,
-  tagId: PropTypes.string.isRequired,
   ticket: PropTypes.object.isRequired,
   members: PropTypes.object.isRequired,
   defaultExpanded: PropTypes.bool,

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -38,95 +38,91 @@ export const TopicTicketAccordion = (props) => {
   const threatImpact = ssvcPriorityToThreatImpact(ticket.ssvc_deployer_priority);
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
-      <Box sx={{ width: "320px", overflowY: "auto" }}>
-        <Accordion
-          disableGutters
-          defaultExpanded={defaultExpanded}
-          sx={{
-            borderTop: 1,
-            borderBottom: 1,
-            borderColor: "divider",
-            "&:not(:last-child)": { borderBottom: 0 },
-            "&::before": { display: "none" },
-          }}
-        >
-          <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
-            <Box sx={{ display: "flex", alignItems: "center" }}>
-              <Box sx={{ mr: 1 }}>
-                <ThreatImpactStatusChip threatImpact={threatImpact} />
-              </Box>
-              <Box>{target}</Box>
+    <Accordion
+      disableGutters
+      defaultExpanded={defaultExpanded}
+      sx={{
+        borderTop: 1,
+        borderBottom: 1,
+        borderColor: "divider",
+        "&:not(:last-child)": { borderBottom: 0 },
+        "&::before": { display: "none" },
+      }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Box sx={{ mr: 1 }}>
+            <ThreatImpactStatusChip threatImpact={threatImpact} />
+          </Box>
+          <Box>{target}</Box>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
+          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+            Assignees
+          </Typography>
+          <Box sx={{ maxWidth: 150 }}>
+            <AssigneesSelector
+              pteamId={pteamId}
+              serviceId={serviceId}
+              topicId={topicId}
+              tagId={tagId}
+              ticketId={ticket.ticket_id}
+              currentAssigneeIds={ticket.current_ticket_status.assignees}
+              members={members}
+            />
+          </Box>
+        </CardActions>
+        <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
+          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+            Status
+          </Typography>
+          <Box display="flex" flexDirection="column">
+            <Box display="flex" alignItems="center">
+              <TopicStatusSelector
+                pteamId={pteamId}
+                serviceId={serviceId}
+                topicId={topicId}
+                tagId={tagId}
+                ticketId={ticket.ticket_id}
+                currentStatus={ticketStatus}
+              />
+              {(ticketStatus.topic_status ?? "alerted") === "alerted" && (
+                <WarningTooltip message="No one has acknowledged this topic" />
+              )}
             </Box>
-          </AccordionSummary>
-          <AccordionDetails>
-            <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                Assignees
-              </Typography>
-              <Box sx={{ maxWidth: 150 }}>
-                <AssigneesSelector
-                  pteamId={pteamId}
-                  serviceId={serviceId}
-                  topicId={topicId}
-                  tagId={tagId}
-                  ticketId={ticket.ticket_id}
-                  currentAssigneeIds={ticket.current_ticket_status.assignees}
-                  members={members}
-                />
-              </Box>
-            </CardActions>
-            <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
-              <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-                Status
-              </Typography>
-              <Box display="flex" flexDirection="column">
-                <Box display="flex" alignItems="center">
-                  <TopicStatusSelector
-                    pteamId={pteamId}
-                    serviceId={serviceId}
-                    topicId={topicId}
-                    tagId={tagId}
-                    ticketId={ticket.ticket_id}
-                    currentStatus={ticketStatus}
-                  />
-                  {(ticketStatus.topic_status ?? "alerted") === "alerted" && (
-                    <WarningTooltip message="No one has acknowledged this topic" />
-                  )}
-                </Box>
-                {(ticketStatus.topic_status ?? "scheduled") === "scheduled" &&
-                  ticketStatus.scheduled_at && (
-                    <Box display="flex" alignItems="flex-end">
-                      <Typography ml={0.5} variant="caption">
-                        <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
-                        {dateTimeFormat(ticketStatus.scheduled_at)}
-                      </Typography>
-                    </Box>
-                  )}
-              </Box>
-            </Box>
-            {(ticketStatus.topic_status ?? "alerted") !== "alerted" && (
-              <Box
-                p={1.5}
-                display="flex"
-                flexDirection="row"
-                justifyContent="flex-end"
-                sx={{ color: grey[600] }}
-              >
+            {(ticketStatus.topic_status ?? "scheduled") === "scheduled" &&
+              ticketStatus.scheduled_at && (
                 <Box display="flex" alignItems="flex-end">
-                  <Typography variant="caption">Last updated by</Typography>
-                  <Typography ml={0.5} variant="caption" fontWeight={900}>
-                    {ticketStatus.user_id === systemAccount.uuid
-                      ? systemAccount.email
-                      : members[ticketStatus.user_id]?.email ?? "not a pteam member"}
+                  <Typography ml={0.5} variant="caption">
+                    <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
+                    {dateTimeFormat(ticketStatus.scheduled_at)}
                   </Typography>
                 </Box>
-              </Box>
-            )}
-          </AccordionDetails>
-        </Accordion>
-      </Box>
-    </Box>
+              )}
+          </Box>
+        </Box>
+        {(ticketStatus.topic_status ?? "alerted") !== "alerted" && (
+          <Box
+            p={1.5}
+            display="flex"
+            flexDirection="row"
+            justifyContent="flex-end"
+            sx={{ color: grey[600] }}
+          >
+            <Box display="flex" alignItems="flex-end">
+              <Typography variant="caption">Last updated by</Typography>
+              <Typography ml={0.5} variant="caption" fontWeight={900}>
+                {ticketStatus.user_id === systemAccount.uuid
+                  ? systemAccount.email
+                  : members[ticketStatus.user_id]?.email ?? "not a pteam member"}
+              </Typography>
+            </Box>
+          </Box>
+        )}
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -35,7 +35,8 @@ export const TopicTicketAccordion = (props) => {
           disableGutters
           defaultExpanded
           sx={{
-            border: 1,
+            borderTop: 1,
+            borderBottom: 1,
             borderColor: "divider",
             "&:not(:last-child)": { borderBottom: 0 },
             "&::before": { display: "none" },
@@ -54,7 +55,7 @@ export const TopicTicketAccordion = (props) => {
               <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
                 Assignees
               </Typography>
-              <Box sx={{ maxWidth: 200 }}>
+              <Box sx={{ maxWidth: 150 }}>
                 <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
               </Box>
             </CardActions>

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -1,0 +1,116 @@
+import { CalendarMonth } from "@mui/icons-material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  CardActions,
+  Typography,
+} from "@mui/material";
+import { grey } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { AssigneesSelector } from "./AssigneesSelector";
+import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
+import { TopicStatusSelector } from "./TopicStatusSelector";
+import { WarningTooltip } from "./WarningTooltip";
+
+export const TopicTicketAccordion = (props) => {
+  const { pteamId, topicId, serviceId, ttStatus, dateTimeFormat, systemAccount, members } = props;
+  console.log(typeof systemAccount);
+  return (
+    <Box display="flex" flexDirection="column" sx={{ height: "350px" }}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="baseline"
+        sx={{ width: "320px", overflowY: "scroll" }}
+      >
+        {[...Array(3)].map((_, i) => (
+          <Accordion key={i} disableGutters defaultExpanded={i === 0 ? true : false}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                <Box sx={{ mr: 1 }}>
+                  <ThreatImpactStatusChip threatImpact={1} />
+                </Box>
+                <Box>/usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA</Box>
+              </Box>
+            </AccordionSummary>
+            <AccordionDetails>
+              {/* <Box display="flex" alignItems="baseline" p={2}>
+                <Typography mr={2} variant="subtitle2" sx={{ fontWeight: 900 }}>
+                  Threat impact
+                </Typography>
+                <ThreatImpactChip threatImpact={topic.threat_impact ?? 4} />
+              </Box> */}
+              <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
+                <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+                  Assignees
+                </Typography>
+                <Box sx={{ maxWidth: 200 }}>
+                  <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
+                </Box>
+              </CardActions>
+              <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
+                <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+                  Status
+                </Typography>
+                <Box display="flex" flexDirection="column">
+                  <Box display="flex" alignItems="center">
+                    <TopicStatusSelector
+                      pteamId={pteamId}
+                      topicId={topicId}
+                      serviceId={serviceId}
+                    />
+                    {(ttStatus.topic_status ?? "alerted") === "alerted" && (
+                      <WarningTooltip message="No one has acknowledged this topic" />
+                    )}
+                  </Box>
+                  {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
+                    ttStatus.scheduled_at && (
+                      <Box display="flex" alignItems="flex-end">
+                        <Typography ml={0.5} variant="caption">
+                          <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
+                          {dateTimeFormat(ttStatus.scheduled_at)}
+                        </Typography>
+                      </Box>
+                    )}
+                </Box>
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        ))}
+      </Box>
+      {(ttStatus.topic_status ?? "alerted") !== "alerted" && (
+        <Box
+          p={1.5}
+          display="flex"
+          flexDirection="row"
+          justifyContent="flex-end"
+          sx={{ color: grey[600] }}
+        >
+          <Box display="flex" alignItems="flex-end">
+            <Typography variant="caption">Last updated by</Typography>
+            <Typography ml={0.5} variant="caption" fontWeight={900}>
+              {ttStatus.user_id === systemAccount.uuid
+                ? systemAccount.email
+                : members[ttStatus.user_id]?.email ?? "not a pteam member"}
+            </Typography>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+TopicTicketAccordion.propTypes = {
+  pteamId: PropTypes.string.isRequired,
+  topicId: PropTypes.string.isRequired,
+  serviceId: PropTypes.string.isRequired,
+  ttStatus: PropTypes.any.isRequired,
+  dateTimeFormat: PropTypes.any.isRequired,
+  systemAccount: PropTypes.any.isRequired,
+  members: PropTypes.any.isRequired,
+};

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -29,8 +29,8 @@ export const TopicTicketAccordion = (props) => {
     threat_impact,
   } = props;
   return (
-    <Box>
-      <Box sx={{ width: "320px", height: "350px", overflowY: "scroll" }}>
+    <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+      <Box sx={{ width: "320px", overflowY: "auto" }}>
         <Accordion
           disableGutters
           defaultExpanded

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -12,28 +12,34 @@ import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React from "react";
 
+import { systemAccount } from "../utils/const";
+import { dateTimeFormat } from "../utils/func";
+
 import { AssigneesSelector } from "./AssigneesSelector";
 import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
 import { TopicStatusSelector } from "./TopicStatusSelector";
 import { WarningTooltip } from "./WarningTooltip";
 
+const ssvcPriorityToThreatImpact = (ssvcPriority) =>
+  ({
+    immediate: 1,
+    out_of_cycle: 2,
+    scheduled: 3,
+    defer: 4,
+  })[ssvcPriority];
+
 export const TopicTicketAccordion = (props) => {
-  const {
-    pteamId,
-    topicId,
-    serviceId,
-    ttStatus,
-    dateTimeFormat,
-    systemAccount,
-    members,
-    threat_impact,
-  } = props;
+  const { pteamId, serviceId, topicId, tagId, ticket, members, defaultExpanded } = props;
+
+  const ticketStatus = ticket.current_ticket_status;
+  const threatImpact = ssvcPriorityToThreatImpact(ticket.ssvc_deployer_priority);
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
       <Box sx={{ width: "320px", overflowY: "auto" }}>
         <Accordion
           disableGutters
-          defaultExpanded
+          defaultExpanded={defaultExpanded}
           sx={{
             borderTop: 1,
             borderBottom: 1,
@@ -45,7 +51,7 @@ export const TopicTicketAccordion = (props) => {
           <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
             <Box sx={{ display: "flex", alignItems: "center" }}>
               <Box sx={{ mr: 1 }}>
-                <ThreatImpactStatusChip threatImpact={threat_impact} />
+                <ThreatImpactStatusChip threatImpact={threatImpact} />
               </Box>
               <Box>/usr/local/lib/python3.7/site-packages/sqlparse-0.4.4.dist-info/METADATA</Box>
             </Box>
@@ -56,7 +62,15 @@ export const TopicTicketAccordion = (props) => {
                 Assignees
               </Typography>
               <Box sx={{ maxWidth: 150 }}>
-                <AssigneesSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
+                <AssigneesSelector
+                  pteamId={pteamId}
+                  serviceId={serviceId}
+                  topicId={topicId}
+                  tagId={tagId}
+                  ticketId={ticket.ticket_id}
+                  currentAssigneeIds={ticket.current_ticket_status.assignees}
+                  members={members}
+                />
               </Box>
             </CardActions>
             <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
@@ -65,54 +79,63 @@ export const TopicTicketAccordion = (props) => {
               </Typography>
               <Box display="flex" flexDirection="column">
                 <Box display="flex" alignItems="center">
-                  <TopicStatusSelector pteamId={pteamId} topicId={topicId} serviceId={serviceId} />
-                  {(ttStatus.topic_status ?? "alerted") === "alerted" && (
+                  <TopicStatusSelector
+                    pteamId={pteamId}
+                    serviceId={serviceId}
+                    topicId={topicId}
+                    tagId={tagId}
+                    ticketId={ticket.ticket_id}
+                    currentStatus={ticketStatus}
+                  />
+                  {(ticketStatus.topic_status ?? "alerted") === "alerted" && (
                     <WarningTooltip message="No one has acknowledged this topic" />
                   )}
                 </Box>
-                {(ttStatus.topic_status ?? "scheduled") === "scheduled" &&
-                  ttStatus.scheduled_at && (
+                {(ticketStatus.topic_status ?? "scheduled") === "scheduled" &&
+                  ticketStatus.scheduled_at && (
                     <Box display="flex" alignItems="flex-end">
                       <Typography ml={0.5} variant="caption">
                         <CalendarMonth fontSize="small" sx={{ color: grey[700], mb: -0.7 }} />
-                        {dateTimeFormat(ttStatus.scheduled_at)}
+                        {dateTimeFormat(ticketStatus.scheduled_at)}
                       </Typography>
                     </Box>
                   )}
               </Box>
             </Box>
+            {(ticketStatus.topic_status ?? "alerted") !== "alerted" && (
+              <Box
+                p={1.5}
+                display="flex"
+                flexDirection="row"
+                justifyContent="flex-end"
+                sx={{ color: grey[600] }}
+              >
+                <Box display="flex" alignItems="flex-end">
+                  <Typography variant="caption">Last updated by</Typography>
+                  <Typography ml={0.5} variant="caption" fontWeight={900}>
+                    {ticketStatus.user_id === systemAccount.uuid
+                      ? systemAccount.email
+                      : members[ticketStatus.user_id]?.email ?? "not a pteam member"}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
           </AccordionDetails>
         </Accordion>
       </Box>
-      {(ttStatus.topic_status ?? "alerted") !== "alerted" && (
-        <Box
-          p={1.5}
-          display="flex"
-          flexDirection="row"
-          justifyContent="flex-end"
-          sx={{ color: grey[600] }}
-        >
-          <Box display="flex" alignItems="flex-end">
-            <Typography variant="caption">Last updated by</Typography>
-            <Typography ml={0.5} variant="caption" fontWeight={900}>
-              {ttStatus.user_id === systemAccount.uuid
-                ? systemAccount.email
-                : members[ttStatus.user_id]?.email ?? "not a pteam member"}
-            </Typography>
-          </Box>
-        </Box>
-      )}
     </Box>
   );
 };
 
 TopicTicketAccordion.propTypes = {
   pteamId: PropTypes.string.isRequired,
-  topicId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
-  ttStatus: PropTypes.object.isRequired,
-  dateTimeFormat: PropTypes.func.isRequired,
-  systemAccount: PropTypes.object.isRequired,
+  topicId: PropTypes.string.isRequired,
+  tagId: PropTypes.string.isRequired,
+  ticket: PropTypes.object.isRequired,
   members: PropTypes.object.isRequired,
-  threat_impact: PropTypes.number.isRequired,
+  defaultExpanded: PropTypes.bool,
+};
+TopicTicketAccordion.defaultProps = {
+  defaultExpanded: false,
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -20,12 +20,12 @@ import { ThreatImpactStatusChip } from "./ThreatImpactStatusChip";
 import { TopicStatusSelector } from "./TopicStatusSelector";
 import { WarningTooltip } from "./WarningTooltip";
 
-const ssvcPriorityToThreatImpact = (ssvcPriority) =>
+const ssvcPriorityToThreatImpactName = (ssvcPriority) =>
   ({
-    immediate: 1,
-    out_of_cycle: 2,
-    scheduled: 3,
-    defer: 4,
+    immediate: "immediate",
+    out_of_cycle: "offcycle",
+    scheduled: "acceptable",
+    defer: "none",
   })[ssvcPriority];
 
 export const TopicTicketAccordion = (props) => {
@@ -35,7 +35,7 @@ export const TopicTicketAccordion = (props) => {
   const tagId = dependency.tag_id;
   const target = dependency.target;
   const ticketStatus = ticket.current_ticket_status;
-  const threatImpact = ssvcPriorityToThreatImpact(ticket.ssvc_deployer_priority);
+  const threatImpactName = ssvcPriorityToThreatImpactName(ticket.ssvc_deployer_priority);
 
   return (
     <Accordion
@@ -52,7 +52,7 @@ export const TopicTicketAccordion = (props) => {
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
         <Box sx={{ display: "flex", alignItems: "center" }}>
           <Box sx={{ mr: 1 }}>
-            <ThreatImpactStatusChip threatImpact={threatImpact} />
+            <ThreatImpactStatusChip threatImpactName={threatImpactName} />
           </Box>
           <Box>{target}</Box>
         </Box>

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -43,7 +43,7 @@ import {
   getPTeamTagsSummary,
   setPTeamId,
 } from "../slices/pteam";
-import { noPTeamMessage, threatImpactName, threatImpactProps } from "../utils/const";
+import { noPTeamMessage, threatImpactNames, threatImpactProps } from "../utils/const";
 const threatImpactCountMax = 99999;
 
 function SearchField(props) {
@@ -217,14 +217,14 @@ export function Status() {
 
   let impactFilters = params
     .getAll("impactFilter")
-    .filter((filter) => Object.values(threatImpactName).includes(filter));
+    .filter((filter) => Object.values(threatImpactNames).includes(filter));
 
   const summary = isActiveAllServicesMode ? pteamTagsSummary : serviceTagsSummary;
   const filteredTags = summary.tags.filter(
     (tag) =>
       (impactFilters.length === 0
         ? true // show all if selected none
-        : impactFilters.includes(threatImpactName[parseInt(tag.threat_impact ?? 4)])) && // show only selected
+        : impactFilters.includes(threatImpactNames[parseInt(tag.threat_impact ?? 4)])) && // show only selected
       (!searchWord?.length > 0 || tag.tag_name.toLowerCase().includes(searchWord)),
   );
 
@@ -350,7 +350,7 @@ export function Status() {
         sx={{ left: -55 }}
       >
         {[0, 1, 2, 3].map((idx) => {
-          const impactName = threatImpactName[idx + 1];
+          const impactName = threatImpactNames[idx + 1];
           const checked = impactFilters.includes(impactName);
           const summary = isActiveAllServicesMode ? pteamTagsSummary : serviceTagsSummary;
           const threatImpactCount = summary.threat_impact_count[(idx + 1).toString()];

--- a/web/src/pages/TopicDetail.jsx
+++ b/web/src/pages/TopicDetail.jsx
@@ -12,7 +12,7 @@ import { useParams } from "react-router-dom";
 
 import { ActionTypeIcon } from "../components/ActionTypeIcon";
 import { getTopic, getActions } from "../slices/topics";
-import { threatImpactName as threatImpactNames, threatImpactProps } from "../utils/const";
+import { threatImpactNames, threatImpactProps } from "../utils/const";
 
 const threatImpactColor = {
   immediate: {

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -41,6 +41,12 @@ export const getPTeamTopics = async (pteamId) => axios.get(`/pteams/${pteamId}/t
 export const getPTeamServiceTaggedTopicIds = async (pteamId, serviceId, tagId) =>
   axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/topic_ids`);
 
+export const getTicketsRelatedToServiceTopicTag = async (pteamId, serviceId, topicId, tagId) =>
+  axios.get(`/pteams/${pteamId}/services/${serviceId}/topics/${topicId}/tags/${tagId}/tickets`);
+
+export const setTicketStatus = async (pteamId, serviceId, ticketId, data) =>
+  axios.post(`/pteams/${pteamId}/services/${serviceId}/ticketstatus/${ticketId}`, data);
+
 export const createPTeamInvitation = async (pteamId, data) =>
   axios.post(`/pteams/${pteamId}/invitation`, data);
 

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -73,7 +73,7 @@ export const experienceColors = {
   7: red[500],
 };
 
-export const threatImpactName = {
+export const threatImpactNames = {
   1: "immediate",
   2: "offcycle",
   3: "acceptable",


### PR DESCRIPTION
## PR の目的

Ticketごとにステータスが管理できるように変更する。

## 経緯・意図・意思決定

- アコーディオン形式でTicket管理できる様に変更した。
- TopicStatusSelectorのPopperがアコーディオンに隠れてしまうため、z-indexを追加している。
- アコーディオンを開くとカード全体の高さが変化してしまうため、カードの高さを350pxに固定した。
- アコーディオンのタイトル部分にThreat impactのアイコンを設置し、従来のThreat impactの表示を削除した。

## API 関連追記

- チケットには ThreatImpact の概念が無い。
  - 暫定的に、ssvc_deployer_priority の４種を ThreatImpact の４種に強制変換している。
  - 将来的に SSVC Priority が表に出てきたら、この暫定処置を廃止する。
- チケットリストに対応
  - ~~TopicTicketAccordion を flexDirection=column で積んだだけなので、はみ出す場合などにスクロールバーなどの対応が必要。~~
  - Last updated by がアコーディオンの外に出ていたので、中に移設。
  - デフォルトで最初のチケットのアコーディオンを展開。
    - 個別に閉じたり開いたりできる。 ~~最大で１つだけ開く、などの細工が要るなら対応可能。~~ → 不要 by PO
- solved の Taken Actions は、ひとまず全チケットの taken action をソートもせずに並べてある。
  - 何を表示すべきか、要検討。
- 既知の不具合
  - Report completed action 実施でまとめて complete した後、チケットのステータスに反映されない。
    - チケット単位で complete するように改修予定なので、そちらで合わせて対応する。

![unsolved1](https://github.com/user-attachments/assets/a116a2a3-e77a-4007-bbb3-778119927238)
![unsolved2](https://github.com/user-attachments/assets/782cb918-2d8e-495e-8aaa-441472e1e2cf)
![solved](https://github.com/user-attachments/assets/448cd60a-75bb-4f16-8a78-adcc9409c88c)
