### PR TITLE
Topic/api ticket based topic status

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -430,9 +430,6 @@ class TicketStatus(Base):
     created_at: Mapped[datetime] = mapped_column(server_default=current_timestamp())
 
     ticket = relationship("Ticket", back_populates="ticket_statuses")
-    current_ticket_status = relationship(
-        "CurrentTicketStatus", uselist=False, back_populates="ticket_status"
-    )
 
 
 class CurrentTicketStatus(Base):
@@ -455,7 +452,7 @@ class CurrentTicketStatus(Base):
     updated_at: Mapped[datetime | None]
 
     ticket = relationship("Ticket", back_populates="current_ticket_status")
-    ticket_status = relationship("TicketStatus", back_populates="current_ticket_status")
+    ticket_status = relationship("TicketStatus")
 
 
 class Alert(Base):

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -11,6 +11,7 @@ from app.models import (
     ExploitationEnum,
     PTeamAuthEnum,
     SafetyImpactEnum,
+    SSVCDeployerPriorityEnum,
     TopicStatusType,
 )
 
@@ -462,6 +463,47 @@ class TopicStatusResponse(ORMModel):
     action_logs: list[ActionLogResponse] = []
 
 
+class ThreatResponse(ORMModel):
+    threat_id: UUID
+    dependency_id: UUID
+    topic_id: UUID
+
+
+class ThreatRequest(ORMModel):
+    dependency_id: UUID
+    topic_id: UUID
+
+
+class TicketStatusRequest(ORMModel):
+    topic_status: TopicStatusType | None = None
+    logging_ids: list[UUID] | None = None
+    assignees: list[UUID] | None = None
+    note: str | None = None
+    scheduled_at: datetime | None = None
+
+
+class TicketStatusResponse(ORMModel):
+    status_id: UUID | None = None  # None is the case no status is set yet
+    ticket_id: UUID
+    topic_status: TopicStatusType = TopicStatusType.alerted
+    user_id: UUID | None = None
+    created_at: datetime | None = None
+    assignees: list[UUID] = []
+    note: str | None = None
+    scheduled_at: datetime | None = None
+    action_logs: list[ActionLogResponse] = []
+
+
+class TicketResponse(ORMModel):
+    ticket_id: UUID
+    threat_id: UUID
+    created_at: datetime
+    updated_at: datetime
+    ssvc_deployer_priority: SSVCDeployerPriorityEnum
+    threat: ThreatResponse
+    current_ticket_status: TicketStatusResponse
+
+
 class PTeamTaggedTopics(ORMModel):
     pteam_id: UUID
     tag_id: UUID
@@ -585,17 +627,6 @@ class ATeamTopicCommentResponse(ORMModel):
     updated_at: datetime | None = None
     comment: str
     email: str
-
-
-class ThreatResponse(ORMModel):
-    threat_id: UUID
-    dependency_id: UUID
-    topic_id: UUID
-
-
-class ThreatRequest(ORMModel):
-    dependency_id: UUID
-    topic_id: UUID
 
 
 class ServiceTaggedTopics(ORMModel):


### PR DESCRIPTION
## PR の目的

- チケットの id を指定してステータスを個別に set/get するエンドポイントを実装
- サービスとトピックの id を指定して、関連するチケット全てをカレントステータスと共に取得するエンドポイントを実装
  - リストは「ssvc_deployer_priority, dependency.target」でソート
