### PR TITLE
topic/fix progress bar in status screen

### DIFF
--- a/web/src/components/PTeamServiceDelete.jsx
+++ b/web/src/components/PTeamServiceDelete.jsx
@@ -15,7 +15,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
 import styles from "../cssModule/dialog.module.css";
-import { getPTeam, invalidateServiceId } from "../slices/pteam";
+import { getPTeam, invalidateServiceId, getPTeamTagsSummary } from "../slices/pteam";
 import { deletePTeamService } from "../utils/api.js";
 
 export function PTeamServiceDelete() {
@@ -49,6 +49,7 @@ export function PTeamServiceDelete() {
     function onSuccess(success, deletingServiceId) {
       dispatch(getPTeam(pteamId)); // sync pteam.services
       dispatch(invalidateServiceId(deletingServiceId));
+      dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
       enqueueSnackbar("Remove service succeeded", { variant: "success" });
     }
     function onError(error) {

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -22,6 +22,7 @@ import {
   getTopicStatus,
   getPTeamServiceTaggedTicketIds,
   getPTeamServiceTagsSummary,
+  getPTeamTagsSummary,
 } from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
 
@@ -79,6 +80,7 @@ export function ReportCompletedActions(props) {
         getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
       );
       dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
+      dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
       enqueueSnackbar("Set topicstatus 'completed' succeeded", { variant: "success" });
     } catch (error) {
       enqueueSnackbar(`Operation failed: ${error}`, { variant: "error" });

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -228,7 +228,6 @@ export function TopicModal(props) {
             dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
           )
           .catch((error) => operationError(error));
-        console.log("test1");
       } else if (presetActionIds.has(a.action_id)) {
         updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
         presetActionIds.delete(a.action_id);

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -216,27 +216,22 @@ export function TopicModal(props) {
 
     const presetActionIds = new Set(presetActions.map((a) => a.action_id));
 
-    actions.forEach((a) => {
+    actions.forEach(async (a) => {
       const actionRequest = {
         ...a,
         topic_id: topicId,
       };
       if (a.action_id === null) {
-        createAction(actionRequest)
-          .then(
-            (success) => dispatch(getPTeamTagsSummary({ pteamId: pteamId })),
-            dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
-          )
-          .catch((error) => operationError(error));
+        await createAction(actionRequest).catch((error) => operationError(error));
       } else if (presetActionIds.has(a.action_id)) {
-        updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
+        await updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
         presetActionIds.delete(a.action_id);
       }
     });
 
     // delete actions that are not related to topic
-    presetActionIds.forEach((actionId) => {
-      deleteAction(actionId).catch((error) => operationError(error));
+    presetActionIds.forEach(async (actionId) => {
+      await deleteAction(actionId).catch((error) => operationError(error));
     });
 
     if (src.created_by !== user.user_id) {

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -31,6 +31,7 @@ import {
   getPTeamTopicActions,
   getPTeamServiceTaggedTicketIds,
   getPTeamServiceTagsSummary,
+  getPTeamTagsSummary,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import {
@@ -170,6 +171,7 @@ export function TopicModal(props) {
       dispatch(getTopic(topicId)),
       dispatch(getPTeamTopicActions({ pteamId: pteamId, topicId: topicId })),
       dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
+      dispatch(getPTeamTagsSummary({ pteamId: pteamId })),
     ]);
     // update only if needed
     if (pteamId && presetTagId) {
@@ -220,7 +222,13 @@ export function TopicModal(props) {
         topic_id: topicId,
       };
       if (a.action_id === null) {
-        createAction(actionRequest).catch((error) => operationError(error));
+        createAction(actionRequest)
+          .then(
+            (success) => dispatch(getPTeamTagsSummary({ pteamId: pteamId })),
+            dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
+          )
+          .catch((error) => operationError(error));
+        console.log("test1");
       } else if (presetActionIds.has(a.action_id)) {
         updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
         presetActionIds.delete(a.action_id);
@@ -343,6 +351,7 @@ export function TopicModal(props) {
       );
     }
     dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
+    dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
   };
 
   function ActionGeneratorModal() {

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -30,6 +30,7 @@ import {
   getTopicStatus,
   getPTeamServiceTaggedTicketIds,
   getPTeamServiceTagsSummary,
+  getPTeamTagsSummary,
 } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
 import { topicStatusProps } from "../utils/const";
@@ -91,6 +92,7 @@ export function TopicStatusSelector(props) {
             }),
           );
           dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
+          dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
         }
         if (ttStatus.topic_status === "completed") {
           dispatch(


### PR DESCRIPTION
## PR の目的
- Status画面のプログレスバーがAllservicesの際の時に正常に動くようにするため、Ticketが追加、更新されているところに
dispatch(getPTeamTagsSummary)を入れました

## 経緯・意図・意思決定
- Ticketが変化するイベント一覧
TopicStatus変更(acknowledged, scheduled, completed)
Topic 削除、追加、変更
service削除
action作成
- 上記に該当する部分にdispatch(getPTeamTagsSummary)を入れました。(基本的にdispatch(getPTeamServiceTagsSummary)がある付近に入れています)
- actionに関しては、service単体のSummaryの時も反映されていなかったのでdispatch(getPTeamServiceTagsSummary), dispatch(getPTeamTagsSummary)の2つ入れています