### PR TITLE
change solved decision

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -259,13 +259,23 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     return int_priority <= int_threshold
 
 
-def count_service_solved_tickets_per_threat_impact(
+def sum_threat_impact_count(topic_ids: list[str], topic_ids_dict: dict, count_key: str) -> dict:
+    sum_threat_impact_count = {"1": 0, "2": 0, "3": 0, "4": 0}
+    for topic_id in topic_ids:
+        current_count = topic_ids_dict[topic_id][count_key]
+        sum_threat_impact_count["1"] += current_count["1"]
+        sum_threat_impact_count["2"] += current_count["2"]
+        sum_threat_impact_count["3"] += current_count["3"]
+        sum_threat_impact_count["4"] += current_count["4"]
+    return sum_threat_impact_count
+
+
+def get_topic_ids_summary_by_service_id_and_tag_id(
     service: models.Service,
     tag_id: UUID | str,
-) -> dict[str, int]:
+) -> dict:
+    topic_ids_dict: dict = {}
     _completed = models.TopicStatusType.completed
-    threat_counts_rows: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
-    prev_topic_id: set = set()
 
     for dependency in service.dependencies:
         if dependency.tag_id != str(tag_id):
@@ -273,152 +283,57 @@ def count_service_solved_tickets_per_threat_impact(
         for threat in dependency.threats:
             if not threat.ticket:
                 continue
-
             _curent_ticket = threat.ticket.current_ticket_status
-            if _curent_ticket.topic_status == _completed and threat.topic_id not in prev_topic_id:
-                threat_imapct_str = str(_curent_ticket.threat_impact)
-                threat_counts_rows[threat_imapct_str] += 1
-                prev_topic_id.add(threat.topic_id)
-
-    return threat_counts_rows
-
-
-def count_service_unsolved_tickets_per_threat_impact(
-    service: models.Service,
-    tag_id: UUID | str,
-) -> dict[str, int]:
-    _completed = models.TopicStatusType.completed
-    threat_counts_rows: dict[str, int] = {"1": 0, "2": 0, "3": 0, "4": 0}
-    prev_topic_id: set = set()
-
-    for dependency in service.dependencies:
-        if dependency.tag_id != str(tag_id):
-            continue
-        for threat in dependency.threats:
-            if not threat.ticket:
-                continue
-
-            _curent_ticket = threat.ticket.current_ticket_status
-            if _curent_ticket.topic_status != _completed and threat.topic_id not in prev_topic_id:
-                threat_imapct_str = str(_curent_ticket.threat_impact)
-                threat_counts_rows[threat_imapct_str] += 1
-                prev_topic_id.add(threat.topic_id)
-
-    return threat_counts_rows
-
-
-def get_sorted_solved_ticket_ids_by_service_tag_and_status(
-    service: models.Service,
-    tag_id: UUID | str,
-) -> list[dict]:
-    _completed = models.TopicStatusType.completed
-    topic_ticket_ids: list[dict] = []
-    topic_ticket_ids_dict: dict = {}
-    result: list = []
-
-    # Search for topic_id and ticket_id corresponding to service_id and tag_id
-    for dependency in service.dependencies:
-        if dependency.tag_id != str(tag_id):
-            continue
-        for threat in dependency.threats:
-            if not threat.ticket:
-                continue
-            _curent_ticket = threat.ticket.current_ticket_status
+            if (tmp_topic_ids_dict := topic_ids_dict.get(threat.topic_id)) is None:
+                tmp_topic_ids_dict = {
+                    "topic_id": threat.topic_id,
+                    "topic_threat_impact": threat.topic.threat_impact,
+                    "topic_updated_at": threat.topic.updated_at,
+                    "is_solved": True,
+                    "solved_threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
+                    "unsolved_threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
+                }
+                topic_ids_dict[threat.topic_id] = tmp_topic_ids_dict
+            threat_imapct_str = str(_curent_ticket.threat_impact)
             if _curent_ticket.topic_status == _completed:
-                if (
-                    tmp_topic_ticket_ids_dict := topic_ticket_ids_dict.get(threat.topic_id)
-                ) is None:
-                    tmp_topic_ticket_ids_dict = {
-                        "topic_id": threat.topic_id,
-                        "topic_threat_impact": threat.topic.threat_impact,
-                        "topic_updated_at": threat.topic.updated_at,
-                        "ticket_ids": [],
-                    }
-                    topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
-                tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
-
-    # The contents of topic_ticket_ids are as follows
-    # [{
-    #   "topic_id":xxxxx,
-    #   "topic_threat_impact":xxxxx,
-    #   "topic_updated_at":xxxxx,
-    #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
-    # }]
-    topic_ticket_ids = list(topic_ticket_ids_dict.values())
+                tmp_topic_ids_dict["solved_threat_impact_count"][threat_imapct_str] += 1
+            else:
+                tmp_topic_ids_dict["unsolved_threat_impact_count"][threat_imapct_str] += 1
+                tmp_topic_ids_dict["is_solved"] = False
 
     # Sort topic_id according to threat_impact and updated_at
-    topic_ticket_ids_sorted = sorted(
-        topic_ticket_ids,
+    topic_ids_sorted = sorted(
+        topic_ids_dict.values(),
         key=lambda x: (
             x["topic_threat_impact"],
             -(_dt.timestamp() if (_dt := x["topic_updated_at"]) else 0),
         ),
     )
-
-    # delete topic_threat_impact and topic_updated_at
-    for _ in topic_ticket_ids_sorted:
-        del _["topic_threat_impact"]
-        del _["topic_updated_at"]
-        result.append(_)
-
-    return result
-
-
-def get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
-    service: models.Service,
-    tag_id: UUID | str,
-) -> list[dict]:
-    _completed = models.TopicStatusType.completed
-    topic_ticket_ids: list[dict] = []
-    topic_ticket_ids_dict: dict = {}
-    result: list = []
-
-    # Search for topic_id and ticket_id corresponding to service_id and tag_id
-    for dependency in service.dependencies:
-        if dependency.tag_id != str(tag_id):
-            continue
-        for threat in dependency.threats:
-            if not threat.ticket:
-                continue
-            _curent_ticket = threat.ticket.current_ticket_status
-            if _curent_ticket.topic_status != _completed:
-                if (
-                    tmp_topic_ticket_ids_dict := topic_ticket_ids_dict.get(threat.topic_id)
-                ) is None:
-                    tmp_topic_ticket_ids_dict = {
-                        "topic_id": threat.topic_id,
-                        "topic_threat_impact": threat.topic.threat_impact,
-                        "topic_updated_at": threat.topic.updated_at,
-                        "ticket_ids": [],
-                    }
-                    topic_ticket_ids_dict[threat.topic_id] = tmp_topic_ticket_ids_dict
-                tmp_topic_ticket_ids_dict["ticket_ids"].append(_curent_ticket.ticket_id)
-
-    # The contents of topic_ticket_ids are as follows
-    # [{
-    #   "topic_id":xxxxx,
-    #   "topic_threat_impact":xxxxx,
-    #   "topic_updated_at":xxxxx,
-    #   "ticket_ids":[xxxxx,xxxxx,xxxxx]
-    # }]
-    topic_ticket_ids = list(topic_ticket_ids_dict.values())
-
-    # Sort topic_id according to threat_impact and updated_at
-    topic_ticket_ids_sorted = sorted(
-        topic_ticket_ids,
-        key=lambda x: (
-            x["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := x["topic_updated_at"]) else 0),
-        ),
+    solved_topic_ids = list(
+        map(lambda item: item["topic_id"], filter(lambda item: item["is_solved"], topic_ids_sorted))
     )
-
-    # delete topic_threat_impact and topic_updated_at
-    for _ in topic_ticket_ids_sorted:
-        del _["topic_threat_impact"]
-        del _["topic_updated_at"]
-        result.append(_)
-
-    return result
+    unsolved_topic_ids = list(
+        map(
+            lambda item: item["topic_id"],
+            filter(lambda item: not item["is_solved"], topic_ids_sorted),
+        )
+    )
+    # gen summary
+    topic_ids_summary: dict[str, dict] = {
+        "solved": {
+            "topic_ids": solved_topic_ids,
+            "threat_impact_count": sum_threat_impact_count(
+                solved_topic_ids, topic_ids_dict, "solved_threat_impact_count"
+            ),
+        },
+        "unsolved": {
+            "topic_ids": unsolved_topic_ids,
+            "threat_impact_count": sum_threat_impact_count(
+                unsolved_topic_ids, topic_ids_dict, "unsolved_threat_impact_count"
+            ),
+        },
+    }
+    return topic_ids_summary
 
 
 def create_ticket_internal(

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -463,7 +463,7 @@ def get_service_by_id(db: Session, service_id: UUID | str) -> models.Service | N
 
 
 def get_dependency_from_service_id_and_tag_id(
-    db: Session, service_id: str, tag_id: str
+    db: Session, service_id: UUID | str, tag_id: UUID | str
 ) -> models.Dependency | None:
     return db.scalars(
         select(models.Dependency).where(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -14,16 +14,13 @@ from app.auth import get_current_user
 from app.common import (
     check_pteam_auth,
     check_pteam_membership,
-    count_service_solved_tickets_per_threat_impact,
-    count_service_unsolved_tickets_per_threat_impact,
     count_threat_impact_from_summary,
     create_topic_tag,
     fix_threats_for_dependency,
     get_pteam_ext_tags,
-    get_sorted_solved_ticket_ids_by_service_tag_and_status,
     get_sorted_topics,
-    get_sorted_unsolved_ticket_ids_by_service_tag_and_status,
     get_tag_ids_with_parent_ids,
+    get_topic_ids_summary_by_service_id_and_tag_id,
 )
 from app.constants import MEMBER_UUID, NOT_MEMBER_UUID
 from app.database import get_db, open_db_session
@@ -256,10 +253,10 @@ def get_pteam_tags(
 
 
 @router.get(
-    "/{pteam_id}/services/{service_id}/tags/{tag_id}/ticket_ids",
+    "/{pteam_id}/services/{service_id}/tags/{tag_id}/topic_ids",
     response_model=schemas.ServiceTaggedTopicsSolvedUnsolved,
 )
-def get_service_tagged_ticket_ids(
+def get_service_tagged_topic_ids(
     pteam_id: UUID,
     service_id: UUID,
     tag_id: UUID,
@@ -276,38 +273,17 @@ def get_service_tagged_ticket_ids(
         raise NO_SUCH_SERVICE
     if not persistence.get_tag_by_id(db, tag_id):
         raise NO_SUCH_TAG
-    if not persistence.get_dependency_from_service_id_and_tag_id(db, str(service_id), str(tag_id)):
+    if not persistence.get_dependency_from_service_id_and_tag_id(db, service_id, tag_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service tag")
 
     ## sovled
-    topic_ticket_ids_soloved = get_sorted_solved_ticket_ids_by_service_tag_and_status(
-        service, tag_id
-    )
-    threat_impact_count_soloved = count_service_solved_tickets_per_threat_impact(service, tag_id)
-
-    ## unsovled
-    topic_ticket_ids_unsoloved = get_sorted_unsolved_ticket_ids_by_service_tag_and_status(
-        service, tag_id
-    )
-    threat_impact_count_unsoloved = count_service_unsolved_tickets_per_threat_impact(
-        service, tag_id
-    )
+    topic_ids_summary = get_topic_ids_summary_by_service_id_and_tag_id(service, tag_id)
 
     return {
-        "solved": {
-            "pteam_id": pteam_id,
-            "service_id": service_id,
-            "tag_id": tag_id,
-            "threat_impact_count": threat_impact_count_soloved,
-            "topic_ticket_ids": topic_ticket_ids_soloved,
-        },
-        "unsolved": {
-            "pteam_id": pteam_id,
-            "service_id": service_id,
-            "tag_id": tag_id,
-            "threat_impact_count": threat_impact_count_unsoloved,
-            "topic_ticket_ids": topic_ticket_ids_unsoloved,
-        },
+        "pteam_id": pteam_id,
+        "service_id": service_id,
+        "tag_id": tag_id,
+        **topic_ids_summary,
     }
 
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -599,14 +599,14 @@ class ThreatRequest(ORMModel):
 
 
 class ServiceTaggedTopics(ORMModel):
-    pteam_id: UUID
-    service_id: UUID
-    tag_id: UUID
     threat_impact_count: dict[str, int]
-    topic_ticket_ids: list[dict]
+    topic_ids: list[UUID]
 
 
 class ServiceTaggedTopicsSolvedUnsolved(ORMModel):
+    pteam_id: UUID
+    service_id: UUID
+    tag_id: UUID
     solved: ServiceTaggedTopics
     unsolved: ServiceTaggedTopics
 

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -67,27 +67,21 @@ def test_it_should_return_solved_number_based_on_ticket_status(
     )
 
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 200
     response = response.json()
 
+    # common
+    assert response["pteam_id"] == ticket_response["pteam_id"]
+    assert response["service_id"] == ticket_response["service_id"]
+    assert response["tag_id"] == ticket_response["tag_id"]
     # solved
-    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["solved"]["service_id"] == ticket_response["service_id"]
-    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["solved"]["topic_ticket_ids"]) == solved_num
-    assert (
-        ticket_response["ticket_id"] in response["solved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-    )
-    assert response["solved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
-
+    assert len(response["solved"]["topic_ids"]) == solved_num
+    assert response["solved"]["topic_ids"][0] == ticket_response["topic_id"]
     # unsolved
-    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
-    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
+    assert len(response["unsolved"]["topic_ids"]) == unsolved_num
 
 
 @pytest.mark.parametrize(
@@ -119,64 +113,36 @@ def test_it_should_return_unsolved_number_based_on_ticket_status(
     )
 
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 200
     response = response.json()
 
+    # common
+    assert response["pteam_id"] == ticket_response["pteam_id"]
+    assert response["service_id"] == ticket_response["service_id"]
+    assert response["tag_id"] == ticket_response["tag_id"]
     # solved
-    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["solved"]["service_id"] == ticket_response["service_id"]
-    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["solved"]["topic_ticket_ids"]) == solved_num
-
+    assert len(response["solved"]["topic_ids"]) == solved_num == 0
     # unsolved
-    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
-    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
-    assert len(response["unsolved"]["topic_ticket_ids"]) == unsolved_num
-    assert (
-        ticket_response["ticket_id"] in response["unsolved"]["topic_ticket_ids"][0]["ticket_ids"][0]
-    )
-    assert response["unsolved"]["topic_ticket_ids"][0]["topic_id"] == ticket_response["topic_id"]
+    assert len(response["unsolved"]["topic_ids"]) == unsolved_num
+    assert response["unsolved"]["topic_ids"][0] == ticket_response["topic_id"]
 
 
 @pytest.mark.parametrize(
-    "threat_impact, topic_status, solved_threat_impact_count, unsolved_threat_impact_count",
+    "threat_impact, topic_status1, topic_status2, expected_solved_count, expected_unsolved_count",
     [
         (
             1,
             models.TopicStatusType.completed,
-            {"1": 1, "2": 0, "3": 0, "4": 0},
+            models.TopicStatusType.completed,
+            {"1": 2, "2": 0, "3": 0, "4": 0},
             {"1": 0, "2": 0, "3": 0, "4": 0},
         ),
         (
             2,
             models.TopicStatusType.completed,
-            {"1": 0, "2": 1, "3": 0, "4": 0},
-            {"1": 0, "2": 0, "3": 0, "4": 0},
-        ),
-        (
-            3,
-            models.TopicStatusType.completed,
-            {"1": 0, "2": 0, "3": 1, "4": 0},
-            {"1": 0, "2": 0, "3": 0, "4": 0},
-        ),
-        (
-            4,
-            models.TopicStatusType.completed,
-            {"1": 0, "2": 0, "3": 0, "4": 1},
-            {"1": 0, "2": 0, "3": 0, "4": 0},
-        ),
-        (
-            1,
-            models.TopicStatusType.acknowledged,
-            {"1": 0, "2": 0, "3": 0, "4": 0},
-            {"1": 1, "2": 0, "3": 0, "4": 0},
-        ),
-        (
-            2,
             models.TopicStatusType.acknowledged,
             {"1": 0, "2": 0, "3": 0, "4": 0},
             {"1": 0, "2": 1, "3": 0, "4": 0},
@@ -184,19 +150,26 @@ def test_it_should_return_unsolved_number_based_on_ticket_status(
         (
             3,
             models.TopicStatusType.acknowledged,
+            models.TopicStatusType.completed,
             {"1": 0, "2": 0, "3": 0, "4": 0},
             {"1": 0, "2": 0, "3": 1, "4": 0},
         ),
         (
             4,
             models.TopicStatusType.acknowledged,
+            models.TopicStatusType.acknowledged,
             {"1": 0, "2": 0, "3": 0, "4": 0},
-            {"1": 0, "2": 0, "3": 0, "4": 1},
+            {"1": 0, "2": 0, "3": 0, "4": 2},
         ),
     ],
 )
 def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
-    testdb, threat_impact, topic_status, solved_threat_impact_count, unsolved_threat_impact_count
+    testdb,
+    threat_impact,
+    topic_status1,
+    topic_status2,
+    expected_solved_count,
+    expected_unsolved_count,
 ):
     topic = {
         **TOPIC1,
@@ -206,7 +179,7 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic)
 
     json_data = {
-        "topic_status": topic_status,
+        "topic_status": topic_status1,
         "note": "string",
         "assignees": [],
         "scheduled_at": str(datetime.now()),
@@ -220,28 +193,35 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
         json_data,
     )
 
+    dependencys = testdb.scalars(
+        select(models.Dependency).where(
+            models.Dependency.service_id == str(ticket_response["service_id"]),
+            models.Dependency.tag_id == str(ticket_response["tag_id"]),
+        )
+    ).all()
+    if len(dependencys) == 2:
+        dependencys[1].threats[0].ticket.current_ticket_status.topic_status = topic_status2
+        testdb.flush()
+
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 200
     response = response.json()
 
+    # common
+    assert response["pteam_id"] == ticket_response["pteam_id"]
+    assert response["service_id"] == ticket_response["service_id"]
+    assert response["tag_id"] == ticket_response["tag_id"]
     # solved
-    assert response["solved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["solved"]["service_id"] == ticket_response["service_id"]
-    assert response["solved"]["tag_id"] == ticket_response["tag_id"]
-    assert response["solved"]["threat_impact_count"] == solved_threat_impact_count
-
+    assert response["solved"]["threat_impact_count"] == expected_solved_count
     # unsolved
-    assert response["unsolved"]["pteam_id"] == ticket_response["pteam_id"]
-    assert response["unsolved"]["service_id"] == ticket_response["service_id"]
-    assert response["unsolved"]["tag_id"] == ticket_response["tag_id"]
-    assert response["unsolved"]["threat_impact_count"] == unsolved_threat_impact_count
+    assert response["unsolved"]["threat_impact_count"] == expected_unsolved_count
 
 
 @pytest.mark.parametrize(
-    "_topic1, _topic2, _topic3, _topic4, sorted_titles",
+    "_topic1, _topic2, _topic3, _topic4, titles_sorted_by_threat_impact",
     [
         (
             {"threat_impact": 1, "title": "topic one"},
@@ -281,7 +261,7 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     ],
 )
 def test_it_shoud_return_solved_sorted_title_based_on_threat_impact(
-    testdb, _topic1, _topic2, _topic3, _topic4, sorted_titles
+    testdb, _topic1, _topic2, _topic3, _topic4, titles_sorted_by_threat_impact
 ):
     topic1 = {
         **TOPIC1,
@@ -361,36 +341,29 @@ def test_it_shoud_return_solved_sorted_title_based_on_threat_impact(
     )
 
     response = client.get(
-        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 200
     response_json = response.json()
 
+    # common
+    assert response_json["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["service_id"] == ticket_response1["service_id"]
+    assert response_json["tag_id"] == ticket_response1["tag_id"]
     # solved
-    assert response_json["solved"]["pteam_id"] == ticket_response1["pteam_id"]
-    assert response_json["solved"]["service_id"] == ticket_response1["service_id"]
-    assert response_json["solved"]["tag_id"] == ticket_response1["tag_id"]
     topic_title_list = []
-    for topic_ticket_id in response_json["solved"]["topic_ticket_ids"]:
-        response_topic = client.get(
-            f"/topics/{topic_ticket_id['topic_id']}",
-            headers=headers(USER1),
-        )
+    for topic_id in response_json["solved"]["topic_ids"]:
+        response_topic = client.get(f"/topics/{topic_id}", headers=headers(USER1))
         topic = response_topic.json()
         topic_title_list.append(topic["title"])
-
-    assert topic_title_list == sorted_titles
-
+    assert topic_title_list == titles_sorted_by_threat_impact
     # unsolved
-    assert response_json["unsolved"]["pteam_id"] == ticket_response1["pteam_id"]
-    assert response_json["unsolved"]["service_id"] == ticket_response1["service_id"]
-    assert response_json["unsolved"]["tag_id"] == ticket_response1["tag_id"]
-    assert len(response_json["unsolved"]["topic_ticket_ids"]) == 0
+    assert len(response_json["unsolved"]["topic_ids"]) == 0
 
 
 @pytest.mark.parametrize(
-    "_topic1, _topic2, _topic3, _topic4, sorted_titles",
+    "_topic1, _topic2, _topic3, _topic4, titles_sorted_by_threat_impact",
     [
         (
             {"threat_impact": 1, "title": "topic one"},
@@ -430,7 +403,7 @@ def test_it_shoud_return_solved_sorted_title_based_on_threat_impact(
     ],
 )
 def test_it_shoud_return_unsolved_sorted_title_based_on_threat_impact(
-    testdb, _topic1, _topic2, _topic3, _topic4, sorted_titles
+    testdb, _topic1, _topic2, _topic3, _topic4, titles_sorted_by_threat_impact
 ):
     topic1 = {
         **TOPIC1,
@@ -510,32 +483,25 @@ def test_it_shoud_return_unsolved_sorted_title_based_on_threat_impact(
     )
 
     response = client.get(
-        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{ticket_response1['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 200
     response_json = response.json()
 
+    # common
+    assert response_json["pteam_id"] == ticket_response1["pteam_id"]
+    assert response_json["service_id"] == ticket_response1["service_id"]
+    assert response_json["tag_id"] == ticket_response1["tag_id"]
     # solved
-    assert response_json["solved"]["pteam_id"] == ticket_response1["pteam_id"]
-    assert response_json["solved"]["service_id"] == ticket_response1["service_id"]
-    assert response_json["solved"]["tag_id"] == ticket_response1["tag_id"]
-    assert len(response_json["solved"]["topic_ticket_ids"]) == 0
-
+    assert len(response_json["solved"]["topic_ids"]) == 0
     # unsolved
-    assert response_json["unsolved"]["pteam_id"] == ticket_response1["pteam_id"]
-    assert response_json["unsolved"]["service_id"] == ticket_response1["service_id"]
-    assert response_json["unsolved"]["tag_id"] == ticket_response1["tag_id"]
     topic_title_list = []
-    for topic_ticket_id in response_json["unsolved"]["topic_ticket_ids"]:
-        response_topic = client.get(
-            f"/topics/{topic_ticket_id['topic_id']}",
-            headers=headers(USER1),
-        )
+    for topic_id in response_json["unsolved"]["topic_ids"]:
+        response_topic = client.get(f"/topics/{topic_id}", headers=headers(USER1))
         topic = response_topic.json()
         topic_title_list.append(topic["title"])
-
-    assert topic_title_list == sorted_titles
+    assert topic_title_list == titles_sorted_by_threat_impact
 
 
 def test_sbom_uploaded_at_with_called_upload_tags_file():

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -204,7 +204,7 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     # set topic_status
     get_tickets_url = (
         f"/pteams/{ticket_response['pteam_id']}/services/"
-        f"{ticket_response['service_id']}/topics/{ticket_response['topic_id']}/tickets"
+        f"{ticket_response['service_id']}/topics/{ticket_response['topic_id']}/tags/{ticket_response['tag_id']}/tickets"
     )
     tickets = client.get(get_tickets_url, headers=headers(USER1)).json()
     _set_ticket_status(

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -171,6 +171,27 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
     expected_solved_count,
     expected_unsolved_count,
 ):
+    @staticmethod
+    def _set_ticket_status(
+        user: dict,
+        pteam_id: str,
+        service_id: str,
+        ticket_id: str,
+        topic_status: models.TopicStatusType,
+    ) -> None:
+        post_topicstatus_url = f"/pteams/{pteam_id}/services/{service_id}/ticketstatus/{ticket_id}"
+        status_request = {
+            "topic_status": topic_status,
+            "assignees": [],
+            "note": "",
+            "scheduled_at": "2345-06-07T08:09:10",
+        }
+        client.post(
+            post_topicstatus_url,
+            headers=headers(user),
+            json=status_request,
+        )
+
     # Given
     # create ticket
     topic = {
@@ -180,42 +201,25 @@ def test_it_shoud_return_threat_impact_count_num_based_on_tickte_status(
 
     ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, topic)
 
-    # set topic_status1
-    json_data = {
-        "topic_status": topic_status1,
-        "note": "string",
-        "assignees": [],
-        "scheduled_at": str(datetime.now()),
-    }
-    create_service_topicstatus(
-        USER1,
-        ticket_response["pteam_id"],
-        ticket_response["service_id"],
-        ticket_response["topic_id"],
-        ticket_response["tag_id"],
-        json_data,
-    )
-
-    # set topic_status2
+    # set topic_status
     get_tickets_url = (
         f"/pteams/{ticket_response['pteam_id']}/services/"
         f"{ticket_response['service_id']}/topics/{ticket_response['topic_id']}/tickets"
     )
     tickets = client.get(get_tickets_url, headers=headers(USER1)).json()
-    status_request = {
-        "topic_status": topic_status2,
-        "assignees": [],
-        "note": "",
-        "scheduled_at": "2345-06-07T08:09:10",
-    }
-    post_topicstatus_url = (
-        f"/pteams/{ticket_response['pteam_id']}/services/"
-        f"{ticket_response['service_id']}/ticketstatus/{tickets[1]['ticket_id']}"
+    _set_ticket_status(
+        USER1,
+        ticket_response["pteam_id"],
+        ticket_response["service_id"],
+        tickets[0]["ticket_id"],
+        topic_status1,
     )
-    client.post(
-        post_topicstatus_url,
-        headers=headers(USER1),
-        json=status_request,
+    _set_ticket_status(
+        USER1,
+        ticket_response["pteam_id"],
+        ticket_response["service_id"],
+        tickets[1]["ticket_id"],
+        topic_status2,
     )
 
     # When

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1954,7 +1954,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):
     # with wrong pteam_id
     pteam_id = str(uuid4())
     response = client.get(
-        f"/pteams/{pteam_id}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{pteam_id}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 404
@@ -1983,7 +1983,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_member(testdb):
     # with wrong pteam member
     create_user(USER2)
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER2),
     )
     assert response.status_code == 403
@@ -2012,7 +2012,7 @@ def test_service_tagged_ticket_ids_with_wrong_service_id(testdb):
     # with wrong service_id
     service_id = str(uuid4())
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{service_id}/tags/{ticket_response['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{service_id}/tags/{ticket_response['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 404
@@ -2041,7 +2041,7 @@ def test_service_tagged_ticket_ids_with_service_not_in_pteam(testdb):
 
     # with service not in pteam
     response = client.get(
-        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response2['service_id']}/tags/{ticket_response1['tag_id']}/ticket_ids",
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response2['service_id']}/tags/{ticket_response1['tag_id']}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 404
@@ -2070,7 +2070,7 @@ def test_service_tagged_tikcet_ids_with_wrong_tag_id(testdb):
     # with wrong tag_id
     tag_id = str(uuid4())
     response = client.get(
-        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{tag_id}/ticket_ids",
+        f"/pteams/{ticket_response['pteam_id']}/services/{ticket_response['service_id']}/tags/{tag_id}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 404
@@ -2100,7 +2100,7 @@ def test_service_tagged_ticket_ids_with_valid_but_not_service_tag(testdb):
     str1 = "a1:a2:a3"
     tag = create_tag(USER1, str1)
     response = client.get(
-        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{tag.tag_id}/ticket_ids",
+        f"/pteams/{ticket_response1['pteam_id']}/services/{ticket_response1['service_id']}/tags/{tag.tag_id}/topic_ids",
         headers=headers(USER1),
     )
     assert response.status_code == 404

--- a/web/src/components/PTeamEditAction.jsx
+++ b/web/src/components/PTeamEditAction.jsx
@@ -22,7 +22,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { getPTeamTopicActions, getPTeamServiceTaggedTicketIds } from "../slices/pteam";
+import { getPTeamTopicActions, getPTeamServiceTaggedTopicIds } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import { updateTopic, createAction, updateAction, deleteAction } from "../utils/api";
 import { actionTypes } from "../utils/const";
@@ -140,7 +140,7 @@ export function PTeamEditAction(props) {
     if (pteamId && presetTagId) {
       await Promise.all([
         dispatch(
-          getPTeamServiceTaggedTicketIds({
+          getPTeamServiceTaggedTopicIds({
             pteamId: pteamId,
             serviceId: serviceId,
             tagId: presetTagId,

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -17,13 +17,13 @@ export function PTeamTaggedTopics(props) {
   const taggedTopics = useSelector((state) => state.pteam.taggedTopics); // dispatched by parent
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
-  const targets = isSolved ? taggedTopics?.[tagId]?.solved : taggedTopics?.[tagId]?.unsolved;
+  const targets = taggedTopics?.[serviceId]?.[tagId]?.[isSolved ? "solved" : "unsolved"];
 
   if (targets === undefined || !allTags) {
     return <>Loading...</>;
   }
 
-  const targetTopicIds = targets.topic_ticket_ids.slice(perPage * (page - 1), perPage * page);
+  const targetTopicIds = targets.topic_ids.slice(perPage * (page - 1), perPage * page);
   const presetTagId = tagId;
   const presetParentTagId = allTags.find((tag) => tag.tag_id === tagId)?.parent_id;
 
@@ -32,7 +32,7 @@ export function PTeamTaggedTopics(props) {
       <Pagination
         shape="rounded"
         page={page}
-        count={Math.ceil(targets.topic_ticket_ids.length / perPage)}
+        count={Math.ceil(targets.topic_ids.length / perPage)}
         onChange={(event, value) => setPage(value)}
       />
       <Select
@@ -76,12 +76,12 @@ export function PTeamTaggedTopics(props) {
       </Box>
       {paginationRow}
       <List sx={{ p: 0 }}>
-        {targetTopicIds.map((ticketId_topicId) => (
-          <ListItem key={ticketId_topicId.topic_id} sx={{ minHeight: "250px", p: 0 }}>
+        {targetTopicIds.map((topicId) => (
+          <ListItem key={topicId} sx={{ minHeight: "250px", p: 0 }}>
             <TopicCard
-              key={ticketId_topicId.topic_id}
+              key={topicId}
               pteamId={pteamId}
-              topicId={ticketId_topicId.topic_id}
+              topicId={topicId}
               currentTagId={tagId}
               serviceId={serviceId}
               references={references}

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -20,7 +20,7 @@ import { useParams } from "react-router-dom";
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getTopicStatus,
-  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary,
 } from "../slices/pteam";
 import { createActionLog, createTopicStatus } from "../utils/api";
@@ -76,7 +76,7 @@ export function ReportCompletedActions(props) {
         getTopicStatus({ pteamId: pteamId, serviceId: serviceId, topicId: topicId, tagId: tagId }),
       );
       dispatch(
-        getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
+        getPTeamServiceTaggedTopicIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
       );
       dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
       enqueueSnackbar("Set topicstatus 'completed' succeeded", { variant: "success" });

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -29,7 +29,7 @@ import { useDispatch, useSelector } from "react-redux";
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getPTeamTopicActions,
-  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
@@ -175,7 +175,7 @@ export function TopicModal(props) {
     if (pteamId && presetTagId) {
       await Promise.all([
         dispatch(
-          getPTeamServiceTaggedTicketIds({
+          getPTeamServiceTaggedTopicIds({
             pteamId: pteamId,
             serviceId: serviceId,
             tagId: presetTagId,
@@ -335,7 +335,7 @@ export function TopicModal(props) {
   const handleDeleteTopic = () => {
     if (presetTagId) {
       dispatch(
-        getPTeamServiceTaggedTicketIds({
+        getPTeamServiceTaggedTopicIds({
           pteamId: pteamId,
           serviceId: serviceId,
           tagId: presetTagId,

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -28,7 +28,7 @@ import { useParams } from "react-router-dom";
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
   getTopicStatus,
-  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary,
 } from "../slices/pteam";
 import { createTopicStatus } from "../utils/api";
@@ -94,7 +94,7 @@ export function TopicStatusSelector(props) {
         }
         if (ttStatus.topic_status === "completed") {
           dispatch(
-            getPTeamServiceTaggedTicketIds({
+            getPTeamServiceTaggedTopicIds({
               pteamId: pteamId,
               serviceId: serviceId,
               tagId: tagId,

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -13,7 +13,7 @@ import {
   getDependencies,
   getPTeam,
   getPTeamMembers,
-  getPTeamServiceTaggedTicketIds,
+  getPTeamServiceTaggedTopicIds,
 } from "../slices/pteam";
 import { a11yProps } from "../utils/func.js";
 
@@ -38,7 +38,7 @@ export function Tag() {
 
   const dependencies = serviceDependencies[serviceId];
   const currentTagDependencies = dependencies?.filter((dependency) => dependency.tag_id === tagId);
-  const taggedTopics = taggedTopicsDict[tagId];
+  const taggedTopics = taggedTopicsDict?.[serviceId]?.[tagId];
 
   useEffect(() => {
     if (!user.user_id) return; // wait login completed
@@ -71,7 +71,7 @@ export function Tag() {
 
     if (taggedTopics === undefined) {
       dispatch(
-        getPTeamServiceTaggedTicketIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
+        getPTeamServiceTaggedTopicIds({ pteamId: pteamId, serviceId: serviceId, tagId: tagId }),
       );
       return;
     }
@@ -101,8 +101,8 @@ export function Tag() {
     return <>Now loading...</>;
   }
 
-  const numSolved = taggedTopics.solved?.topic_ticket_ids?.length ?? 0;
-  const numUnsolved = taggedTopics.unsolved?.topic_ticket_ids?.length ?? 0;
+  const numSolved = taggedTopics.solved?.topic_ids?.length ?? 0;
+  const numUnsolved = taggedTopics.unsolved?.topic_ids?.length ?? 0;
 
   const tagDict = allTags.find((tag) => tag.tag_id === tagId);
   const serviceDict = pteam.services.find((service) => service.service_id === serviceId);

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -6,7 +6,7 @@ import {
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
   getPTeamMembers as apiGetPTeamMembers,
-  getPTeamServiceTaggedTicketIds as apiGetPTeamServiceTaggedTicketIds,
+  getPTeamServiceTaggedTopicIds as apiGetPTeamServiceTaggedTopicIds,
   getPTeamTopicActions as apiGetPTeamTopicActions,
   getTopicStatus as apiGetTopicStatus,
   getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
@@ -64,10 +64,10 @@ export const getDependencies = createAsyncThunk(
     })),
 );
 
-export const getPTeamServiceTaggedTicketIds = createAsyncThunk(
-  "pteam/getPTeamServiceTaggedTicketIds",
+export const getPTeamServiceTaggedTopicIds = createAsyncThunk(
+  "pteam/getPTeamServiceTaggedTopicIds",
   async (data) =>
-    await apiGetPTeamServiceTaggedTicketIds(data.pteamId, data.serviceId, data.tagId).then(
+    await apiGetPTeamServiceTaggedTopicIds(data.pteamId, data.serviceId, data.tagId).then(
       (response) => ({
         pteamId: data.pteamId,
         serviceId: data.serviceId,
@@ -181,14 +181,13 @@ const pteamSlice = createSlice({
           [action.payload.serviceId]: action.payload.data,
         },
       }))
-      .addCase(getPTeamServiceTaggedTicketIds.fulfilled, (state, action) => ({
+      .addCase(getPTeamServiceTaggedTopicIds.fulfilled, (state, action) => ({
         ...state,
         taggedTopics: {
           ...state.taggedTopics,
-          [action.payload.tagId]: {
-            ...state.taggedTopics[action.payload.tagId],
-            solved: action.payload.data.solved,
-            unsolved: action.payload.data.unsolved,
+          [action.payload.serviceId]: {
+            ...state.taggedTopics[action.payload.serviceId],
+            [action.payload.tagId]: action.payload.data,
           },
         },
       }))

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -38,8 +38,8 @@ export const updatePTeamAuth = async (pteamId, data) =>
 
 export const getPTeamTopics = async (pteamId) => axios.get(`/pteams/${pteamId}/topics`);
 
-export const getPTeamServiceTaggedTicketIds = async (pteamId, serviceId, tagId) =>
-  axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/ticket_ids`);
+export const getPTeamServiceTaggedTopicIds = async (pteamId, serviceId, tagId) =>
+  axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/topic_ids`);
 
 export const createPTeamInvitation = async (pteamId, data) =>
   axios.post(`/pteams/${pteamId}/invitation`, data);


### PR DESCRIPTION
## PR の目的

- /pteams/{pteam_id}/services/{service_id}/tags/{tag_id}/ticket_ids
APIにおいて、Solved、Unsolved判定をチケット単位からトピック単位に変更する。

 - threat_impact_countの集計は、チケット単位とする。Unsolvedの場合、TopicStatusType.completed状態であるチケットは除いてカウントする。
 
 - APIのURL変更
<変更前>
get /pteams/{pteam_id}/services/{service_id}/tags/{tag_id}/ticket_ids
<変更後>
get /pteams/{pteam_id}/services/{service_id}/tags/{tag_id}/topic_ids

 - 上記APIのスキーマ変更
~~~
<変更前>
{
  "solved": {
    "pteam_id",
    "service_id",
    "tag_id",
    "threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
    "topic_ticket_ids": [
      {
        "topic_id",
        "ticket_ids": []
      }
    ]
  },
  "unsolved": { solvedと同様 }
}
~~~
<変更後>
~~~
{
  "pteam_id",
  "service_id",
  "tag_id",
  "solved": {
    "threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
    "topic_ids": []
  },
  "unsolved": { solvedと同様 }
}
~~~

## 経緯・意図・意思決定
1つのService、１つのTag(アーティファクト)、１つのTopicに紐づくTicketが2件あり、片方だけがcompletedの場合のアーティファクト詳細画面表示について、下記の通り期待した動作にならない。

【修正前】
同じTopicを[UNSOLVED TOPICS]、[SOLVED TOPICS]の両方に表示する。
[UNSOLVED TOPICS]にはcompletedでないTicketのみ、
[SOLVED TOPICS]にはcompletedであるTicketのみ、表示する。

【正しい挙動】
[UNSOLVED TOPICS]の1つのTopic内にTicketを2件表示する。
[SOLVED TOPICS]には表示しない。

## 参考文献
