### PR TITLE
Fix/api get tickets require tag

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -668,10 +668,11 @@ def get_tags_summary_by_pteam_id(db: Session, pteam_id: UUID | str) -> list[dict
     return summary
 
 
-def get_sorted_tickets_related_to_service_and_topic(
+def get_sorted_tickets_related_to_service_and_topic_and_tag(
     db: Session,
     service_id: UUID | str,
     topic_id: UUID | str,
+    tag_id: UUID | str,
 ) -> Sequence[models.Ticket]:
     select_stmt = (
         select(models.Ticket)
@@ -693,6 +694,7 @@ def get_sorted_tickets_related_to_service_and_topic(
             and_(
                 models.Dependency.dependency_id == models.Threat.dependency_id,
                 models.Dependency.service_id == str(service_id),
+                models.Dependency.tag_id == str(tag_id),
             ),
         )
         .order_by(models.Ticket.ssvc_deployer_priority, models.Dependency.target)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -457,18 +457,19 @@ def set_ticket_status(
 
 
 @router.get(
-    "/{pteam_id}/services/{service_id}/topics/{topic_id}/tickets",
+    "/{pteam_id}/services/{service_id}/topics/{topic_id}/tags/{tag_id}/tickets",
     response_model=list[schemas.TicketResponse],
 )
 def get_tickets_with_status_by_service_id_and_topic_id(
     pteam_id: UUID,
     service_id: UUID,
     topic_id: UUID,
+    tag_id: UUID,
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
-    Get tickets (with status) related to the service and topic.
+    Get tickets (with status) related to the service, topic and tag.
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM
@@ -480,8 +481,12 @@ def get_tickets_with_status_by_service_id_and_topic_id(
         raise NO_SUCH_SERVICE
     if not persistence.get_topic_by_id(db, topic_id):
         raise NO_SUCH_TOPIC
+    if not persistence.get_tag_by_id(db, tag_id):
+        raise NO_SUCH_TAG
 
-    tickets = command.get_sorted_tickets_related_to_service_and_topic(db, service_id, topic_id)
+    tickets = command.get_sorted_tickets_related_to_service_and_topic_and_tag(
+        db, service_id, topic_id, tag_id
+    )
 
     ret = [
         {

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2863,7 +2863,7 @@ class TestTicketStatus:
                 USER1, {**TOPIC1, "tags": [self.tag1.tag_name], "actions": [action1]}
             )
             tickets = self._get_tickets(
-                self.pteam1.pteam_id, self.service_id1, self.topic1.topic_id
+                self.pteam1.pteam_id, self.service_id1, self.topic1.topic_id, self.tag1.tag_id
             )
             self.ticket_id1 = tickets[0]["ticket_id"]
 
@@ -2909,8 +2909,11 @@ class TestTicketStatus:
                 },
             }
 
-        def _get_tickets(self, pteam_id: str, service_id: str, topic_id: str) -> dict:
-            url = f"/pteams/{pteam_id}/services/{service_id}/topics/{topic_id}/tickets"
+        def _get_tickets(self, pteam_id: str, service_id: str, topic_id: str, tag_id: str) -> dict:
+            url = (
+                f"/pteams/{pteam_id}/services/{service_id}"
+                f"/topics/{topic_id}/tags/{tag_id}/tickets"
+            )
             user1_access_token = self._get_access_token(USER1)
             _headers = {
                 "Authorization": f"Bearer {user1_access_token}",
@@ -3123,7 +3126,7 @@ class TestGetTickets:
     def test_returns_empty_if_no_tickets(self, not_actionable_topic1):
         url = (
             f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tickets"
+            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
         )
         user1_access_token = self._get_access_token(USER1)
         _headers = {
@@ -3171,7 +3174,7 @@ class TestGetTickets:
 
         url = (
             f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tickets"
+            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
         )
         user1_access_token = self._get_access_token(USER1)
         _headers = {
@@ -3229,7 +3232,7 @@ class TestGetTickets:
 
         url = (
             f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tickets"
+            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
         )
         user1_access_token = self._get_access_token(USER1)
         _headers = {


### PR DESCRIPTION
## PR の目的

- チケットリスト取得用 api のパラメータに tag_id を追加
  - UI が要するチケットリストはアーティファクトで絞り込む必要がある（UI 側では対処し難い）ため
- インテグレーションテストが足りてない（というより無い）ですが、UI との合わせ込みに問題が無いことを確認した後に別タスクで拡充予定