### PR TITLE
change create threat condition

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -429,40 +429,35 @@ def fix_threats_for_topic(db: Session, topic: models.Topic):
                 vulnerables_to_check |= vulnerables_dict.get(tag.parent_name, set())
 
             # detect how should be
-            need_threat, need_ticket = False, False
+            need_ticket = False
             if not vulnerables_to_check:
                 # topic is matched with this dependency on the tag, but have no actionable info
-                need_threat, need_ticket = True, False
+                need_ticket = False
             else:
                 for vulnerable in vulnerables_to_check:
                     try:
                         if vulnerable.detect_matched({dependency_version}):
                             # vulnerable and actionable
-                            need_threat, need_ticket = True, True
+                            need_ticket = True
                             break
                     except ValueError:
-                        need_threat = True
+                        pass
                         # continue to find out actionable or not
         else:
             # dependency version is not comparable
-            need_threat, need_ticket = True, False
+            need_ticket = False
 
-        # fix threat and ticket
-        if need_threat:
-            if current_threat:
-                threat = current_threat
-            else:
-                threat = models.Threat(
-                    dependency_id=dependency.dependency_id, topic_id=topic.topic_id
-                )
-                persistence.create_threat(db, threat)
-            if need_ticket:
-                if not threat.ticket:
-                    create_ticket_internal(db, threat, now=now)
-            elif threat.ticket:
-                persistence.delete_ticket(db, threat.ticket)
-        elif current_threat:
-            persistence.delete_threat(db, current_threat)
+        # fix ticket
+        if current_threat:
+            threat = current_threat
+        else:
+            threat = models.Threat(dependency_id=dependency.dependency_id, topic_id=topic.topic_id)
+            persistence.create_threat(db, threat)
+        if need_ticket:
+            if not threat.ticket:
+                create_ticket_internal(db, threat, now=now)
+        elif threat.ticket:
+            persistence.delete_ticket(db, threat.ticket)
 
         db.flush()
 
@@ -519,38 +514,35 @@ def fix_threats_for_dependency(db: Session, dependency: models.Dependency):
             vulnerables_to_check = vulnerables_dict.get(topic_id, set())
 
             # detect how should be
-            need_threat, need_ticket = False, False
+            need_ticket = False
             if not vulnerables_to_check:
                 # topic is matched with the dependency on the tag, but have no actionable info
-                need_threat, need_ticket = True, False
+                need_ticket = False
             else:
                 for vulnerable in vulnerables_to_check:
                     try:
                         if vulnerable.detect_matched({dependency_version}):
                             # vulnerable and actionable
-                            need_threat, need_ticket = True, True
+                            need_ticket = True
                             break
                     except ValueError:
-                        need_threat = True
+                        pass
                         # continue to find out actionable or not
         else:
             # dependency version is not comparable
-            need_threat, need_ticket = True, False
+            need_ticket = False
 
-        # fix threat and ticket
-        if need_threat:
-            if current_threat:
-                threat = current_threat
-            else:
-                threat = models.Threat(dependency_id=dependency.dependency_id, topic_id=topic_id)
-                persistence.create_threat(db, threat)
-            if need_ticket:
-                if not threat.ticket:
-                    create_ticket_internal(db, threat, now=now)
-            elif threat.ticket:
-                persistence.delete_ticket(db, threat.ticket)
-        elif current_threat:
-            persistence.delete_threat(db, current_threat)
+        # fix ticket
+        if current_threat:
+            threat = current_threat
+        else:
+            threat = models.Threat(dependency_id=dependency.dependency_id, topic_id=topic_id)
+            persistence.create_threat(db, threat)
+        if need_ticket:
+            if not threat.ticket:
+                create_ticket_internal(db, threat, now=now)
+        elif threat.ticket:
+            persistence.delete_ticket(db, threat.ticket)
 
 
 def count_threat_impact_from_summary(tags_summary: list[dict]):

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -966,7 +966,18 @@ class TestPostUploadSBOMFileCycloneDX:
                     {  # vulnerable_versions
                         "cryptography:pypi:pipenv": ["<30.0"],
                     },
-                    [],  # expected
+                    [  # expected
+                        {
+                            "tag_name": "cryptography:pypi:pipenv",
+                            "target": "threatconnectome/api/Pipfile.lock",
+                            "version": "39.0.2",
+                        },
+                        {
+                            "tag_name": "cryptography:pypi:pipenv",
+                            "target": "sample target1",  # scan root
+                            "version": "39.0.2",
+                        },
+                    ],
                 ),
                 # test case 2: os-pkgs
                 (
@@ -1035,7 +1046,18 @@ class TestPostUploadSBOMFileCycloneDX:
                     {  # vulnerable_versions
                         "libcrypt1:ubuntu-20.04:": ["<4.3.0"],
                     },
-                    [],  # expected
+                    [  # expected
+                        {
+                            "tag_name": "libcrypt1:ubuntu-20.04:",
+                            "target": "ubuntu",
+                            "version": "1:4.4.10-10ubuntu4",
+                        },
+                        {
+                            "tag_name": "libcrypt1:ubuntu-20.04:",
+                            "target": "sample target1",  # scan root
+                            "version": "1:4.4.10-10ubuntu4",
+                        },
+                    ],
                 ),
                 # test case 3: lang-pkgs with group
                 (

--- a/api/app/tests/integrations/test_threats.py
+++ b/api/app/tests/integrations/test_threats.py
@@ -23,8 +23,8 @@ class TestFixThreatsForTopic:
         "dep_version, vuln_versions, should_exist_threat, should_exist_ticket",
         [
             ("1.2", ["< 2.0"], True, True),  # vulnerable and actionable
-            ("1.2", ["< 1.0"], False, False),  # not vulnerable
-            ("1.2", ["< 1.0", "> 3.0"], False, False),  # not vulnerable
+            ("1.2", ["< 1.0"], True, False),  # not vulnerable
+            ("1.2", ["< 1.0", "> 3.0"], True, False),  # not vulnerable
             ("1.2", ["< 1.0", "> 3.0 || = 1.2"], True, True),  # vulnerable and actionable
             ("1.2", [], True, False),  # cannot detect vulnerable
             ("1.2", ["< uncomparable_range"], True, False),  # cannot detect vulnerable
@@ -172,8 +172,8 @@ class TestFixThreatsForDependency:
         "dep_version, vuln_versions, should_exist_threat, should_exist_ticket",
         [
             ("1.2", ["< 2.0"], True, True),  # vulnerable and actionable
-            ("1.2", ["< 1.0"], False, False),  # not vulnerable
-            ("1.2", ["< 1.0", "> 3.0"], False, False),  # not vulnerable
+            ("1.2", ["< 1.0"], True, False),  # not vulnerable
+            ("1.2", ["< 1.0", "> 3.0"], True, False),  # not vulnerable
             ("1.2", ["< 1.0", "> 3.0 || = 1.2"], True, True),  # vulnerable and actionable
             ("1.2", [], True, False),  # cannot detect vulnerable
             ("1.2", ["< uncomparable_range"], True, False),  # cannot detect vulnerable


### PR DESCRIPTION
## PR の目的
- Threatを生成、削除する条件に誤りがあったため、変更する。
  - TopicとDependencyをTagで紐づける方法が2点ある。
  (A) Topicの生成、更新時にTopicCreateRequest.tagsに指定する。
  (B) Topicが持つTopicActionのaction.ext.tagsに指定する。
  - 従来、(A)があっても(B)がなければThreatを生成しない、削除する、と判定していた。
  - 今回、(A)があればThreatを生成する、削除しない、に変更する。

## 経緯・意図・意思決定
 - (B)があればTicketを生成する、なければ生成しない、という判定は変更しない。
 - 既知問題として、delete Action時にTicketの削除判定を行っていない問題があるが、こちらは別PRで扱う。