### PR TITLE
Topic/changed specification of scheduled at in set ticket status

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -339,9 +339,9 @@ def set_ticket_status(
     Set status of the ticket.
     Current status should be inherited if requested value is None.
 
-    Use of scheduled_at in request body:
-    - Current status should be inherited when scheduled_at is None
-    - Set None in new status when scheduled_at is datetime.fromtimestamp(0)
+    To clear scheduled_at give datetime.fromtimestamp(0) to scheduled_at.
+
+    scheduled_at is necessary to make topic_status "scheduled".
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -338,6 +338,10 @@ def set_ticket_status(
     """
     Set status of the ticket.
     Current status should be inherited if requested value is None.
+
+    Use of scheduled_at in request body:
+    - Current status should be inherited when scheduled_at is None
+    - Set None in new status when scheduled_at is datetime.fromtimestamp(0)
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -422,9 +422,6 @@ def set_ticket_status(
         new_status.logging_ids = list(map(str, data.logging_ids))
     if data.note is not None:
         new_status.note = data.note
-    print("bbb")
-    print(type(data.scheduled_at))
-    print(data.scheduled_at)
     if data.scheduled_at is not None:
         if data.scheduled_at == datetime.fromtimestamp(0):
             new_status.scheduled_at = None

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3093,14 +3093,14 @@ class TestTicketStatus:
                 raise HTTPError(response)
 
             data = response.json()
-            assert data['scheduled_at'] is None
+            assert data["scheduled_at"] is None
 
             # verification of correct registration in DB
             get_response = self._get_ticket_status(
                 self.pteam1.pteam_id, self.service_id1, self.ticket_id1
             )
 
-            assert get_response['scheduled_at'] is None
+            assert get_response["scheduled_at"] is None
 
 
 class TestGetTickets:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3089,35 +3089,18 @@ class TestTicketStatus:
                 "accept": "application/json",
             }
             response = client.post(url, headers=_headers, json=status_request)
-            assert response.status_code == 200
+            if response.status_code != 200:
+                raise HTTPError(response)
 
             data = response.json()
-            # check not-none only because we do not have values to compare
-            for key in {"status_id", "created_at"}:
-                assert data[key] is not None
-                del data[key]
-
-            del status_request["scheduled_at"]
-            status_request["scheduled_at"] = None
-
-            expected_status = {
-                "ticket_id": str(self.ticket_id1),
-                "user_id": str(self.user1.user_id),
-                "action_logs": [],
-                **status_request,
-            }
-            assert data == expected_status
+            assert data['scheduled_at'] is None
 
             # verification of correct registration in DB
             get_response = self._get_ticket_status(
                 self.pteam1.pteam_id, self.service_id1, self.ticket_id1
             )
 
-            # check not-none only because we do not have values to compare
-            for key in {"status_id", "created_at"}:
-                assert get_response[key] is not None
-                del get_response[key]
-            assert get_response == expected_status
+            assert get_response['scheduled_at'] is None
 
 
 class TestGetTickets:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3045,6 +3045,80 @@ class TestTicketStatus:
             }
             assert data == expected_status
 
+        def test_it_should_return_400_when_topic_status_is_scheduled_and_there_is_no_schduled_at(
+            self, actionable_topic1
+        ):
+            status_request = {
+                "topic_status": models.TopicStatusType.scheduled.value,
+                "assignees": [str(self.user2.user_id)],
+                "note": "assign user2 and schedule at 2345/6/7",
+            }
+            url = (
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
+                f"/ticketstatus/{self.ticket_id1}"
+            )
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            response = client.post(url, headers=_headers, json=status_request)
+            assert response.status_code == 400
+
+            set_response = response.json()
+            assert set_response["detail"] == "If statsu is schduled, specify schduled_at"
+
+        def test_it_should_put_None_in_schduled_at_when_schduled_at_is_datetime_fromtimestamp_zero(
+            self, actionable_topic1
+        ):
+            status_request = {
+                "topic_status": models.TopicStatusType.scheduled.value,
+                "assignees": [str(self.user2.user_id)],
+                "note": "assign user2 and schedule at 2345/6/7",
+                "scheduled_at": str(datetime.fromtimestamp(0)),
+            }
+            url = (
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
+                f"/ticketstatus/{self.ticket_id1}"
+            )
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            response = client.post(url, headers=_headers, json=status_request)
+            assert response.status_code == 200
+
+            data = response.json()
+            # check not-none only because we do not have values to compare
+            for key in {"status_id", "created_at"}:
+                assert data[key] is not None
+                del data[key]
+
+            del status_request["scheduled_at"]
+            status_request["scheduled_at"] = None
+
+            expected_status = {
+                "ticket_id": str(self.ticket_id1),
+                "user_id": str(self.user1.user_id),
+                "action_logs": [],
+                **status_request,
+            }
+            assert data == expected_status
+
+            # verification of correct registration in DB
+            get_response = self._get_ticket_status(
+                self.pteam1.pteam_id, self.service_id1, self.ticket_id1
+            )
+
+            # check not-none only because we do not have values to compare
+            for key in {"status_id", "created_at"}:
+                assert get_response[key] is not None
+                del get_response[key]
+            assert get_response == expected_status
+
 
 class TestGetTickets:
 


### PR DESCRIPTION
## PR の目的
- pteams.pyにあるset_ticket_status APIのscheduled_atの仕様変更しました。

## 経緯・意図・意思決定
### APIについて
- requestで送られてくるtopic_statusがscheduledで、scheduled_atがNoneの時、エラーが出るようにしました
エラーステータスは400、エラーメッセージは「If statsu is schduled, specify schduled_at」
- requestで送られてくるscheduled_atがdatetime.fromtimestamp(0) だった場合、TicketStatusテーブルのscheduled_atにNoneを入れるようにしました。


### テストについて
2つ付け加えました
- test_it_should_return_400_when_topic_status_is_scheduled_and_there_is_no_schduled_at
requestで送られてくるtopic_statusがscheduledで、scheduled_atがNoneの時、エラーステータスは400、エラーメッセージは「If statsu is schduled, specify schduled_at」が返ってくるか検証しています
- test_it_should_put_None_in_schduled_at_when_schduled_at_is_datetime_fromtimestamp_zero
requestで送られてくるscheduled_atがdatetime.fromtimestamp(0) だった場合、responseで返ってくるscheduled_atがNoneになっているか検証。またTicketStatusテーブルのscheduled_atにNoneが格納されているか検証
