### PR TITLE
fix ticket when delete action

### DIFF
--- a/api/app/routers/actions.py
+++ b/api/app/routers/actions.py
@@ -142,7 +142,10 @@ def delete_action(
     if not (action := persistence.get_action_by_id(db, action_id)):
         raise NO_SUCH_ACTION
 
+    topic = action.topic
     persistence.delete_action(db, action)
+
+    fix_threats_for_topic(db, topic)
 
     db.commit()
 

--- a/api/app/tests/integrations/test_threats.py
+++ b/api/app/tests/integrations/test_threats.py
@@ -1,7 +1,9 @@
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from app import models
+from app.main import app
 from app.tests.medium.constants import (
     PTEAM1,
     TOPIC1,
@@ -12,9 +14,12 @@ from app.tests.medium.utils import (
     create_tag,
     create_topic,
     create_user,
+    headers,
     update_topic,
     upload_pteam_tags,
 )
+
+client = TestClient(app)
 
 
 class TestFixThreatsForTopic:
@@ -164,6 +169,77 @@ class TestFixThreatsForTopic:
                 assert db_threat1.ticket is None
         else:
             assert len(db_dependency1.threats) == 0
+
+    @pytest.mark.parametrize(
+        "vuln_versions_1, vuln_versions_2, delete_action_1, delete_action_2, should_exist_ticket",
+        [
+            (["< 1.5"], ["< 1.0"], False, True, True),
+            (["< 1.0"], ["< 1.5"], False, True, False),
+            (["< 1.0"], ["< 1.5"], True, True, False),
+        ],
+    )
+    def test_threat_ticket_creation_on_delete_action(
+        self,
+        testdb,
+        vuln_versions_1,
+        vuln_versions_2,
+        delete_action_1,
+        delete_action_2,
+        should_exist_ticket,
+    ):
+        dep_version = "1.2"
+
+        create_user(USER1)
+        tag1 = create_tag(USER1, "foobar:ubuntu-24.04:")
+        pteam1 = create_pteam(USER1, PTEAM1)
+        refs0 = {tag1.tag_name: [("test target", dep_version)]}  # dependency has tag1
+        service_name = "test service"
+        upload_pteam_tags(USER1, pteam1.pteam_id, service_name, refs0)
+
+        action1 = {
+            "action": "test action",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [tag1.tag_name],
+                "vulnerable_versions": {tag1.tag_name: vuln_versions_1},
+            },
+        }
+        action2 = {
+            "action": "test action2",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [tag1.tag_name],
+                "vulnerable_versions": {tag1.tag_name: vuln_versions_2},
+            },
+        }
+        # create topic1 with actionable tag1 -- having threat & ticket at this time
+        topic1 = create_topic(
+            USER1, {**TOPIC1, "tags": [tag1.tag_name], "actions": [action1, action2]}
+        )
+
+        if delete_action_1:
+            client.delete(
+                f"/actions/{topic1.actions[0].action_id}",
+                headers=headers(USER1),
+            )
+        if delete_action_2:
+            client.delete(
+                f"/actions/{topic1.actions[1].action_id}",
+                headers=headers(USER1),
+            )
+
+        db_dependency1 = testdb.scalars(
+            select(models.Dependency)
+            .join(models.Service)
+            .where(models.Service.pteam_id == str(pteam1.pteam_id))
+        ).one()
+
+        assert len(db_dependency1.threats) == 1
+        db_threat1 = db_dependency1.threats[0]
+        assert db_threat1.topic_id == str(topic1.topic_id)
+        assert (db_threat1.ticket is not None) == should_exist_ticket
 
 
 class TestFixThreatsForDependency:

--- a/api/app/tests/integrations/test_threats.py
+++ b/api/app/tests/integrations/test_threats.py
@@ -221,25 +221,14 @@ class TestFixThreatsForTopic:
 
         return (str(pteam1.pteam_id), str(topic1.topic_id))
 
-    @pytest.mark.parametrize(
-        "vuln_versions_1, vuln_versions_2, delete_action_1, delete_action_2, should_exist_ticket",
-        [
-            (["< 1.0"], ["< 1.5"], False, True, False),
-            (["< 1.0"], ["< 1.5"], True, True, False),
-        ],
-    )
+    @pytest.mark.parametrize("delete_action_1", [False, True])
     def test_ticket_should_be_deleted_when_delete_action_which_has_affected_version(
         self,
         testdb,
-        vuln_versions_1,
-        vuln_versions_2,
         delete_action_1,
-        delete_action_2,
-        should_exist_ticket,
     ):
-        dep_version = "1.2"
         pteam_id, topic_id = TestFixThreatsForTopic.create_ticket_and_delete_action(
-            dep_version, vuln_versions_1, vuln_versions_2, delete_action_1, delete_action_2
+            "1.2", ["< 1.0"], ["< 1.5"], delete_action_1, True
         )
 
         db_dependency1 = testdb.scalars(
@@ -251,27 +240,14 @@ class TestFixThreatsForTopic:
         assert len(db_dependency1.threats) == 1
         db_threat1 = db_dependency1.threats[0]
         assert db_threat1.topic_id == topic_id
-        assert (db_threat1.ticket is not None) == should_exist_ticket
+        assert db_threat1.ticket is None
 
-    @pytest.mark.parametrize(
-        "vuln_versions_1, vuln_versions_2, delete_action_1, delete_action_2, should_exist_ticket",
-        [
-            (["< 1.5"], ["< 1.0"], False, True, True),
-            (["< 1.5"], ["< 1.0"], False, True, True),
-        ],
-    )
     def test_ticket_should_not_be_deleted_when_delete_action_which_has_not_affected_version(
         self,
         testdb,
-        vuln_versions_1,
-        vuln_versions_2,
-        delete_action_1,
-        delete_action_2,
-        should_exist_ticket,
     ):
-        dep_version = "1.2"
         pteam_id, topic_id = TestFixThreatsForTopic.create_ticket_and_delete_action(
-            dep_version, vuln_versions_1, vuln_versions_2, delete_action_1, delete_action_2
+            "1.2", ["< 1.5"], ["< 1.0"], False, True
         )
 
         db_dependency1 = testdb.scalars(
@@ -283,7 +259,7 @@ class TestFixThreatsForTopic:
         assert len(db_dependency1.threats) == 1
         db_threat1 = db_dependency1.threats[0]
         assert db_threat1.topic_id == topic_id
-        assert (db_threat1.ticket is not None) == should_exist_ticket
+        assert db_threat1.ticket is not None
 
 
 class TestFixThreatsForDependency:


### PR DESCRIPTION
## PR の目的
- delete /actions/{action_id}  APIで fix_threats_for_topic() を呼ぶべきだが、呼んでいなかったため修正する。
<br>

## 経緯・意図・意思決定
- actionを削除した際に、実行可能なactionが無くなったTicketが消えるべきだが、この実装漏れのため、消えていなかった。
- 下記PRの直後に本修正後の動作確認で、一度に複数件のActionが削除される操作を行ったところ、エラーが発生した。
原因はfix_threats_for_topic()においてThreatを検索し、なければ生成する処理が2件並列で実行されたため、検索と生成の間に別スレットの生成が挟まって重複エラーとなった。
この問題は別途対策検討するが、通常はAction削除でThreatを生成することはなく、下記PRの直後のため発生した問題であるため、本PRに問題はないと判断した。
https://github.com/nttcom/threatconnectome/pull/269