### PR TITLE
Readmeの修正（Node v16+→20+）

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Teams registerd in demo environment as following:
   - `Ubuntu 20.04+ or MacOS 12.0.1+`
 - `Docker`
   - `Docker Compose`
-- `Node v16+`
+- `Node v20+`
   - `npm v7+`
 
 ### Development environment


### PR DESCRIPTION
## PR の目的

ReadmeのNode.jsのversionをv16+→v20+に変更

## 経緯・意図・意思決定

Node.js v16のサポートが切れているため、現在サポートされているversionへの変更を実施。

## 参考文献

- https://nodejs.org/en/about/previous-releases
- https://endoflife.date/nodejs