### PR TITLE
topic/support for cyclonedx ver1.6

### DIFF
--- a/api/app/sbom.py
+++ b/api/app/sbom.py
@@ -143,12 +143,13 @@ class TrivyCDXParser(SBOMParser):
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> list[Artifact]:
         if (
             sbom_info.spec_name != "CycloneDX"
-            or sbom_info.spec_version not in {"1.5"}
+            or sbom_info.spec_version not in {"1.5", "1.6"}
             or sbom_info.tool_name != "trivy"
         ):
             raise ValueError(f"Not supported: {sbom_info}")
         actual_parse_func = {
             "1.5": cls.parse_func_1_5,
+            "1.6": cls.parse_func_1_5,
         }.get(sbom_info.spec_version)
         if not actual_parse_func:
             raise ValueError("Internal error: actual_parse_func not found")


### PR DESCRIPTION
## PR の目的
- Cyclone DX 1.6に対応しました。

## 経緯・意図・意思決定
### 調査結果
- cyclonedx 1.5から1.6のバージョンアップについて特に大きな影響は今のところありませんでした。
参考箇所: https://github.com/CycloneDX/specification/releases
- trivy最新バージョン v0.54で作成したsbomファイル(cyclonedx 1.6)を作成し、threatconnectomeに登録しました。
   - 4種類sbomファイルを作成しました。
     - fs         対象：threatconnectomeをgit cloneしたもの
     - rootfs  対象： 現在の開発で使用しているGCP
     - image  対象： docker pull djangoで持ってきたdocker image
     - repo     対象： https://github.com/nttcom/threatconnectome にあるリポジトリ
   - 4種類のsbomファイルをそれぞれ問題なく登録することができました。
### sbom.pyの変更について
- 調査結果を踏まえて、1.6を許容するように変更しました。
- cyclonedxが1.6の時、1.5のパーサを使用しています。