### PR TITLE
make serviceIds optional

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -166,5 +166,5 @@ PTeamStatusCard.propTypes = {
     updated_at: PropTypes.string,
     status_count: PropTypes.object,
   }).isRequired,
-  serviceIds: PropTypes.array.isRequired,
+  serviceIds: PropTypes.array,
 };


### PR DESCRIPTION
## PR の目的

- PTeamStatusCard.serviceIds が isRequired になっているバグを修正
