### PR TITLE
Fix/UI undefined topic actions

### DIFF
--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -261,5 +261,8 @@ TopicStatusSelector.propTypes = {
   tagId: PropTypes.string.isRequired,
   ticketId: PropTypes.string.isRequired,
   currentStatus: PropTypes.object.isRequired,
-  topicActions: PropTypes.array.isRequired,
+  topicActions: PropTypes.array,
+};
+TopicStatusSelector.defaultProps = {
+  topicActions: [],
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -134,8 +134,9 @@ TopicTicketAccordion.propTypes = {
   ticket: PropTypes.object.isRequired,
   members: PropTypes.object.isRequired,
   defaultExpanded: PropTypes.bool,
-  topicActions: PropTypes.array.isRequired,
+  topicActions: PropTypes.array,
 };
 TopicTicketAccordion.defaultProps = {
   defaultExpanded: false,
+  topicActions: [],
 };


### PR DESCRIPTION
## PR の目的

- topicActions が isRequired になっているバグを修正
  - slice から取得するため dispatch 完了まで undefined になるため、optional にして empty array をデフォルト値に設定。