### PR TITLE
Fix/UI duplicated key

### DIFF
--- a/web/src/components/TagReferences.jsx
+++ b/web/src/components/TagReferences.jsx
@@ -47,7 +47,7 @@ export function TagReferences(props) {
                 {references.map(
                   (ref) =>
                     ref.service === serviceDict.service_name && (
-                      <TableRow key={ref.service + "-" + ref.target}>
+                      <TableRow key={ref.service + "-" + ref.target + "-" + ref.version}>
                         <TableCell component="th" scope="row">
                           {ref.target}
                         </TableCell>


### PR DESCRIPTION
## PR の目的

- TagReferences で key が重複するバグを修正
  - service + target だけでは重複しうるため、service + target + version でキーを生成