### PR TITLE
Fix/UI warning notched

### DIFF
--- a/web/src/components/AssigneesSelector.jsx
+++ b/web/src/components/AssigneesSelector.jsx
@@ -77,6 +77,7 @@ export function AssigneesSelector(props) {
         inputProps={{
           "area-label": "Without label",
         }}
+        notched="true" /* to avoid Warning: Received `true` for a non-boolean attribute `notched` */
       >
         <MenuItem disabled value="">
           <em>select assignees</em>


### PR DESCRIPTION
## PR の目的

- 不可解な warning の解消
  - Tag ページ（厳密には assignees のセレクタ）を表示すると、コンソールに下記のワーニングが出力される
    ```
    Warning: Received `true` for a non-boolean attribute `notched`.
    
    If you want to write it to the DOM, pass a string instead: notched="true" or notched={value.toString()}.
    div
    ./node_modules/@emotion/react/dist/emotion-element-c39617d8.browser.esm.js/withEmotionCache/<@http://localhost:3000/tc/static/js/bundle.js:31883:66
    InputBase@http://localhost:3000/tc/static/js/bundle.js:63040:83
    Input@http://localhost:3000/tc/static/js/bundle.js:62300:82
    Select@http://localhost:3000/tc/static/js/bundle.js:69962:82
    AssigneesSelector@http://localhost:3000/tc/static/js/bundle.js:8932:7
    ```
  - Select 内部の InputBase の属性らしい。未指定だと `true` が適用されて警告が出る。
    - ワーニングメッセージどおりに string の "true" を設定すると回避できるが、このケースでは Select の attribute として設定する模様（inputProps などではダメだった）