### PR TITLE
Topic/add error statement in set ticket status

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -525,10 +525,12 @@ def set_ticket_status(
         )
 
     now = datetime.now()
+    if data.scheduled_at:
+        data_scheduled_at = data.scheduled_at.replace(tzinfo=None)
     if (
         data.topic_status == models.TopicStatusType.scheduled
         and data.scheduled_at
-        and data.scheduled_at < now
+        and data_scheduled_at < now
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -594,7 +596,7 @@ def set_ticket_status(
     if data.note is not None:
         new_status.note = data.note
     if data.scheduled_at is not None:
-        if data.scheduled_at > now and data.topic_status == models.TopicStatusType.scheduled:
+        if data_scheduled_at > now and data.topic_status == models.TopicStatusType.scheduled:
             new_status.scheduled_at = data.scheduled_at
         elif data.scheduled_at == datetime.fromtimestamp(0):
             new_status.scheduled_at = None

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -512,22 +512,7 @@ def set_ticket_status(
     if data.topic_status == models.TopicStatusType.scheduled and data.scheduled_at is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="If statsu is schduled, specify schduled_at",
-        )
-
-    if _current := ticket.current_ticket_status.ticket_status:
-        prev_topic_status = _current.topic_status
-    else:
-        prev_topic_status = models.TopicStatusType.alerted
-
-    if (
-        prev_topic_status == models.TopicStatusType.scheduled
-        and data.topic_status is None
-        and data.scheduled_at is None
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="If statsu and scheduled_at is None, put values in status and scheduled_at",
+            detail="If status is schduled, specify schduled_at",
         )
 
     if (
@@ -537,20 +522,23 @@ def set_ticket_status(
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="If statsu is not schduled, do not specify schduled_at",
+            detail="If status is not schduled, do not specify schduled_at",
         )
 
     now = datetime.now()
     if data.scheduled_at:
         data_scheduled_at = data.scheduled_at.replace(tzinfo=None)
     if (
-        data.topic_status == models.TopicStatusType.scheduled
+        (
+            data.topic_status == models.TopicStatusType.scheduled
+            or ticket.current_ticket_status.status_id == models.TopicStatusType.scheduled
+        )
         and data.scheduled_at
         and data_scheduled_at < now
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="If statsu is schduled, schduled_at must be a future time",
+            detail="If status is schduled, schduled_at must be a future time",
         )
 
     for logging_id_ in data.logging_ids or []:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -509,11 +509,27 @@ def set_ticket_status(
     if data.topic_status == models.TopicStatusType.alerted:
         # user cannot set alerted
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wrong topic status")
-    if data.topic_status == models.TopicStatusType.scheduled and not data.scheduled_at:
+    if data.topic_status == models.TopicStatusType.scheduled and data.scheduled_at is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="If statsu is schduled, specify schduled_at",
         )
+
+    if _current := ticket.current_ticket_status.ticket_status:
+        prev_topic_status = _current.topic_status
+    else:
+        prev_topic_status = models.TopicStatusType.alerted
+
+    if (
+        prev_topic_status == models.TopicStatusType.scheduled
+        and data.topic_status is None
+        and data.scheduled_at is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="If statsu and scheduled_at is None, put values in status and scheduled_at",
+        )
+
     if (
         data.topic_status != models.TopicStatusType.scheduled
         and data.scheduled_at

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -43,15 +43,15 @@ client = TestClient(app)
 
 
 @pytest.mark.parametrize(
-    "topic_status, solved_num, unsolved_num",
+    "topic_status, scheduled_at, solved_num, unsolved_num",
     [
-        (models.TopicStatusType.acknowledged, 0, 1),
-        (models.TopicStatusType.scheduled, 0, 1),
-        (models.TopicStatusType.completed, 1, 0),
+        (models.TopicStatusType.acknowledged, None, 0, 1),
+        (models.TopicStatusType.scheduled, "2345-06-07T08:09:10", 0, 1),
+        (models.TopicStatusType.completed, None, 1, 0),
     ],
 )
 def test_it_should_return_solved_or_unsolved_number_based_on_ticket_status(
-    testdb, topic_status, solved_num, unsolved_num
+    testdb, topic_status, scheduled_at, solved_num, unsolved_num
 ):
     create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)
@@ -71,7 +71,7 @@ def test_it_should_return_solved_or_unsolved_number_based_on_ticket_status(
         "topic_status": topic_status,
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": scheduled_at,
     }
     set_ticket_status(
         USER1, pteam1.pteam_id, service1["service_id"], ticket1["ticket_id"], json_data
@@ -153,7 +153,7 @@ def test_it_should_return_threat_impact_count_num_based_on_tickte_status(
             "topic_status": topic_status,
             "assignees": [],
             "note": "",
-            "scheduled_at": "2345-06-07T08:09:10",
+            "scheduled_at": str(datetime.fromtimestamp(0)),
         }
         client.post(
             post_topicstatus_url,
@@ -317,7 +317,7 @@ def test_it_shoud_return_solved_sorted_title_based_on_threat_impact(
         "topic_status": models.TopicStatusType.completed,
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -477,7 +477,7 @@ def test_it_shoud_return_unsolved_sorted_title_based_on_threat_impact(
         "topic_status": models.TopicStatusType.acknowledged,
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -2950,7 +2950,7 @@ class TestTicketStatus:
             assert response.status_code == 400
 
             set_response = response.json()
-            assert set_response["detail"] == "If statsu is schduled, specify schduled_at"
+            assert set_response["detail"] == "If status is schduled, specify schduled_at"
 
         def test_it_should_return_400_when_topic_status_is_acknowledged_and_there_is_schduled_at(
             self, actionable_topic1
@@ -2975,7 +2975,7 @@ class TestTicketStatus:
             assert response.status_code == 400
 
             set_response = response.json()
-            assert set_response["detail"] == "If statsu is not schduled, do not specify schduled_at"
+            assert set_response["detail"] == "If status is not schduled, do not specify schduled_at"
 
         def test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past(
             self, actionable_topic1
@@ -3001,7 +3001,7 @@ class TestTicketStatus:
 
             set_response = response.json()
             assert (
-                set_response["detail"] == "If statsu is schduled, schduled_at must be a future time"
+                set_response["detail"] == "If status is schduled, schduled_at must be a future time"
             )
 
         def test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero(

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1940,7 +1940,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_id(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -1968,7 +1968,7 @@ def test_service_tagged_ticket_ids_with_wrong_pteam_member(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -1996,7 +1996,7 @@ def test_service_tagged_ticket_ids_with_wrong_service_id(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -2025,7 +2025,7 @@ def test_service_tagged_ticket_ids_with_service_not_in_pteam(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -2052,7 +2052,7 @@ def test_service_tagged_tikcet_ids_with_wrong_tag_id(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -2080,7 +2080,7 @@ def test_service_tagged_ticket_ids_with_valid_but_not_service_tag(testdb):
         "topic_status": "acknowledged",
         "note": "string",
         "assignees": [],
-        "scheduled_at": str(datetime.now()),
+        "scheduled_at": None,
     }
     set_ticket_status(
         USER1,
@@ -2952,11 +2952,63 @@ class TestTicketStatus:
             set_response = response.json()
             assert set_response["detail"] == "If statsu is schduled, specify schduled_at"
 
-        def test_it_should_put_None_in_schduled_at_when_schduled_at_is_datetime_fromtimestamp_zero(
+        def test_it_should_return_400_when_topic_status_is_acknowledged_and_there_is_schduled_at(
+            self, actionable_topic1
+        ):
+            status_request = {
+                "topic_status": models.TopicStatusType.completed.value,
+                "assignees": [str(self.user2.user_id)],
+                "note": "assign user2 and schedule at 2345/6/7",
+                "scheduled_at": "2345-06-07T08:09:10",
+            }
+            url = (
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
+                f"/ticketstatus/{self.ticket_id1}"
+            )
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            response = client.post(url, headers=_headers, json=status_request)
+            assert response.status_code == 400
+
+            set_response = response.json()
+            assert set_response["detail"] == "If statsu is not schduled, do not specify schduled_at"
+
+        def test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past(
             self, actionable_topic1
         ):
             status_request = {
                 "topic_status": models.TopicStatusType.scheduled.value,
+                "assignees": [str(self.user2.user_id)],
+                "note": "assign user2 and schedule at 2345/6/7",
+                "scheduled_at": str(datetime.fromtimestamp(0)),
+            }
+            url = (
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
+                f"/ticketstatus/{self.ticket_id1}"
+            )
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            response = client.post(url, headers=_headers, json=status_request)
+            assert response.status_code == 400
+
+            set_response = response.json()
+            assert (
+                set_response["detail"] == "If statsu is schduled, schduled_at must be a future time"
+            )
+
+        def test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero(
+            self, actionable_topic1
+        ):
+            status_request = {
+                "topic_status": models.TopicStatusType.completed.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": str(datetime.fromtimestamp(0)),


### PR DESCRIPTION
## PR の目的
- set_ticket_status APIにエラー出力を追加しました。

## 経緯・意図・意思決定
### APIについて
- 3つの要素を追加しました
- topic_status != scheduledのときにscheduled_atが指定されている場合エラーを出力するようにする(datetime.fromtimestamp(0)の時は除く)
- topic_status=scheduledの時に過去の時間が入っていた時エラーを出力する
- topic_status=scheduledの時に過去の時間が入らないようにif文を条件分岐させました
    - datetime.now()がnaiveでdata.scheduled_atがawareとなっており比較ができないため、data.scheduled_atをnaiveに直して比較しています

### テストについて
- テストを2つ追加、set_ticket_statusにエラー出力追加に伴うテスト文の修正を行いました
- topic_statusがacknowledgedでschduled_atに値がある時、正しくエラーが出力されているかを検証
- topic_statusがschduledでschduled_atの値が過去の時、正しくエラーが出力されているかを検証
- 他のテストでtopic_statusがacknowledgedやcompletedの時にstr(datetime.now())をschduled_atに入れている部分をNoneにしました