### PR TITLE
force AssigneesSelector rerender if assignees modified

### DIFF
--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -64,12 +64,13 @@ export const TopicTicketAccordion = (props) => {
           </Typography>
           <Box sx={{ maxWidth: 150 }}>
             <AssigneesSelector
+              key={ticketStatus.assignees.join("")}
               pteamId={pteamId}
               serviceId={serviceId}
               topicId={topicId}
               tagId={tagId}
               ticketId={ticket.ticket_id}
-              currentAssigneeIds={ticket.current_ticket_status.assignees}
+              currentAssigneeIds={ticketStatus.assignees}
               members={members}
             />
           </Box>


### PR DESCRIPTION
## PR の目的

- チケットステータスを alerted から acknowledged に変更した際、assignees が更新されないバグを修正
  - AssigneesSelector 内部では Select 関連ハンドラと密結合で調整し辛いため、呼び出し側で key に assignees を指定し、変更時に再レンダリングされるように調整
