### PR TITLE
make TopicCard scrollable

### DIFF
--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -205,7 +205,13 @@ export function TopicCard(props) {
       </Box>
       <Divider />
       <Box display="flex" sx={{ height: "350px" }}>
-        <Box flexGrow={1} display="flex" flexDirection="column" justifyContent="space-between">
+        <Box
+          flexGrow={1}
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-between"
+          sx={{ overflowY: "auto" }}
+        >
           <CardContent>
             {!isSolved ? (
               topicActions && (


### PR DESCRIPTION
## PR の目的
- アーティファクト詳細画面のトピックBox内で show detail を押しても詳細が表示されなかったため、スクロール可能にする。
