### PR TITLE
update axios

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material": "^5.15.10",
         "@mui/x-date-pickers": "^6.19.4",
         "@reduxjs/toolkit": "^2.2.0",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "date-fns": "^2.30.0",
         "firebase": "^10.11.0",
         "notistack": "^3.0.1",
@@ -6310,11 +6310,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -23633,11 +23633,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "@mui/material": "^5.15.10",
     "@mui/x-date-pickers": "^6.19.4",
     "@reduxjs/toolkit": "^2.2.0",
-    "axios": "^1.6.7",
+    "axios": "^1.7.4",
     "date-fns": "^2.30.0",
     "firebase": "^10.11.0",
     "notistack": "^3.0.1",


### PR DESCRIPTION
## PR の目的
- web で使ってる axios のバージョンを "^1.6.7" から "^1.7.4" へ変更する。

## 経緯・意図・意思決定
axios (1.6.7) に脆弱性が見つかり、Github Actions「Run Trivy scan to web」でエラーが出た。修正バージョンは1.7.4。