### PR TITLE
bugfix/action is deleted when topic is updated

### DIFF
--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -214,10 +214,8 @@ export function TopicModal(props) {
   const handleUpdateTopic = async () => {
     if (!validateActionTags()) return;
 
-    // console.log(presetActions);
     const presetActionIds = new Set(presetActions.map((a) => a.action_id));
 
-    console.log(actions);
     actions.forEach(async (a) => {
       const actionRequest = {
         ...a,

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -214,8 +214,10 @@ export function TopicModal(props) {
   const handleUpdateTopic = async () => {
     if (!validateActionTags()) return;
 
+    // console.log(presetActions);
     const presetActionIds = new Set(presetActions.map((a) => a.action_id));
 
+    console.log(actions);
     actions.forEach(async (a) => {
       const actionRequest = {
         ...a,
@@ -224,8 +226,8 @@ export function TopicModal(props) {
       if (a.action_id === null) {
         await createAction(actionRequest).catch((error) => operationError(error));
       } else if (presetActionIds.has(a.action_id)) {
-        await updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
         presetActionIds.delete(a.action_id);
+        await updateAction(a.action_id, actionRequest).catch((error) => operationError(error));
       }
     });
 


### PR DESCRIPTION
## PR の目的
- UpdateTopicをする際に、actionが削除される問題について解消しました

## 経緯・意図・意思決定
- UI上でtopicのtitle、Abstractやactionのrecommendなどを更新するときに、actionが意図せずに削除されてしまう。
### 原因
- await updateActionの下でpresetActionIds.delete(a.action_id)を行っているため、updateActionが終わった後にpresetActionIds.delete(a.action_id)を実行していました。
- 本来行いたい処理は以下の順番です
presetActionIds.delete(a.action_id)
↓
deleteAction
- 現状
awaitの下にある影響で処理の順番が入れ替わっている
deleteAction
↓
presetActionIds.delete(a.action_id)

### 解決策
- await updateActionより上でpresetActionIds.delete(a.action_id)を行うように修正しました。
