### PR TITLE
アコーディオンのタイトルが改行されない問題の修正

### DIFF
--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -54,7 +54,7 @@ export const TopicTicketAccordion = (props) => {
           <Box sx={{ mr: 1 }}>
             <ThreatImpactStatusChip threatImpactName={threatImpactName} />
           </Box>
-          <Box>{target}</Box>
+          <Box sx={{ wordBreak: "break-all" }}>{target}</Box>
         </Box>
       </AccordionSummary>
       <AccordionDetails>


### PR DESCRIPTION
## PR の目的

一部のチケットでアコーディオンのタイトルが改行されない問題を修正

## 経緯・意図・意思決定

`wordBreak: "break-all"`のプロパティを追加することで長いチケットのタイトルも改行されるように変更
