### PR TITLE
set flex:1 to CardContent

### DIFF
--- a/web/src/components/PTeamServicesListModal.jsx
+++ b/web/src/components/PTeamServicesListModal.jsx
@@ -151,7 +151,7 @@ export function PTeamServicesListModal(props) {
               }}
             >
               <CardMedia image={thumbnails[service.service_id]} sx={{ aspectRatio: "4 / 3" }} />
-              <CardContent>
+              <CardContent sx={{ flex: 1 }}>
                 <CardHeader title={service.service_name} sx={{ px: 0 }}></CardHeader>
                 <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-all" }}>
                   {service.description}


### PR DESCRIPTION
## PR の目的

- サービスリスト選択モーダルで Description 存在時（長文時？）に画像のアスペクト比が崩れる（おそらくFirefox, Safari のみ）不具合を修正