### PR TITLE
Highlight artifacts with threats above the Alert threshold

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -126,7 +126,7 @@ export function PTeamStatusCard(props) {
       setAlertImpact(pteam.alert_threat_impact);
     }
   }, [pteam]);
-  console.log(alertImpact);
+
   return (
     <TableRow
       onClick={onHandleClick}

--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -135,12 +135,11 @@ export function PTeamStatusCard(props) {
         borderBottom: "2px",
         // Change the background color and border based on the Alert Threshold value set by the team.
         ...(threatImpactNum <= alertImpact && {
-          boxShadow: `inset 0 0 0 4px ${amber[100]}`,
+          boxShadow: `inset 0 0 0 2px ${amber[100]}`,
           backgroundColor: yellow[50],
         }),
         cursor: "pointer",
-        "&:last-child td": { border: 0 },
-        "&:last-child th": { border: 0 },
+        "&:last-child td, &:last-child th": { border: 0 },
         "&:hover": { bgcolor: grey[100] },
       }}
     >

--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -1,8 +1,8 @@
 import { Box, Chip, Stack, TableCell, TableRow, Tooltip, Typography } from "@mui/material";
-import { grey } from "@mui/material/colors";
+import { grey, yellow, amber } from "@mui/material/colors";
 import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 
 import { threatImpactNames, topicStatusProps } from "../utils/const";
@@ -111,6 +111,8 @@ StatusRatioGraph.propTypes = {
 
 export function PTeamStatusCard(props) {
   const { onHandleClick, tag, serviceIds } = props;
+  const [alertImpact, setAlertImpact] = useState(1);
+
   const pteam = useSelector((state) => state.pteam.pteam);
 
   const threatImpactNum = tag.threat_impact ?? 4;
@@ -119,12 +121,26 @@ export function PTeamStatusCard(props) {
       ? "safe" // solved all and at least 1 tickets
       : threatImpactNames[threatImpactNum];
 
+  useEffect(() => {
+    if (pteam) {
+      setAlertImpact(pteam.alert_threat_impact);
+    }
+  }, [pteam]);
+  console.log(alertImpact);
   return (
     <TableRow
       onClick={onHandleClick}
       sx={{
+        border: "2px",
+        borderBottom: "2px",
+        // Change the background color and border based on the Alert Threshold value set by the team.
+        ...(threatImpactNum <= alertImpact && {
+          boxShadow: `inset 0 0 0 4px ${amber[100]}`,
+          backgroundColor: yellow[50],
+        }),
         cursor: "pointer",
-        "&:last-child td, &:last-child th": { border: 0 },
+        "&:last-child td": { border: 0 },
+        "&:last-child th": { border: 0 },
         "&:hover": { bgcolor: grey[100] },
       }}
     >


### PR DESCRIPTION
## PR の目的
- Alert threshold以上の脅威を持つアーティファクトを強調表示する
   - 背景色（yellow[50]）の変更と枠（amber[100]）の追加

## 経緯・意図・意思決定
- ユーザー側から見てAlert threshold以上の脅威を持つアーティファクトの視認性を高めるため

## 参考文献
https://mui.com/material-ui/customization/color/
https://mui.com/material-ui/customization/color/