### PR TITLE
Add logic to prevent highlighting when threshold is None.

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -134,10 +134,11 @@ export function PTeamStatusCard(props) {
         border: "2px",
         borderBottom: "2px",
         // Change the background color and border based on the Alert Threshold value set by the team.
-        ...(threatImpactNum <= alertImpact && {
-          boxShadow: `inset 0 0 0 2px ${amber[100]}`,
-          backgroundColor: yellow[50],
-        }),
+        ...(alertImpact !== 4 &&
+          threatImpactNum <= alertImpact && {
+            boxShadow: `inset 0 0 0 2px ${amber[100]}`,
+            backgroundColor: yellow[50],
+          }),
         cursor: "pointer",
         "&:last-child td, &:last-child th": { border: 0 },
         "&:hover": { bgcolor: grey[100] },


### PR DESCRIPTION
## PR の目的
- threshhold が Noneの場合、強調表示機能を無効化
- threshhold が None以外の場合、強調表示機能を有効化

## 経緯・意図・意思決定
- thresholdがNoneの場合、全てのアーティファクトが強調表示されてしまうため、強調表示の意味がなくなるため

## 参考文献
- https://mui.com/system/shadows/
- https://mui.com/material-ui/customization/color/