### PR TITLE
topic API applies model changes

### DIFF
--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -317,7 +317,6 @@ def create_topic(
         content_fingerprint=calculate_topic_content_fingerprint(
             fixed_title, fixed_abstract, data.threat_impact, data.tags
         ),
-        safety_impact=data.safety_impact,
         exploitation=data.exploitation,
         automatable=data.automatable,
     )
@@ -390,8 +389,6 @@ def update_topic(
         topic.abstract = new_abstract
     if data.threat_impact is not None:
         topic.threat_impact = data.threat_impact
-    if data.safety_impact is not None:
-        topic.safety_impact = data.safety_impact
     if data.exploitation is not None:
         topic.exploitation = data.exploitation
     if data.automatable is not None:

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -8,9 +8,9 @@ from app.constants import DEFAULT_ALERT_THREAT_IMPACT
 from app.models import (
     ActionType,
     ATeamAuthEnum,
+    AutomatableEnum,
     ExploitationEnum,
     PTeamAuthEnum,
-    SafetyImpactEnum,
     SSVCDeployerPriorityEnum,
     TopicStatusType,
 )
@@ -173,9 +173,8 @@ class Topic(TopicEntry):
     threat_impact: int
     created_by: UUID
     created_at: datetime
-    safety_impact: SafetyImpactEnum | None
     exploitation: ExploitationEnum | None
-    automatable: bool | None
+    automatable: AutomatableEnum | None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 
@@ -230,9 +229,8 @@ class TopicCreateRequest(ORMModel):
     tags: list[str] = []
     misp_tags: list[str] = []
     actions: list[ActionCreateRequest] = []
-    safety_impact: SafetyImpactEnum | None = None
     exploitation: ExploitationEnum | None = None
-    automatable: bool | None = None
+    automatable: AutomatableEnum | None = None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 
@@ -243,9 +241,8 @@ class TopicUpdateRequest(ORMModel):
     threat_impact: int | None = None
     tags: list[str] | None = None
     misp_tags: list[str] | None = None
-    safety_impact: SafetyImpactEnum | None = None
     exploitation: ExploitationEnum | None = None
-    automatable: bool | None = None
+    automatable: AutomatableEnum | None = None
 
     _threat_impact_range = field_validator("threat_impact", mode="before")(threat_impact_range)
 

--- a/api/app/ssvc.py
+++ b/api/app/ssvc.py
@@ -10,7 +10,6 @@ def calculate_ssvc_deployer_priority(
     exposure = service.exposure  # noqa: F841
     automatable = topic.automatable  # noqa: F841
     mission_impact = calculate_mission_impact(threat.dependency)  # noqa: F841
-    safety_impact = topic.safety_impact  # noqa: F841
     # TODO Calculation not implemented.
 
     if threat.topic.threat_impact == 1:

--- a/api/app/tests/medium/constants.py
+++ b/api/app/tests/medium/constants.py
@@ -92,9 +92,8 @@ TOPIC1 = {
     "tags": [TAG1],
     "misp_tags": [MISPTAG1],
     "actions": [],
-    "safety_impact": "catastrophic",
     "exploitation": "active",
-    "automatable": True,
+    "automatable": "yes",
 }
 TOPIC2 = {
     "topic_id": uuid4(),
@@ -104,9 +103,8 @@ TOPIC2 = {
     "tags": [TAG1],
     "misp_tags": [],
     "actions": [],
-    "safety_impact": "hazardous",
     "exploitation": "active",
-    "automatable": True,
+    "automatable": "yes",
 }
 TOPIC3 = {
     "topic_id": uuid4(),
@@ -116,9 +114,8 @@ TOPIC3 = {
     "tags": [TAG1, TAG3],
     "misp_tags": [],
     "actions": [],
-    "safety_impact": "catastrophic",
     "exploitation": "active",
-    "automatable": True,
+    "automatable": "yes",
 }
 TOPIC4 = {
     "topic_id": uuid4(),
@@ -128,9 +125,8 @@ TOPIC4 = {
     "tags": [TAG3],
     "misp_tags": [],
     "actions": [],
-    "safety_impact": "hazardous",
     "exploitation": "active",
-    "automatable": True,
+    "automatable": "yes",
 }
 ACTION1 = {
     "action": "action one",

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -64,9 +64,8 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(mocker) 
                     },
                 },
             ],
-            "safety_impact": "catastrophic",
             "exploitation": "active",
-            "automatable": True,
+            "automatable": "yes",
         }
 
     pteam0 = create_pteam(USER1, _gen_pteam_params(0))


### PR DESCRIPTION
## PR の目的
- PR#307でTopicのModel変更を行うため、Topic関連APIも追随する。
・safety_impactをTopicから削除
・Topic.automatableの型をboolからAutomatableEnumに変更
・ExploitationEnumのPOC/poc を PUBLIC_POC/public_poc に変更
https://github.com/nttcom/threatconnectome/pull/307

 - 影響を受けるAPI
   - post /topics/{topic_id}
   - get /pteams/{pteam_id}/topics   ※UIで使ってない
   - get /topics/{topic_id}
   - put /topics/{topic_id}
   - post /topics/{topic_id}
   - put /topics/{topic_id}
  
これらAPIをUIで使う際、safety_impact、automatable、exploitationを見ていないため、UIに影響なし。
