### PR TITLE
inherit expandService param at switching service

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -19,13 +19,12 @@ import { blobToDataURL } from "../utils/func";
 const noImageAvailableUrl = "images/no-image-available-720x480.png";
 
 export function PTeamServiceDetails(props) {
-  const { pteamId, service } = props;
+  const { pteamId, service, expandService, onSwitchExpandService } = props;
 
   const dispatch = useDispatch();
 
   const thumbnails = useSelector((state) => state.pteam.serviceThumbnails);
 
-  const [isOpen, setIsOpen] = useState(false);
   const [image, setImage] = useState(noImageAvailableUrl);
 
   const thumbnail = thumbnails[service.service_id];
@@ -57,10 +56,10 @@ export function PTeamServiceDetails(props) {
   return (
     <>
       <Collapse
-        in={isOpen}
+        in={expandService}
         collapsedSize={100}
         sx={
-          isOpen
+          expandService
             ? {}
             : {
                 position: "relative",
@@ -92,8 +91,8 @@ export function PTeamServiceDetails(props) {
           </CardContent>
         </Card>
       </Collapse>
-      <Button onClick={() => setIsOpen(!isOpen)} sx={{ display: "block", m: "auto" }}>
-        {isOpen ? "- Read less" : "+ Read more"}
+      <Button onClick={onSwitchExpandService} sx={{ display: "block", m: "auto" }}>
+        {expandService ? "- READ LESS" : "+ READ MORE"}
       </Button>
     </>
   );
@@ -102,4 +101,6 @@ export function PTeamServiceDetails(props) {
 PTeamServiceDetails.propTypes = {
   pteamId: PropTypes.string.isRequired,
   service: PropTypes.object.isRequired,
+  expandService: PropTypes.bool.isRequired,
+  onSwitchExpandService: PropTypes.func.isRequired,
 };

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -122,6 +122,7 @@ export function Status() {
 
   const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
+  const expandService = params.get("expandService") === "on" ? true : false;
 
   const user = useSelector((state) => state.user.user);
   const pteam = useSelector((state) => state.pteam.pteam);
@@ -143,6 +144,12 @@ export function Status() {
     tagName: "",
     serviceIds: [],
   });
+
+  const inheritExpandService = (_params) => {
+    if (expandService) _params.set("expandService", "on");
+    else _params.delete("expandService");
+    return _params;
+  };
 
   useEffect(() => {
     if (!user.user_id) return; // wait login completed
@@ -166,15 +173,17 @@ export function Status() {
     if (!serviceId) {
       if (pteam.services.length === 0) return; // nothing to do any more.
       // no service selected. force selecting one of services -- the first one
-      const newParams = new URLSearchParams();
+      let newParams = new URLSearchParams();
       newParams.set("pteamId", pteamId);
       newParams.set("serviceId", pteam.services[0].service_id);
+      newParams = inheritExpandService(newParams);
       navigate(location.pathname + "?" + newParams.toString());
       return;
     } else if (!pteam.services.find((service) => service.service_id === serviceId)) {
       alert("Invalid serviceId!");
-      const newParams = new URLSearchParams();
+      let newParams = new URLSearchParams();
       newParams.set("pteamId", pteamId);
+      newParams = inheritExpandService(newParams);
       navigate("/?" + newParams.toString());
       return;
     }
@@ -278,12 +287,13 @@ export function Status() {
   );
 
   const handleChangeService = (serviceId) => {
-    const newParams = new URLSearchParams();
+    let newParams = new URLSearchParams();
     newParams.set("pteamId", pteamId);
     newParams.set("serviceId", serviceId);
     if (searchWord) {
       newParams.set("word", searchWord);
     }
+    newParams = inheritExpandService(newParams);
     navigate(location.pathname + "?" + newParams.toString());
   };
 
@@ -333,6 +343,15 @@ export function Status() {
       params.set("allservices", "on");
       navigate(location.pathname + "?" + params.toString());
     }
+  };
+
+  const handleSwitchExpandService = () => {
+    if (expandService) {
+      params.delete("expandService");
+    } else {
+      params.set("expandService", "on");
+    }
+    navigate(location.pathname + "?" + params.toString());
   };
 
   const handleClick = (event) => {
@@ -432,7 +451,14 @@ export function Status() {
         />
       )}
       <CustomTabPanel value={isActiveUploadMode} index={0}>
-        {service && <PTeamServiceDetails pteamId={pteamId} service={service} />}
+        {service && (
+          <PTeamServiceDetails
+            pteamId={pteamId}
+            service={service}
+            expandService={expandService}
+            onSwitchExpandService={handleSwitchExpandService}
+          />
+        )}
         <Box display="flex" mt={2}>
           {filterRow}
           <Box flexGrow={1} />

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -122,7 +122,6 @@ export function Status() {
 
   const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
-  const expandService = params.get("expandService") === "on" ? true : false;
 
   const user = useSelector((state) => state.user.user);
   const pteam = useSelector((state) => state.pteam.pteam);
@@ -132,7 +131,8 @@ export function Status() {
   const serviceTagsSummary = serviceTagsSummaries[serviceId];
   const pteamTagsSummary = pteamTagsSummaries[pteamId];
 
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [expandService, setExpandService] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
   const searchMenuOpen = Boolean(anchorEl);
 
   const isActiveAllServicesMode = params.get("allservices") === "on" ? true : false;
@@ -144,12 +144,6 @@ export function Status() {
     tagName: "",
     serviceIds: [],
   });
-
-  const inheritExpandService = (_params) => {
-    if (expandService) _params.set("expandService", "on");
-    else _params.delete("expandService");
-    return _params;
-  };
 
   useEffect(() => {
     if (!user.user_id) return; // wait login completed
@@ -173,17 +167,15 @@ export function Status() {
     if (!serviceId) {
       if (pteam.services.length === 0) return; // nothing to do any more.
       // no service selected. force selecting one of services -- the first one
-      let newParams = new URLSearchParams();
+      const newParams = new URLSearchParams();
       newParams.set("pteamId", pteamId);
       newParams.set("serviceId", pteam.services[0].service_id);
-      newParams = inheritExpandService(newParams);
       navigate(location.pathname + "?" + newParams.toString());
       return;
     } else if (!pteam.services.find((service) => service.service_id === serviceId)) {
       alert("Invalid serviceId!");
-      let newParams = new URLSearchParams();
+      const newParams = new URLSearchParams();
       newParams.set("pteamId", pteamId);
-      newParams = inheritExpandService(newParams);
       navigate("/?" + newParams.toString());
       return;
     }
@@ -287,13 +279,12 @@ export function Status() {
   );
 
   const handleChangeService = (serviceId) => {
-    let newParams = new URLSearchParams();
+    const newParams = new URLSearchParams();
     newParams.set("pteamId", pteamId);
     newParams.set("serviceId", serviceId);
     if (searchWord) {
       newParams.set("word", searchWord);
     }
-    newParams = inheritExpandService(newParams);
     navigate(location.pathname + "?" + newParams.toString());
   };
 
@@ -345,14 +336,7 @@ export function Status() {
     }
   };
 
-  const handleSwitchExpandService = () => {
-    if (expandService) {
-      params.delete("expandService");
-    } else {
-      params.set("expandService", "on");
-    }
-    navigate(location.pathname + "?" + params.toString());
-  };
+  const handleSwitchExpandService = () => setExpandService(!expandService);
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);


### PR DESCRIPTION
## PR の目的

- Status ページでのサービス切替時に、サービス詳細表示の伸縮状態を継承するように改修
  - ~~伸縮状態を query parameter の expandService で管理し、navigate 時に継承することで実現~~
  - expandService は state での管理に切り替え、query param からは除外。

なお、本 PR ではチーム切替時の継承には対応していない（必要があれば別タスクで対応）。