### PR TITLE
fix wrong prop alignContent to aligncontent

### DIFF
--- a/web/src/components/PTeamServicesListModal.jsx
+++ b/web/src/components/PTeamServicesListModal.jsx
@@ -134,7 +134,6 @@ export function PTeamServicesListModal(props) {
               key={service.service_id}
               onClick={() => handleNavigateTag(service.service_id)}
               variant="outlined"
-              aligncontent="space-between"
               sx={{
                 margin: 1,
                 width: "100%",

--- a/web/src/components/PTeamServicesListModal.jsx
+++ b/web/src/components/PTeamServicesListModal.jsx
@@ -134,7 +134,7 @@ export function PTeamServicesListModal(props) {
               key={service.service_id}
               onClick={() => handleNavigateTag(service.service_id)}
               variant="outlined"
-              alignContent="space-between"
+              aligncontent="space-between"
               sx={{
                 margin: 1,
                 width: "100%",


### PR DESCRIPTION
## PR の目的

- warning に従い prop 名の誤りを修正
```
Warning: React does not recognize the `alignContent` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `aligncontent` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```