### PR TITLE
add divider between cardmedia and cardcontent

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -5,6 +5,7 @@ import {
   CardMedia,
   Chip,
   Collapse,
+  Divider,
   Stack,
   Typography,
 } from "@mui/material";
@@ -77,6 +78,7 @@ export function PTeamServiceDetails(props) {
       >
         <Card sx={{ display: "flex", height: 200 }}>
           <CardMedia image={image} sx={{ aspectRatio: "4 / 3" }} />
+          <Divider orientation="vertical" variant="middle" flexItem />
           <CardContent sx={{ flex: 1 }}>
             <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
               {keywords.map((keyword) => (


### PR DESCRIPTION
## PR の目的
- PTeamServiceDetailsのCardMediaとCardContentの間にDividerを追加

## 経緯・意図・意思決定
- Status画面で表示されるサムネイル画像の背景が白い場合、レイアウトが崩れて見えてしまうため
- POに相談の結果、Dividerを採用しvariantはmiddleに決定

## 参考文献
https://mui.com/material-ui/react-divider/