### PR TITLE
fix CardMedia.image not to be missing

### DIFF
--- a/web/src/components/PTeamServicesListModal.jsx
+++ b/web/src/components/PTeamServicesListModal.jsx
@@ -144,7 +144,10 @@ export function PTeamServicesListModal(props) {
                 height: 200,
               }}
             >
-              <CardMedia image={thumbnails[service.service_id]} sx={{ aspectRatio: "4 / 3" }} />
+              <CardMedia
+                image={thumbnails[service.service_id] ?? noImageAvailableUrl}
+                sx={{ aspectRatio: "4 / 3" }}
+              />
               <CardContent sx={{ flex: 1 }}>
                 <CardHeader title={service.service_name} sx={{ px: 0 }}></CardHeader>
                 <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-all" }}>


### PR DESCRIPTION
## PR の目的

- CardMedia.image が undefined なタイミングがあり警告が出ていたので修正
  - サムネイルダウンロード完了まで noImageAvailable が表示される、という仕様も動作していなかったはず。
```
Warning: Failed prop type: MUI: Either `children`, `image`, `src` or `component` prop must be specified.
CardMedia@http://localhost:3000/tc/static/js/bundle.js:55516:82
```