### PR TITLE
Topic/change alert notification settings to comply with ssvc priority

### DIFF
--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -18,7 +18,6 @@ export function PTeamGeneralSetting(props) {
   const [pteamName, setPTeamName] = useState("");
   const [contactInfo, setContactInfo] = useState("");
   const [slackUrl, setSlackUrl] = useState("");
-  const [alertImpact, setAlertImpact] = useState(1);
   const [flashsenseUrl, setFlashsenseUrl] = useState("");
   const [checkFlashsense, setCheckFlashsense] = useState(false);
   const [flashsenseMessage, setFlashsenseMessage] = useState();
@@ -46,7 +45,6 @@ export function PTeamGeneralSetting(props) {
       setPTeamName(pteam.pteam_name);
       setContactInfo(pteam.contact_info);
       setSlackUrl(pteam.alert_slack.webhook_url);
-      setAlertImpact(pteam.alert_threat_impact);
     }
     setCheckFlashsense(false);
     setFlashsenseMessage();
@@ -82,7 +80,6 @@ export function PTeamGeneralSetting(props) {
       pteam_name: pteamName,
       contact_info: contactInfo,
       alert_slack: { enable: true, webhook_url: slackUrl }, //todo change enable status
-      alert_threat_impact: alertImpact,
     };
     await updatePTeam(pteamId, pteamInfo)
       .then(() => {

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -31,7 +31,12 @@ import {
   checkSlack as postCheckSlack,
   checkMail as postCheckMail,
 } from "../utils/api";
-import { modalCommonButtonStyle, sortedSSVCPriorities, ssvcPriorityProps } from "../utils/const";
+import {
+  defaultSSVCPriority,
+  modalCommonButtonStyle,
+  sortedSSVCPriorities,
+  ssvcPriorityProps,
+} from "../utils/const";
 
 import { CheckButton } from "./CheckButton";
 
@@ -42,7 +47,7 @@ export function PTeamNotificationSetting(props) {
   const [slackEnable, setSlackEnable] = useState(false);
   const [mailAddress, setMailAddress] = useState("");
   const [mailEnable, setMailEnable] = useState(false);
-  const [alertThreshold, setAlertThreshold] = useState("");
+  const [alertThreshold, setAlertThreshold] = useState(defaultSSVCPriority);
   const [checkSlack, setCheckSlack] = useState(false);
   const [checkEmail, setCheckEmail] = useState(false);
   const [slackMessage, setSlackMessage] = useState();
@@ -182,9 +187,9 @@ export function PTeamNotificationSetting(props) {
           sx={{ marginRight: "10px", minWidth: "800px" }}
           size="small"
         >
-          {sortedSSVCPriorities.map((x) => (
-            <MenuItem key={x} value={x}>
-              {ssvcPriorityProps[x].displayName}
+          {sortedSSVCPriorities.map((ssvcPriority) => (
+            <MenuItem key={ssvcPriority} value={ssvcPriority}>
+              {ssvcPriorityProps[ssvcPriority].displayName}
             </MenuItem>
           ))}
         </Select>

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -31,7 +31,7 @@ import {
   checkSlack as postCheckSlack,
   checkMail as postCheckMail,
 } from "../utils/api";
-import { threatImpactNames, threatImpactProps, modalCommonButtonStyle } from "../utils/const";
+import { modalCommonButtonStyle, sortedSSVCPriorities, ssvcPriorityProps } from "../utils/const";
 
 import { CheckButton } from "./CheckButton";
 
@@ -42,7 +42,7 @@ export function PTeamNotificationSetting(props) {
   const [slackEnable, setSlackEnable] = useState(false);
   const [mailAddress, setMailAddress] = useState("");
   const [mailEnable, setMailEnable] = useState(false);
-  const [alertImpact, setAlertImpact] = useState(1);
+  const [alertThreshold, setAlertThreshold] = useState("");
   const [checkSlack, setCheckSlack] = useState(false);
   const [checkEmail, setCheckEmail] = useState(false);
   const [slackMessage, setSlackMessage] = useState();
@@ -61,7 +61,7 @@ export function PTeamNotificationSetting(props) {
       setSlackEnable(pteam.alert_slack.enable);
       setMailAddress(pteam.alert_mail.address);
       setMailEnable(pteam.alert_mail.enable);
-      setAlertImpact(pteam.alert_threat_impact);
+      setAlertThreshold(pteam.alert_ssvc_priority);
     }
     setEdittingSlackUrl(false);
     setCheckSlack(false);
@@ -97,7 +97,7 @@ export function PTeamNotificationSetting(props) {
     const pteamInfo = {
       alert_slack: { enable: slackEnable, webhook_url: slackUrl },
       alert_mail: { enable: mailEnable, address: mailAddress },
-      alert_threat_impact: alertImpact,
+      alert_ssvc_priority: alertThreshold,
     };
     await updatePTeam(pteamId, pteamInfo)
       .then(() => {
@@ -176,14 +176,15 @@ export function PTeamNotificationSetting(props) {
           Alert threshold
         </Typography>
         <Select
-          value={alertImpact}
-          onChange={(event) => setAlertImpact(Number(event.target.value))}
+          value={alertThreshold}
+          onChange={(event) => setAlertThreshold(String(event.target.value))}
+          // use String() to prevent undefined from setting alertimpact
           sx={{ marginRight: "10px", minWidth: "800px" }}
           size="small"
         >
-          {Object.keys(threatImpactNames).map((key) => (
-            <MenuItem key={key} value={key}>
-              {key}: {threatImpactProps[threatImpactNames[key]].chipLabel}
+          {sortedSSVCPriorities.map((x) => (
+            <MenuItem key={x} value={x}>
+              {ssvcPriorityProps[x].displayName}
             </MenuItem>
           ))}
         </Select>

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -32,7 +32,7 @@ import {
   checkMail as postCheckMail,
 } from "../utils/api";
 import {
-  defaultSSVCPriority,
+  defaultAlertThreshold,
   modalCommonButtonStyle,
   sortedSSVCPriorities,
   ssvcPriorityProps,
@@ -47,7 +47,7 @@ export function PTeamNotificationSetting(props) {
   const [slackEnable, setSlackEnable] = useState(false);
   const [mailAddress, setMailAddress] = useState("");
   const [mailEnable, setMailEnable] = useState(false);
-  const [alertThreshold, setAlertThreshold] = useState(defaultSSVCPriority);
+  const [alertThreshold, setAlertThreshold] = useState(defaultAlertThreshold);
   const [checkSlack, setCheckSlack] = useState(false);
   const [checkEmail, setCheckEmail] = useState(false);
   const [slackMessage, setSlackMessage] = useState();

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -197,6 +197,7 @@ export const ssvcPriorityProps = {
   safe: prop_safe,
   Safe: prop_safe,
 };
+export const defaultSSVCPriority = sortedSSVCPriorities[0];
 
 export const topicStatusProps = {
   alerted: {

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -197,7 +197,7 @@ export const ssvcPriorityProps = {
   safe: prop_safe,
   Safe: prop_safe,
 };
-export const defaultSSVCPriority = sortedSSVCPriorities[0];
+export const defaultAlertThreshold = sortedSSVCPriorities[0];
 
 export const topicStatusProps = {
   alerted: {


### PR DESCRIPTION
## PR の目的
-  Pteam settingsのNOTIFICATIONにおけるAlert thresholdのUI表示をSSVC priority準拠のものに変更する
   - 1.Immediate→Immediate
   - 2.Offcycle→Out-of-cycle
   - 3.Acceptable→Scheduled
   - 4.None→Defer
- const.jsにalertThresholdのデフォルト値を設定
- PteamGenaralSetting.jsx内のalertImpact、alert_threat_impactを削除

## 経緯・意図・意思決定 
- 本PRにてAlert thresholdのUI表示を対応
   - アラート通知の閾値の設定をSSVCに準拠する必要があるため
      - ticketの指標でssvcを使用するように変更したため
- 管理をしやすくするため、alertThresholdのデフォルト値を設定
- PteamGenaralSetting.jsx内にてalertImpact、alert_threat_impactを利用していなかったため、削除

## 参考文献
https://certcc.github.io/SSVC/howto/deployer_tree/