### PR TITLE
change calculate_human_impact to private function

### DIFF
--- a/api/app/ssvc/ssvc_calculator.py
+++ b/api/app/ssvc/ssvc_calculator.py
@@ -91,11 +91,11 @@ def calculate_ssvc_priority_by_threat(
         threat.dependency.dependency_mission_impact or service.service_mission_impact
     )
     safety_impact = service.safety_impact
-    human_impact = calculate_human_impact(safety_impact, mission_impact)
+    human_impact = _calculate_human_impact(safety_impact, mission_impact)
     return _calculate_ssvc_priority(exploitation, system_exposure, automatable, human_impact)
 
 
-def calculate_human_impact(
+def _calculate_human_impact(
     safety_impact: models.SafetyImpactEnum, mission_impact: models.MissionImpactEnum
 ) -> models.HumanImpactEnum | None:
     key = (

--- a/api/app/tests/small/test_ssvc_calculator.py
+++ b/api/app/tests/small/test_ssvc_calculator.py
@@ -95,7 +95,7 @@ def test_calculate_human_impact(
     mission_impact: models.MissionImpactEnum,
     expected_human_impact: models.HumanImpactEnum | None,
 ):
-    human_impact = ssvc_calculator.calculate_human_impact(safety_impact, mission_impact)
+    human_impact = ssvc_calculator._calculate_human_impact(safety_impact, mission_impact)
     assert human_impact == expected_human_impact
 
 


### PR DESCRIPTION
## PR の目的
- Human Impactを計算する関数を、publicからprivateに変更する。(実際にアクセス制限するわけではなく、privateを表す関数名に変更する)

## 経緯・意図・意思決定
Human Impactを表示する必要があると考えてpublicにしていたが、必要なくなったため変更した。