### PR TITLE
サービスステータス画面のSSVC対応UIのモック作成

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Card,
   CardContent,
@@ -15,6 +16,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { storeServiceThumbnail } from "../slices/pteam";
 import { getServiceThumbnail } from "../utils/api";
 import { blobToDataURL } from "../utils/func";
+
+import { PTeamStatusSSVCCards } from "./PTeamStatusSSVCCards";
 
 const noImageAvailableUrl = "images/no-image-available-720x480.png";
 
@@ -91,6 +94,9 @@ export function PTeamServiceDetails(props) {
             </Typography>
           </CardContent>
         </Card>
+        <Box sx={{ mt: 1 }}>
+          <PTeamStatusSSVCCards />
+        </Box>
       </Collapse>
       <Button onClick={() => setIsOpen(!isOpen)} sx={{ display: "block", m: "auto" }}>
         {isOpen ? "- Read less" : "+ Read more"}

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -1,0 +1,79 @@
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import {
+  Box,
+  Grid,
+  Paper,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import React from "react";
+
+export function PTeamStatusSSVCCards() {
+  const SSVCCardsList = [
+    {
+      title: "Highest SSVC Priority",
+      description: "Highest SSVC Priority description",
+      item: ["Immediate", "Out-of-Cycle", "Scheduled", "Defer"],
+    },
+    {
+      title: "System Exposure",
+      description: "System Exposure description",
+      item: ["Small", "Controlled", "Open"],
+    },
+    {
+      title: "Mission Impact",
+      description: "Mission Impact description",
+      item: ["Degraded", "MEF Support Crippled", "MEF Failure", "Mission Failure"],
+    },
+  ];
+
+  return (
+    <Grid container spacing={2}>
+      {SSVCCardsList.map((card) => (
+        <Grid key={card.title} item xs={4}>
+          <Paper
+            sx={{
+              textAlign: "center",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", my: 1 }}>
+              <Typography variant="h6" component="div" sx={{ pr: 0.5 }}>
+                {card.title}
+              </Typography>
+              <Tooltip title={card.description}>
+                <HelpOutlineOutlinedIcon color="action" fontSize="small" />
+              </Tooltip>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                height: "100%",
+                justifyContent: "center",
+                alignItems: "center",
+                mb: 1,
+              }}
+            >
+              <ToggleButtonGroup
+                color="primary"
+                size="small"
+                orientation="vertical"
+                value={card.item[0]}
+              >
+                {card.item.map((item) => (
+                  <ToggleButton key={item} value={item} disabled>
+                    {item}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+            </Box>
+          </Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}


### PR DESCRIPTION
## PR の目的

サービスステータス画面にSSVC関連の情報を表示するための改修

## 経緯・意図・意思決定

- サービス詳細カードの下に「Highest SSVC Priority」「System Exposure」「Mission Impact」の情報を表示するカードを追加

## 補足情報

- 現在、アクティブステータスは一番上の項目に固定
- `Tooltip`の`title`は仮表示のため、変更が必要
- `ToggleButton`の`color`は すべて`primary`に設定