### PR TITLE
change topic_ids API interface

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -1,6 +1,7 @@
 import json
 import unicodedata
 from datetime import datetime
+from functools import cmp_to_key
 from hashlib import md5
 from typing import Sequence
 from uuid import UUID
@@ -247,15 +248,28 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     return ticket.ssvc_deployer_priority <= pteam.alert_ssvc_priority
 
 
-def sum_threat_impact_count(topic_ids: list[str], topic_ids_dict: dict, count_key: str) -> dict:
-    sum_threat_impact_count = {"1": 0, "2": 0, "3": 0, "4": 0}
+def sum_ssvc_priority_count(topic_ids: list[str], topic_ids_dict: dict, count_key: str) -> dict:
+    immediate = models.SSVCDeployerPriorityEnum.IMMEDIATE.value
+    out_of_cycle = models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE.value
+    scheduled = models.SSVCDeployerPriorityEnum.SCHEDULED.value
+    defer = models.SSVCDeployerPriorityEnum.DEFER.value
+    sum_threat_impact_count = {immediate: 0, out_of_cycle: 0, scheduled: 0, defer: 0}
     for topic_id in topic_ids:
         current_count = topic_ids_dict[topic_id][count_key]
-        sum_threat_impact_count["1"] += current_count["1"]
-        sum_threat_impact_count["2"] += current_count["2"]
-        sum_threat_impact_count["3"] += current_count["3"]
-        sum_threat_impact_count["4"] += current_count["4"]
+        sum_threat_impact_count[immediate] += current_count[immediate]
+        sum_threat_impact_count[out_of_cycle] += current_count[out_of_cycle]
+        sum_threat_impact_count[scheduled] += current_count[scheduled]
+        sum_threat_impact_count[defer] += current_count[defer]
     return sum_threat_impact_count
+
+
+def _compare_ssvc_priority(arg1, arg2):
+    if arg1["highest_ssvc_priority"] == arg2["highest_ssvc_priority"]:
+        return 0
+    if arg1["highest_ssvc_priority"] < arg2["highest_ssvc_priority"]:
+        return -1
+    else:
+        return 1
 
 
 def get_topic_ids_summary_by_service_id_and_tag_id(
@@ -264,6 +278,10 @@ def get_topic_ids_summary_by_service_id_and_tag_id(
 ) -> dict:
     topic_ids_dict: dict = {}
     _completed = models.TopicStatusType.completed
+    immediate = models.SSVCDeployerPriorityEnum.IMMEDIATE.value
+    out_of_cycle = models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE.value
+    scheduled = models.SSVCDeployerPriorityEnum.SCHEDULED.value
+    defer = models.SSVCDeployerPriorityEnum.DEFER.value
 
     for dependency in service.dependencies:
         if dependency.tag_id != str(tag_id):
@@ -271,31 +289,38 @@ def get_topic_ids_summary_by_service_id_and_tag_id(
         for threat in dependency.threats:
             if not threat.ticket:
                 continue
+            ssvc_priority = threat.ticket.ssvc_deployer_priority
             _curent_ticket = threat.ticket.current_ticket_status
             if (tmp_topic_ids_dict := topic_ids_dict.get(threat.topic_id)) is None:
                 tmp_topic_ids_dict = {
                     "topic_id": threat.topic_id,
-                    "topic_threat_impact": threat.topic.threat_impact,
+                    "highest_ssvc_priority": ssvc_priority,
                     "topic_updated_at": threat.topic.updated_at,
                     "is_solved": True,
-                    "solved_threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
-                    "unsolved_threat_impact_count": {"1": 0, "2": 0, "3": 0, "4": 0},
+                    "solved_ssvc_priority_count": {
+                        immediate: 0,
+                        out_of_cycle: 0,
+                        scheduled: 0,
+                        defer: 0,
+                    },
+                    "unsolved_ssvc_priority_count": {
+                        immediate: 0,
+                        out_of_cycle: 0,
+                        scheduled: 0,
+                        defer: 0,
+                    },
                 }
                 topic_ids_dict[threat.topic_id] = tmp_topic_ids_dict
-            threat_imapct_str = str(_curent_ticket.threat_impact)
             if _curent_ticket.topic_status == _completed:
-                tmp_topic_ids_dict["solved_threat_impact_count"][threat_imapct_str] += 1
+                tmp_topic_ids_dict["solved_ssvc_priority_count"][ssvc_priority.value] += 1
             else:
-                tmp_topic_ids_dict["unsolved_threat_impact_count"][threat_imapct_str] += 1
+                tmp_topic_ids_dict["unsolved_ssvc_priority_count"][ssvc_priority.value] += 1
                 tmp_topic_ids_dict["is_solved"] = False
 
     # Sort topic_id according to threat_impact and updated_at
     topic_ids_sorted = sorted(
         topic_ids_dict.values(),
-        key=lambda x: (
-            x["topic_threat_impact"],
-            -(_dt.timestamp() if (_dt := x["topic_updated_at"]) else 0),
-        ),
+        key=cmp_to_key(_compare_ssvc_priority),
     )
     solved_topic_ids = list(
         map(lambda item: item["topic_id"], filter(lambda item: item["is_solved"], topic_ids_sorted))
@@ -310,14 +335,14 @@ def get_topic_ids_summary_by_service_id_and_tag_id(
     topic_ids_summary: dict[str, dict] = {
         "solved": {
             "topic_ids": solved_topic_ids,
-            "threat_impact_count": sum_threat_impact_count(
-                solved_topic_ids, topic_ids_dict, "solved_threat_impact_count"
+            "ssvc_priority_count": sum_ssvc_priority_count(
+                solved_topic_ids, topic_ids_dict, "solved_ssvc_priority_count"
             ),
         },
         "unsolved": {
             "topic_ids": unsolved_topic_ids,
-            "threat_impact_count": sum_threat_impact_count(
-                unsolved_topic_ids, topic_ids_dict, "unsolved_threat_impact_count"
+            "ssvc_priority_count": sum_ssvc_priority_count(
+                unsolved_topic_ids, topic_ids_dict, "unsolved_ssvc_priority_count"
             ),
         },
     }

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -641,7 +641,7 @@ class ATeamTopicCommentResponse(ORMModel):
 
 
 class ServiceTaggedTopics(ORMModel):
-    threat_impact_count: dict[str, int]
+    ssvc_priority_count: dict[str, int]
     topic_ids: list[UUID]
 
 

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -357,7 +357,7 @@ def test_it_shoud_return_solved_sorted_title_based_on_ssvc_priority(
             {"exploitation": "none", "automatable": "no", "title": "topic one"},
             {"exploitation": "none", "automatable": "no", "title": "topic two"},
             {"exploitation": "none", "automatable": "no", "title": "topic three"},
-            ["topic one", "topic two", "topic three"],
+            ["topic three", "topic two", "topic one"],
         ),
     ],
 )

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -230,7 +230,7 @@ def test_it_should_return_ssvc_priority_count_num_based_on_tickte_status(
             {"exploitation": "none", "automatable": "no", "title": "topic one"},
             {"exploitation": "none", "automatable": "no", "title": "topic two"},
             {"exploitation": "none", "automatable": "no", "title": "topic three"},
-            ["topic one", "topic two", "topic three"],
+            ["topic three", "topic two", "topic one"],
         ),
     ],
 )


### PR DESCRIPTION
## PR の目的
- アーティファクト詳細画面のthreat_impactをssvc_priorityに変更するためのAPI対応
  - 下記APIのレスポンスのthreat_impact_countをssvc_priority_countに変更する。
/{pteam_id}/services/{service_id}/tags/{tag_id}/topic_ids
  - トピック一覧のソートキーは、第一キーがssvc_priorityの最高値、第二キーがtopicのupdated_at

## 補足情報
ブランチ[topic/artifact-ssvc-priority]を、アーティファクト詳細画面のthreat_impactをssvc_priorityに変更するタスクにおける、API、UI共通ブランチとする。
本PRはこのブランチへマージするAPI修正であり、別途UI修正をこのブランチにマージ予定。
