### PR TITLE
fix to use ssvc priority instead of threat impact

### DIFF
--- a/web/src/components/SSVCPriorityStatusChip.jsx
+++ b/web/src/components/SSVCPriorityStatusChip.jsx
@@ -1,0 +1,42 @@
+import { Paper, Tooltip } from "@mui/material";
+import { styled } from "@mui/material/styles";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { ssvcPriorityProps } from "../utils/const";
+
+export function SSVCPriorityStatusChip(props) {
+  const { ssvcPriority } = props;
+  const ssvcPriorityProp = ssvcPriorityProps[ssvcPriority];
+
+  const Icon = ssvcPriorityProp.icon;
+  const StyledTooltip = styled((styledProps) => (
+    <Tooltip classes={{ popper: styledProps.className }} {...styledProps} />
+  ))`
+    & .MuiTooltip-tooltip {
+      background-color: ${ssvcPriorityProp.style.bgcolor};
+      color: ${ssvcPriorityProp.style.color};
+    }
+  `;
+
+  return (
+    <StyledTooltip title={ssvcPriorityProp.statusLabel}>
+      <Paper
+        variant="outlined"
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "4px",
+          ...ssvcPriorityProp.style,
+        }}
+      >
+        <Icon style={{ color: "white", fontSize: "20px" }} />
+      </Paper>
+    </StyledTooltip>
+  );
+}
+
+SSVCPriorityStatusChip.propTypes = {
+  ssvcPriority: PropTypes.string.isRequired,
+};

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -133,6 +133,71 @@ export const threatImpactProps = {
   },
 };
 
+const prop_immediate = {
+  displayName: "Immediate",
+  icon: RunningWithErrorsIcon,
+  statusLabel: "Your pteam has a immediate",
+  style: {
+    bgcolor: red[600],
+    color: "white",
+    textTransform: "none",
+  },
+};
+const prop_out_of_cycle = {
+  displayName: "Out-of-cycle",
+  icon: WarningIcon,
+  statusLabel: "Your pteam has a out-of-cycle",
+  style: {
+    bgcolor: orange[600],
+    color: "white",
+    textTransform: "none",
+  },
+};
+const prop_scheduled = {
+  displayName: "Scheduled",
+  icon: PriorityHighIcon,
+  statusLabel: "Your pteam has a scheduled",
+  style: {
+    bgcolor: amber[600],
+    color: "white",
+    textTransform: "none",
+  },
+};
+const prop_defer = {
+  displayName: "Defer",
+  icon: CheckIcon,
+  statusLabel: "Your pteam has defer",
+  style: {
+    bgcolor: grey[600],
+    color: "white",
+    textTransform: "none",
+  },
+};
+const prop_safe = {
+  chipLabel: "Safe",
+  icon: HealthAndSafetyIcon,
+  statusLabel: "Your pteam has safe",
+  style: {
+    bgcolor: green[600],
+    color: "white",
+    textTransform: "none",
+  },
+};
+// sorted priorities -- should match with strings which api returns.
+export const sortedSSVCPriorities = ["immediate", "out_of_cycle", "scheduled", "defer"];
+export const ssvcPriorityProps = {
+  immediate: prop_immediate,
+  Immediate: prop_immediate,
+  out_of_cycle: prop_out_of_cycle,
+  "Out-of-cycle": prop_out_of_cycle,
+  scheduled: prop_scheduled,
+  Scheduled: prop_scheduled,
+  defer: prop_defer,
+  Defer: prop_defer,
+  safe: prop_safe,
+  Safe: prop_safe,
+};
+
 export const topicStatusProps = {
   alerted: {
     chipLabel: "alerted",

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -87,3 +87,20 @@ export const blobToDataURL = async (blob) =>
     reader.onerror = (error) => reject(error);
     reader.readAsDataURL(blob);
   });
+
+export const compareSSVCPriority = (prio1, prio2) => {
+  const toIntDict = {
+    immediate: 1,
+    Immediate: 1,
+    out_of_cycle: 2,
+    "Out-of-cycle": 2,
+    scheduled: 3,
+    Scheduled: 3,
+    defer: 4,
+    Defer: 4,
+  };
+  const [int1, int2] = [toIntDict[prio1], toIntDict[prio2]];
+  if (int1 === int2) return 0;
+  else if (int1 < int2) return -1;
+  else return 1;
+};


### PR DESCRIPTION
## PR の目的

- UI 側で threat impact に代わり ssvc priority を使うように改修
  - enum である ssvcPriority の比較用関数を util/func.js に実装
  - 旧来の threatImpact 用の諸々（props や Chip コンポーネント）は未だ削除していない
    - 乗り換えが完了して不要が確定した後に削除する