### PR TITLE
Topic/re alert when ssvc calculation value changes

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -243,6 +243,9 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     if ticket.ssvc_deployer_priority is None:
         return False
 
+    if ticket.current_ticket_status.topic_status == models.TopicStatusType.completed:
+        return False
+
     pteam = ticket.threat.dependency.service.pteam
     return ticket.ssvc_deployer_priority <= pteam.alert_ssvc_priority
 

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -12,7 +12,7 @@ from PIL import Image
 from sqlalchemy.orm import Session
 
 from app import command, models, persistence, schemas
-from app.alert import notify_sbom_upload_ended
+from app.alert import notify_sbom_upload_ended, send_alert_to_pteam
 from app.auth import get_current_user
 from app.common import (
     check_pteam_auth,
@@ -25,11 +25,13 @@ from app.common import (
     get_sorted_topics,
     get_tag_ids_with_parent_ids,
     get_topic_ids_summary_by_service_id_and_tag_id,
+    ticket_meets_condition_to_create_alert,
 )
 from app.constants import MEMBER_UUID, NOT_MEMBER_UUID
 from app.database import get_db, open_db_session
 from app.sbom import sbom_json_to_artifact_json_lines
 from app.slack import validate_slack_webhook_url
+from app.ssvc import ssvc_calculator
 
 router = APIRouter(prefix="/pteams", tags=["pteams"])
 
@@ -242,6 +244,30 @@ def update_pteam_service(
 
     if data.safety_impact is not None:
         service.safety_impact = data.safety_impact
+    db.flush()
+
+    # calculate ssvc priority and notify
+    if data.system_exposure or data.service_mission_impact or data.safety_impact:
+        threats: list[models.Threat] = []
+        for dependency in service.dependencies:
+            threats.extend(persistence.search_threats(db, dependency.dependency_id, None))
+
+        now = datetime.now()
+        for threat in threats:
+            ticket = threat.ticket
+            if ticket is not None:
+                _ssvc_deployer_priority = ssvc_calculator.calculate_ssvc_priority_by_threat(threat)
+                ticket.ssvc_deployer_priority = _ssvc_deployer_priority
+                db.flush
+
+                if ticket_meets_condition_to_create_alert(ticket):
+                    alert = models.Alert(
+                        ticket_id=ticket.ticket_id,
+                        alerted_at=now,
+                        alert_content="",  # alert_content is not used
+                    )
+                    persistence.create_alert(db, alert)
+                    send_alert_to_pteam(alert)
 
     db.commit()
 

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -10,6 +10,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 from app import command, models, persistence, schemas
+from app.alert import send_alert_to_pteam
 from app.auth import get_current_user, token_scheme
 from app.common import (
     calculate_topic_content_fingerprint,
@@ -18,8 +19,10 @@ from app.common import (
     fix_threats_for_topic,
     get_or_create_misp_tag,
     get_sorted_topics,
+    ticket_meets_condition_to_create_alert,
 )
 from app.database import get_db
+from app.ssvc import ssvc_calculator
 
 router = APIRouter(prefix="/topics", tags=["topics"])
 
@@ -404,6 +407,28 @@ def update_topic(
 
     if tags_updated:
         fix_threats_for_topic(db, topic)
+
+    # calculate ssvc priority
+    if data.exploitation or data.automatable:
+        threats: list[models.Threat] = []
+        threats.extend(persistence.search_threats(db, None, topic.topic_id))
+
+        now = datetime.now()
+        for threat in threats:
+            ticket = threat.ticket
+            if ticket is not None:
+                _ssvc_deployer_priority = ssvc_calculator.calculate_ssvc_priority_by_threat(threat)
+                ticket.ssvc_deployer_priority = _ssvc_deployer_priority
+                db.flush
+
+                if ticket_meets_condition_to_create_alert(ticket):
+                    alert = models.Alert(
+                        ticket_id=ticket.ticket_id,
+                        alerted_at=now,
+                        alert_content="",  # alert_content is not used
+                    )
+                    persistence.create_alert(db, alert)
+                    send_alert_to_pteam(alert)
 
     db.commit()
 

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -344,69 +344,91 @@ def test_update_topic_not_creater():
         )
 
 
-def test_update_topic_alert_by_mail_if_vulnerabilities_are_found_when_updating_topic(mocker):
-    def _gen_pteam_params(idx: int) -> dict:
-        return {
-            "pteam_name": f"pteam{idx}",
-            "alert_slack": {
-                "enable": True,
-                "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
-            },
-            "alert_mail": {
-                "enable": True,
-                "address": f"account{idx}@example.com",
-            },
-            "alert_ssvc_priority": DEFAULT_ALERT_SSVC_PRIORITY,
-        }
-
-    def _gen_topic_params(tags: list[schemas.TagResponse]) -> dict:
-        topic_id = str(uuid4())
-        return {
-            "topic_id": topic_id,
-            "title": "test topic " + topic_id,
-            "abstract": "test abstract " + topic_id,
-            "threat_impact": 1,
-            "tags": [tag.tag_name for tag in tags],
-            "misp_tags": [],
-            "actions": [
-                {
-                    "topic_id": topic_id,
-                    "action": "update to 999.9.9",
-                    "action_type": models.ActionType.elimination,
-                    "recommended": True,
-                    "ext": {
-                        "tags": [tag.tag_name for tag in tags],
-                        "vulnerable_versions": {tag.tag_name: ["< 999.9.9"] for tag in tags},
-                    },
+class TestUpdateTopic:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        def _gen_pteam_params(idx: int) -> dict:
+            return {
+                "pteam_name": f"pteam{idx}",
+                "alert_slack": {
+                    "enable": True,
+                    "webhook_url": SAMPLE_SLACK_WEBHOOK_URL + str(idx),
                 },
-            ],
-            "exploitation": "active",
-            "automatable": "yes",
+                "alert_mail": {
+                    "enable": True,
+                    "address": f"account{idx}@example.com",
+                },
+                "alert_ssvc_priority": DEFAULT_ALERT_SSVC_PRIORITY,
+            }
+
+        def _gen_topic_params(tags: list[schemas.TagResponse]) -> dict:
+            topic_id = str(uuid4())
+            return {
+                "topic_id": topic_id,
+                "title": "test topic " + topic_id,
+                "abstract": "test abstract " + topic_id,
+                "threat_impact": 1,
+                "tags": [tag.tag_name for tag in tags],
+                "misp_tags": [],
+                "actions": [
+                    {
+                        "topic_id": topic_id,
+                        "action": "update to 999.9.9",
+                        "action_type": models.ActionType.elimination,
+                        "recommended": True,
+                        "ext": {
+                            "tags": [tag.tag_name for tag in tags],
+                            "vulnerable_versions": {tag.tag_name: ["< 999.9.9"] for tag in tags},
+                        },
+                    },
+                ],
+                "exploitation": "active",
+                "automatable": "yes",
+            }
+
+        self.user1 = create_user(USER1)
+        self.pteam0 = create_pteam(USER1, _gen_pteam_params(0))
+        self.tag1 = create_tag(USER1, TAG1)
+        test_service = "test_service"
+        test_target = "test target"
+        test_version = "1.2.3"
+        refs0 = {self.tag1.tag_name: [(test_target, test_version)]}
+        upload_pteam_tags(USER1, self.pteam0.pteam_id, test_service, refs0)
+        self.topic = create_topic(USER1, _gen_topic_params([self.tag1]))
+
+    def test_alert_by_mail_if_vulnerabilities_are_found_when_updating_topic(self, mocker):
+        ## ssvc_deployer_priority is immediate
+        request = {
+            "exploitation": ExploitationEnum.ACTIVE.value,
+            "automatable": AutomatableEnum.NO.value,
         }
 
-    create_user(USER1)
-    pteam0 = create_pteam(USER1, _gen_pteam_params(0))
-    tag = create_tag(USER1, TAG1)
-    test_service = "test_service"
-    test_target = "test target"
-    test_version = "1.2.3"
-    refs0 = {tag.tag_name: [(test_target, test_version)]}
-    upload_pteam_tags(USER1, pteam0.pteam_id, test_service, refs0)
-    topic = create_topic(USER1, _gen_topic_params([tag]))
+        send_alert_to_pteam = mocker.patch("app.routers.topics.send_alert_to_pteam")
+        response = client.put(
+            f"/topics/{self.topic.topic_id}",
+            headers=headers(USER1),
+            json=request,
+        )
+        assert response.status_code == 200
+        send_alert_to_pteam.assert_called_once()
 
-    request = {
-        "exploitation": ExploitationEnum.ACTIVE.value,
-        "automatable": AutomatableEnum.YES.value,
-    }
+    def test_not_alert_when_ssvc_deployer_priority_is_lower_than_alert_ssvc_priority_in_pteam(
+        self, mocker
+    ):
+        ## ssvc_deployer_priority is out_of_cycle
+        request = {
+            "exploitation": ExploitationEnum.PUBLIC_POC.value,
+            "automatable": AutomatableEnum.YES.value,
+        }
 
-    send_alert_to_pteam = mocker.patch("app.routers.topics.send_alert_to_pteam")
-    response = client.put(
-        f"/topics/{topic.topic_id}",
-        headers=headers(USER1),
-        json=request,
-    )
-    assert response.status_code == 200
-    send_alert_to_pteam.assert_called_once()
+        send_alert_to_pteam = mocker.patch("app.routers.topics.send_alert_to_pteam")
+        response = client.put(
+            f"/topics/{self.topic.topic_id}",
+            headers=headers(USER1),
+            json=request,
+        )
+        assert response.status_code == 200
+        send_alert_to_pteam.assert_not_called()
 
 
 def test_delete_topic(testdb: Session):


### PR DESCRIPTION
## PR の目的
- SVCCの計算で使用する値が変更されたとき、関連するTicketにアラート発行する機能を追加しました
- SSVC計算で使用する値
  - Topic
    - exploitation
    - automatable
  - Service
    - exposure
    - service_mission_impact
    - safety_impact

## 経緯・意図・意思決定
### API
- 変更したAPIは2つです。
  - api/app/routers/pteams.py update_pteam_service
    - exposure、service_mission_impact、safety_impactのどれか1つでもリクエストに入っていた場合、ssvc計算をし該当するTicketテーブルに登録します。また設定している閾値と比較し、該当しているものに関してはAlertテーブルに新しく行を追加します。
  - api/app/routers/topics.py update_topic
  　- exploitation、automatableのどれか1つでもリクエストに入っていた場合、ssvc計算をし該当するTicketテーブルに登録します。また設定している閾値と比較し、該当しているものに関してはAlertテーブルに新しく行を追加します。
- CurrentTicketStatusのtopic_statusがcompletedものに関してはアラートが飛ばないようにしています。(api/app/common.py)

### テスト
- テストは合計3つ作成しました。
- test_pteams.py 2つ
- 2つともmockerを用いて、アラートを飛ばしている関数が呼び出されているかを検証しています
   - test_alert_by_mail_if_vulnerabilities_are_found_when_updating_service  
     - Ticketテーブルまで作成し、update_pteam_serviceでexposure、service_mission_impact、safety_impactの値を変更しアラートが飛ぶかを検証しています。
   - test_not_alert_with_current_ticket_status_is_completed
     - Ticketテーブルまで作成しCurrentTicketStatusのtopic_statusをcompletedにします。その後update_pteam_serviceでexposure、service_mission_impact、safety_impactの値を変更し、アラートが飛ばないかを検証しています。
- test_topics.py 1つ
- test_pteams.py同様にmockerを用いて、アラートを飛ばしている関数が呼び出されているかを検証しています
- test_update_topic_alert_by_mail_if_vulnerabilities_are_found_when_updating_topic
- Ticketテーブルまで作成し、update_topicでexploitation、automatableの値を変更しアラートが飛ぶかを検証しています。
