### PR TITLE
bugfix/error-when-setting-status-to-completed

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -609,33 +609,17 @@ def set_ticket_status(
         data_scheduled_at = data.scheduled_at.replace(tzinfo=None)
 
     if data.topic_status == models.TopicStatusType.scheduled:
-        if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:
-            if data.scheduled_at == datetime.fromtimestamp(0):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        "If current status and previous status is schduled, "
-                        "unable to reset schduled_at"
-                    ),
-                )
-            elif data_scheduled_at < now:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is schduled, schduled_at must be a future time",
-                )
-        else:
-            if data.scheduled_at is None:
+        if data.scheduled_at is None:
+            if ticket.current_ticket_status.topic_status != models.TopicStatusType.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="If status is schduled, specify schduled_at",
                 )
-            elif data.scheduled_at == datetime.fromtimestamp(0):
+        else:
+            if data.scheduled_at == datetime.fromtimestamp(0):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        "If current status is schduled and previous status is not schduled, "
-                        "unable to reset schduled_at"
-                    ),
+                    detail="If status is schduled, unable to reset schduled_at",
                 )
             elif data_scheduled_at < now:
                 raise HTTPException(
@@ -643,19 +627,14 @@ def set_ticket_status(
                     detail="If status is schduled, schduled_at must be a future time",
                 )
     else:
-        if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:
-            if data.scheduled_at is None:
+        if data.scheduled_at is None:
+            if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
                         "If current status is not schduled and previous status is schduled, "
                         "need to reset schduled_at"
                     ),
-                )
-            elif data.scheduled_at != datetime.fromtimestamp(0) and data.scheduled_at:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is not schduled, do not specify schduled_at",
                 )
         else:
             if data.scheduled_at != datetime.fromtimestamp(0) and data.scheduled_at:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -608,23 +608,26 @@ def set_ticket_status(
     if data.scheduled_at:
         data_scheduled_at = data.scheduled_at.replace(tzinfo=None)
 
-    if data.topic_status == models.TopicStatusType.scheduled:
+    if data.topic_status == models.TopicStatusType.scheduled or (
+        data.topic_status is None
+        and ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled
+    ):
         if data.scheduled_at is None:
             if ticket.current_ticket_status.topic_status != models.TopicStatusType.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is schduled, specify schduled_at",
+                    detail="If status is scheduled, specify schduled_at",
                 )
         else:
             if data.scheduled_at == datetime.fromtimestamp(0):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is schduled, unable to reset schduled_at",
+                    detail="If status is scheduled, unable to reset schduled_at",
                 )
             elif data_scheduled_at < now:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is schduled, schduled_at must be a future time",
+                    detail="If status is scheduled, schduled_at must be a future time",
                 )
     else:
         if data.scheduled_at is None:
@@ -632,7 +635,7 @@ def set_ticket_status(
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
-                        "If current status is not schduled and previous status is schduled, "
+                        "If current status is not scheduled and previous status is schduled, "
                         "need to reset schduled_at"
                     ),
                 )
@@ -640,7 +643,7 @@ def set_ticket_status(
             if data.scheduled_at != datetime.fromtimestamp(0) and data.scheduled_at:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="If status is not schduled, do not specify schduled_at",
+                    detail="If status is not scheduled, do not specify schduled_at",
                 )
 
     for logging_id_ in data.logging_ids or []:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -593,7 +593,7 @@ def set_ticket_status(
             or ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled
         )
         and data.scheduled_at
-        and data_scheduled_at < now
+        and (data_scheduled_at != datetime.fromtimestamp(0) and data_scheduled_at < now)
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -643,7 +643,7 @@ def set_ticket_status(
                     detail="If status is schduled, schduled_at must be a future time",
                 )
     else:
-        if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:  ##(2)
+        if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:
             if data.scheduled_at is None:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/app/tests/medium/routers/test_ateams.py
+++ b/api/app/tests/medium/routers/test_ateams.py
@@ -1621,6 +1621,7 @@ def test_get_topic_status():
     # complete
     request = {
         "topic_status": models.TopicStatusType.completed,
+        "scheduled_at": str(datetime.fromtimestamp(0)),
     }
     set_ticket_status(USER1, pteam1.pteam_id, service1["service_id"], ticket1["ticket_id"], request)
 
@@ -1906,6 +1907,7 @@ def test_get_topic_status():
     # PTEAM2 complete TOPIC2 TAG2
     request = {
         "topic_status": models.TopicStatusType.completed,
+        "scheduled_at": str(datetime.fromtimestamp(0)),
     }
     set_ticket_status(
         USER1, pteam2.pteam_id, service2["service_id"], ticket2_2b["ticket_id"], request

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3164,7 +3164,7 @@ class TestTicketStatus:
                 "topic_status": models.TopicStatusType.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
-                "scheduled_at": str(datetime.fromtimestamp(0)),
+                "scheduled_at": "2000-01-01T00:00:00",
             }
             url = (
                 f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3156,7 +3156,7 @@ class TestTicketStatus:
             assert response.status_code == 400
 
             set_response = response.json()
-            assert set_response["detail"] == "If status is schduled, specify schduled_at"
+            assert set_response["detail"] == "If status is scheduled, specify schduled_at"
 
         def test_it_should_return_400_when_topic_status_is_acknowledged_and_there_is_schduled_at(
             self, actionable_topic1
@@ -3181,7 +3181,7 @@ class TestTicketStatus:
             assert response.status_code == 400
 
             set_response = response.json()
-            assert set_response["detail"] == "If status is not schduled, do not specify schduled_at"
+            assert set_response["detail"] == "If status is not scheduled, do not specify schduled_at"
 
         def test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past(
             self, actionable_topic1
@@ -3207,7 +3207,7 @@ class TestTicketStatus:
 
             set_response = response.json()
             assert (
-                set_response["detail"] == "If status is schduled, schduled_at must be a future time"
+                set_response["detail"] == "If status is scheduled, schduled_at must be a future time"
             )
 
         def test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero(

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3181,7 +3181,9 @@ class TestTicketStatus:
             assert response.status_code == 400
 
             set_response = response.json()
-            assert set_response["detail"] == "If status is not scheduled, do not specify schduled_at"
+            assert (
+                set_response["detail"] == "If status is not scheduled, do not specify schduled_at"
+            )
 
         def test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past(
             self, actionable_topic1
@@ -3207,7 +3209,8 @@ class TestTicketStatus:
 
             set_response = response.json()
             assert (
-                set_response["detail"] == "If status is scheduled, schduled_at must be a future time"
+                set_response["detail"]
+                == "If status is scheduled, schduled_at must be a future time"
             )
 
         def test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero(

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -89,6 +89,8 @@ export function TopicStatusSelector(props) {
     if (selectedStatus === "scheduled") {
       if (!schedule) return;
       requestParams["scheduled_at"] = schedule.toISOString();
+    } else if (selectedStatus === "acknowledged") {
+      requestParams["scheduled_at"] = "1970-01-01T00:00:00";
     }
     await setTicketStatus(pteamId, serviceId, ticketId, requestParams)
       .then(() => {


### PR DESCRIPTION
## PR の目的
- チケットのtopic_statusをscheduleの状態にした後、completedにするとエラーが表示されてcompletedの状態にすることができない問題を解決しました

## バグの原因
現状のUIの仕様では、statusをcompletedにするときは、TicketStatusテーブルのschedule_atをNoneにして更新しています。
schedule_atをNoneにする場合、リクエストのschedule_atに"1970-01-01T00:00:00"を入れる仕様になっています。
```
if (
        (
            data.topic_status == models.TopicStatusType.scheduled
            or ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled
        )
        and data.scheduled_at
        and data_scheduled_at < now
    ):
        raise HTTPException(
            status_code=status.HTTP_400_BAD_REQUEST,
            detail="If status is schduled, schduled_at must be a future time",
        )
```
そのため、上記のコードの箇所に引っかかってしまいエラーが出力されています。

## 修正箇所
data_scheduled_at != datetime.fromtimestamp(0)をif文に入れてschedule_atに"1970-01-01T00:00:00"がある時は除外するようにしました
