### PR TITLE
refine around highlighting status card

### DIFF
--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -476,6 +476,7 @@ export function Status() {
                       onHandleClick={() =>
                         handleNavigateServiceList(tag.tag_id, tag.tag_name, tag.service_ids)
                       }
+                      pteam={pteam}
                       tag={tag}
                       serviceIds={tag.service_ids}
                     />
@@ -487,6 +488,7 @@ export function Status() {
                     <PTeamStatusCard
                       key={tag.tag_id}
                       onHandleClick={() => handleNavigateTag(tag.tag_id)}
+                      pteam={pteam}
                       tag={tag}
                     />
                   ))}

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -98,6 +98,8 @@ export const compareSSVCPriority = (prio1, prio2) => {
     Scheduled: 3,
     defer: 4,
     Defer: 4,
+    safe: 4,
+    Safe: 4,
   };
   const [int1, int2] = [toIntDict[prio1], toIntDict[prio2]];
   if (int1 === int2) return 0;


### PR DESCRIPTION
## PR の目的

- ハイライト処理を整理しました
  - pteam の自己解決を止め、親から props で受け取るように変更
  - useEffect, useState が不要になったことで、ハイライトが一瞬点いて消えるといった挙動がなくなりました
