### PR TITLE
suppress duplicate alerts

### DIFF
--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -407,8 +407,9 @@ def update_topic(
 
     db.flush()
 
+    created_ticket_ids: list[str] = []
     if tags_updated:
-        fix_threats_for_topic(db, topic)
+        created_ticket_ids = fix_threats_for_topic(db, topic)
 
     # calculate ssvc priority
     if (data.exploitation and data.exploitation != previous_exploitation) or (
@@ -425,7 +426,10 @@ def update_topic(
                 _ssvc_deployer_priority = ssvc_calculator.calculate_ssvc_priority_by_threat(threat)
                 ticket.ssvc_deployer_priority = _ssvc_deployer_priority
 
-                if ticket_meets_condition_to_create_alert(ticket):
+                if (
+                    ticket.ticket_id not in created_ticket_ids
+                    and ticket_meets_condition_to_create_alert(ticket)
+                ):
                     alert = models.Alert(
                         ticket_id=ticket.ticket_id,
                         alerted_at=now,

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -430,6 +430,38 @@ class TestUpdateTopic:
         assert response.status_code == 200
         send_alert_to_pteam.assert_not_called()
 
+    def test_alert_once_when_ticket_is_created_by_topic_update(self, mocker):
+        # delete ticket by different tag
+        tag2 = create_tag(USER1, TAG2)
+        request1 = {
+            "tags": [tag2.tag_name],
+        }
+
+        client.put(
+            f"/topics/{self.topic.topic_id}",
+            headers=headers(USER1),
+            json=request1,
+        )
+
+        # create ticket by matching tag
+        request2 = {
+            "exploitation": ExploitationEnum.ACTIVE.value,
+            "automatable": AutomatableEnum.YES.value,
+            "tags": [self.tag1.tag_name],
+        }
+
+        send_alert_to_pteam_in_common = mocker.patch("app.common.send_alert_to_pteam")
+        send_alert_to_pteam_in_topics = mocker.patch("app.routers.topics.send_alert_to_pteam")
+        response = client.put(
+            f"/topics/{self.topic.topic_id}",
+            headers=headers(USER1),
+            json=request2,
+        )
+        assert response.status_code == 200
+        # alert once
+        send_alert_to_pteam_in_common.assert_called_once()
+        send_alert_to_pteam_in_topics.assert_not_called()
+
 
 def test_delete_topic(testdb: Session):
     user1 = create_user(USER1)


### PR DESCRIPTION
## PR の目的
- 下記のPR#335において、トピック更新時に同じTicketで2回アラートが発行されるケースが見つかったため、本PRでこれを1回に抑止する。
https://github.com/nttcom/threatconnectome/pull/335
  - 実現方式
トピック更新によるTciket生成時と、トピック更新によるSSVC Priority再計算時の2回アラートが発行されていたため、生成されたTciketのidを取得し、これに一致した場合はSSVC Priority再計算時にアラートを発行しないようにした。

## 経緯・意図・意思決定
- 修正前におけるアラート2重発行の条件
(1) put /topics/{topic_id} APIが実行される
(2) (1)の中で、下記2件がマッチング条件を満たすことにより、Ticketが新たに生成される
　(2-1)topic.actions内のextに定義されたタグ名、バージョン名
　(2-2)topic.tagsのタグ名と、これによりTag経由で関連付くDependencyのバージョン
(3) (2)で生成したTicketがアラート発行基準を満たす

- 上記2重発行が実際に起こりうるケース
 1. Ticketが生成された後、Topic更新APIで tagsをactionsとマッチしない名前に変更。→Ticketが削除される
 2. Topic更新APIで tagsをactionsとマッチする名前に変更。→Ticketが生成される
 
- Topic生成時に、tagsとactionsがマッチしない場合、エラーとなり登録できない。
そのため、上記のように一度登録してから更新するケースしかない。
登録時にはマッチしないとエラーになるが、更新時にはマッチしないとエラーにならない、というエラーチェックの不一致があるが、本PRでは統一していない。