### PR TITLE
topic/add re alert test

### DIFF
--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -488,6 +488,10 @@ def get_alert_by_id(db: Session, alert_id: UUID | str) -> models.Alert | None:
     ).one_or_none()
 
 
+def get_alert_by_ticket_id(db: Session, ticket_id: UUID | str) -> Sequence[models.Alert] | None:
+    return db.scalars(select(models.Alert).where(models.Alert.ticket_id == str(ticket_id))).all()
+
+
 def create_alert(db: Session, alert: models.Alert) -> None:
     db.add(alert)
     db.flush()

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -488,10 +488,6 @@ def get_alert_by_id(db: Session, alert_id: UUID | str) -> models.Alert | None:
     ).one_or_none()
 
 
-def get_alert_by_ticket_id(db: Session, ticket_id: UUID | str) -> Sequence[models.Alert] | None:
-    return db.scalars(select(models.Alert).where(models.Alert.ticket_id == str(ticket_id))).all()
-
-
 def create_alert(db: Session, alert: models.Alert) -> None:
     db.add(alert)
     db.flush()

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -4,10 +4,10 @@ from uuid import UUID, uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import insert
+from sqlalchemy import insert, select
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas
+from app import models, schemas
 from app.constants import (
     DEFAULT_ALERT_SSVC_PRIORITY,
 )
@@ -422,7 +422,9 @@ class TestUpdateTopic:
         )
         ticket_id = response_ticket.json()[0]["ticket_id"]
 
-        alerts = persistence.get_alert_by_ticket_id(testdb, ticket_id)
+        alerts = testdb.scalars(
+            select(models.Alert).where(models.Alert.ticket_id == str(ticket_id))
+        ).all()
 
         assert alerts
 

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageChops
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models, schemas
+from app import models, persistence, schemas
 from app.constants import (
     DEFAULT_ALERT_SSVC_PRIORITY,
     MEMBER_UUID,
@@ -3909,7 +3909,27 @@ class TestUpdatePTeamService:
                 json=request,
             )
             assert response.status_code == 200
+
+            ## get ticket_id
+            response_ticket = client.get(
+                f"/pteams/{self.pteam0.pteam_id}/services/{self.service_id0}/topics/{self.topic.topic_id}/tags/{self.tag1.tag_id}/tickets",
+                headers=_headers,
+            )
+            ticket_id = response_ticket.json()[0]["ticket_id"]
+
+            alerts = persistence.get_alert_by_ticket_id(testdb, ticket_id)
+
+            assert alerts
+
+            if alerts[0].alerted_at > alerts[1].alerted_at:
+                alert = alerts[0]
+            else:
+                alert = alerts[1]
+
+            assert alert.ticket.threat.topic_id == str(self.topic.topic_id)
+
             send_alert_to_pteam.assert_called_once()
+            send_alert_to_pteam.assert_called_with(alert)
 
         def test_not_alert_with_current_ticket_status_is_completed(self, mocker):
             user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageChops
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas
+from app import models, schemas
 from app.constants import (
     DEFAULT_ALERT_SSVC_PRIORITY,
     MEMBER_UUID,
@@ -3917,7 +3917,9 @@ class TestUpdatePTeamService:
             )
             ticket_id = response_ticket.json()[0]["ticket_id"]
 
-            alerts = persistence.get_alert_by_ticket_id(testdb, ticket_id)
+            alerts = testdb.scalars(
+                select(models.Alert).where(models.Alert.ticket_id == str(ticket_id))
+            ).all()
 
             assert alerts
 


### PR DESCRIPTION
## PR の目的
- https://github.com/nttcom/threatconnectome/pull/335
- 上記のPRでできていなかったmockのassert_called_with()を使用した引数チェックを追加しました

## 経緯・意図・意思決定
- api/app/tests/medium/routers/test_topics.py, api/app/tests/requests/test_pteams.py
  - ticket_idを取得後、persistence.get_alert_by_ticket_idを使ってalertを持ってきています。同一のticket_idには変更前と変更後の2つalertの行があります。 alert.alerted_atに登録されている時間を比較し遅い時間の方をassert_called_with()の引数チェックに使用しています
  - 取得したalertを用いてtopic_idの比較を行なっています
- api/app/persistence.py
  - ticket_idでalertを取得できる関数を作成しました