### PR TITLE
change each description of the alert icon

### DIFF
--- a/web/src/components/SSVCPriorityCountChip.jsx
+++ b/web/src/components/SSVCPriorityCountChip.jsx
@@ -28,17 +28,19 @@ export function SSVCPriorityCountChip(props) {
 
   return (
     <Box display="flex" sx={outerSx}>
-      <Paper
-        variant="outlined"
-        sx={{
-          ...fixedSx,
-          borderRightWidth: "0",
-          borderTopRightRadius: "0",
-          borderBottomRightRadius: "0",
-        }}
-      >
-        <Icon style={{ fontSize: "20px" }} />
-      </Paper>
+      <Tooltip title={ssvcPriorityProps[ssvcPriority].statusLabel} arrow>
+        <Paper
+          variant="outlined"
+          sx={{
+            ...fixedSx,
+            borderRightWidth: "0",
+            borderTopRightRadius: "0",
+            borderBottomRightRadius: "0",
+          }}
+        >
+          <Icon style={{ fontSize: "20px" }} />
+        </Paper>
+      </Tooltip>
       <Paper
         variant="outlined"
         sx={{

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -136,7 +136,8 @@ export const threatImpactProps = {
 const prop_immediate = {
   displayName: "Immediate",
   icon: RunningWithErrorsIcon,
-  statusLabel: "Your pteam has a immediate",
+  statusLabel:
+    "Immediate: Act immediately; focus all resources on applying the fix as quickly as possible, including, if necessary, pausing regular organization operations.",
   style: {
     bgcolor: red[600],
     color: "white",
@@ -146,7 +147,8 @@ const prop_immediate = {
 const prop_out_of_cycle = {
   displayName: "Out-of-cycle",
   icon: WarningIcon,
-  statusLabel: "Your pteam has a out-of-cycle",
+  statusLabel:
+    "Out-of-cycle: Act more quickly than usual to apply the mitigation or remediation out-of-cycle, during the next available opportunity, working overtime if necessary.",
   style: {
     bgcolor: orange[600],
     color: "white",
@@ -156,7 +158,7 @@ const prop_out_of_cycle = {
 const prop_scheduled = {
   displayName: "Scheduled",
   icon: PriorityHighIcon,
-  statusLabel: "Your pteam has a scheduled",
+  statusLabel: "Scheduled: Act during regularly scheduled maintenance time.",
   style: {
     bgcolor: amber[600],
     color: "white",
@@ -166,7 +168,7 @@ const prop_scheduled = {
 const prop_defer = {
   displayName: "Defer",
   icon: CheckIcon,
-  statusLabel: "Your pteam has defer",
+  statusLabel: "Defer: Do not act at present.",
   style: {
     bgcolor: grey[600],
     color: "white",


### PR DESCRIPTION
## PR の目的
- Status画面、Tag画面のチケットステータスのアラートアイコンに説明文のtooltipを追加と変更
   - 例）アラートアイコンがImmediateの場合
      - Status画面：tooltipなし → 「Immediate: Act immediately; focus all resources on applying ~.」を追加
      - Tag画面：「your team has a Immediate」→「Immediate: Act immediately; focus all resources on applying ~.」に変更

## 経緯・意図・意思決定
- アラートアイコンにマウスオーバーしたときにSSVCプライオリティの適切な説明（参考文献参照）が表示されるようにするため
   - 今まではStatus画面では表示がなく（数値部分のみ表示あり）、Tag画面では「Your team has a xxx」と表示

## 参考文献
https://certcc.github.io/SSVC/howto/deployer_tree/#deployer-decision-outcomes