### PR TITLE
fix expected counts for new default ssvc params

### DIFF
--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -82,9 +82,9 @@ def test_show_tag_page_directly(page: Page):
     # tag page
     expect(page).to_have_url(re.compile(path))
     expect(page.get_by_role("heading", name=TAG1)).to_have_text(TAG1)
-    expect(page.locator("#ssvc-priority-count-chip-immediate")).to_have_text("2")
+    expect(page.locator("#ssvc-priority-count-chip-immediate")).to_have_text("0")
     expect(page.locator("#ssvc-priority-count-chip-out_of_cycle")).to_have_text("0")
-    expect(page.locator("#ssvc-priority-count-chip-scheduled")).to_have_text("0")
+    expect(page.locator("#ssvc-priority-count-chip-scheduled")).to_have_text("2")
     expect(page.locator("#ssvc-priority-count-chip-defer")).to_have_text("0")
     expect(page.get_by_role("heading", name=str(TOPIC1["title"]))).to_have_text(
         str(TOPIC1["title"])
@@ -109,9 +109,9 @@ def test_show_tag_page(page: Page):
 
     # tag page
     expect(page.get_by_role("heading", name=TAG1)).to_have_text(TAG1)
-    expect(page.locator("#ssvc-priority-count-chip-immediate")).to_have_text("2")
+    expect(page.locator("#ssvc-priority-count-chip-immediate")).to_have_text("0")
     expect(page.locator("#ssvc-priority-count-chip-out_of_cycle")).to_have_text("0")
-    expect(page.locator("#ssvc-priority-count-chip-scheduled")).to_have_text("0")
+    expect(page.locator("#ssvc-priority-count-chip-scheduled")).to_have_text("2")
     expect(page.locator("#ssvc-priority-count-chip-defer")).to_have_text("0")
     expect(page.get_by_role("heading", name=str(TOPIC1["title"]))).to_have_text(
         str(TOPIC1["title"])


### PR DESCRIPTION
## PR の目的

- SSVC 関連パラメータ（exploitation, automatable）のデフォルト値変更に伴い、e2etest での期待値を修正
