### PR TITLE
Topic/api fix ssvc priorities

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -391,6 +391,12 @@ class Service(Base):
         "Dependency", back_populates="service", cascade="all, delete-orphan"
     )
     thumbnail = relationship("ServiceThumbnail", uselist=False, cascade="all, delete-orphan")
+    tickets = relationship(  # Service - [ Dependency - Threat ] - Ticket
+        "Ticket",
+        secondary="join(Dependency, Threat, Dependency.dependency_id == Threat.dependency_id)",
+        collection_class=set,
+        viewonly=True,
+    )
 
 
 class ServiceThumbnail(Base):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3905,7 +3905,7 @@ class TestUpdatePTeamService:
                 "safety_impact": models.SafetyImpactEnum.CATASTROPHIC.value,
             }
 
-            send_alert_to_pteam = mocker.patch("app.routers.pteams.send_alert_to_pteam")
+            send_alert_to_pteam = mocker.patch("app.common.send_alert_to_pteam")
             response = client.post(
                 f"/pteams/{self.pteam0.pteam_id}/services/{self.service_id0}",
                 headers=_headers,
@@ -3965,7 +3965,7 @@ class TestUpdatePTeamService:
                 "service_mission_impact": models.MissionImpactEnum.MISSION_FAILURE.value,
                 "safety_impact": models.SafetyImpactEnum.CATASTROPHIC.value,
             }
-            send_alert_to_pteam = mocker.patch("app.routers.pteams.send_alert_to_pteam")
+            send_alert_to_pteam = mocker.patch("app.common.send_alert_to_pteam")
             response = client.post(
                 f"/pteams/{self.pteam0.pteam_id}/services/{self.service_id0}",
                 headers=_headers,
@@ -3991,7 +3991,7 @@ class TestUpdatePTeamService:
                 "safety_impact": models.SafetyImpactEnum.CATASTROPHIC.value,
             }
 
-            send_alert_to_pteam = mocker.patch("app.routers.pteams.send_alert_to_pteam")
+            send_alert_to_pteam = mocker.patch("app.common.send_alert_to_pteam")
             response = client.post(
                 f"/pteams/{self.pteam0.pteam_id}/services/{self.service_id0}",
                 headers=_headers,


### PR DESCRIPTION
## PR の目的

- 指定 pteam に属するチケットの ssvc priority を全て再計算するエンドポイントを実装
  - 変化の有無に関わらず、現在は再アラートを行う
  - サービスごとのチケット、というアクセスは多用しそうなので、relationship（Service.tickets）を定義