### PR TITLE
display status above assignees on the Status detail page

### DIFF
--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -50,23 +50,6 @@ export const TopicTicketAccordion = (props) => {
         </Box>
       </AccordionSummary>
       <AccordionDetails>
-        <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-            Assignees
-          </Typography>
-          <Box sx={{ maxWidth: 150 }}>
-            <AssigneesSelector
-              key={ticketStatus.assignees.join("")}
-              pteamId={pteamId}
-              serviceId={serviceId}
-              topicId={topicId}
-              tagId={tagId}
-              ticketId={ticket.ticket_id}
-              currentAssigneeIds={ticketStatus.assignees}
-              members={members}
-            />
-          </Box>
-        </CardActions>
         <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
           <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
             Status
@@ -115,6 +98,23 @@ export const TopicTicketAccordion = (props) => {
             </Box>
           </Box>
         )}
+        <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
+          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
+            Assignees
+          </Typography>
+          <Box sx={{ maxWidth: 150 }}>
+            <AssigneesSelector
+              key={ticketStatus.assignees.join("")}
+              pteamId={pteamId}
+              serviceId={serviceId}
+              topicId={topicId}
+              tagId={tagId}
+              ticketId={ticket.ticket_id}
+              currentAssigneeIds={ticketStatus.assignees}
+              members={members}
+            />
+          </Box>
+        </CardActions>
       </AccordionDetails>
     </Accordion>
   );


### PR DESCRIPTION
## PR の目的
- Status詳細画面で、Statusの表示をAssignees の上に移動
   - 表示に関して従来通り上からTopicStatusSelector→CalendarMonth→update時の表示（Last updated by ~ ）の順で表示

## 経緯・意図・意思決定
- デモフロー作成時に、Assgineesの表示位置とStatusの表示位置を交換したほうが良いという意見が出たため
