### PR TITLE
Topic詳細画面のSSVC対応UIのモック作成

### DIFF
--- a/web/src/components/TopicSSVCCards.jsx
+++ b/web/src/components/TopicSSVCCards.jsx
@@ -8,85 +8,119 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import PropTypes from "prop-types";
 import React from "react";
 
-export function TopicSSVCCards() {
-  const decisionPoints = [
-    {
-      name: "Automatable",
-      description:
-        "Can an attacker reliably automate creating exploitation events for this vulnerability?",
-      values: [
-        {
-          name: "No",
-          description:
-            "No: Attackers cannot reliably automate steps 1-4 of the kill chain for this vulnerability. These steps are (1) reconnaissance, (2) weaponization, (3) delivery, and (4) exploitation.",
-        },
-        {
-          name: "Yes",
-          description: "Yes: Attackers can reliably automate steps 1-4 of the kill chain.",
-        },
-      ],
-    },
-    {
-      name: "Exploitation",
-      description: "The present state of exploitation of the vulnerability.",
-      values: [
-        {
-          name: "None",
-          description:
-            "None: There is no evidence of active exploitation and no public proof of concept (PoC) of how to exploit the vulnerability.",
-        },
-        {
-          name: "Public PoC",
-          description:
-            "Public PoC: One of the following is true: (1) Typical public PoC exists in sources such as Metasploit or websites like ExploitDB; or (2) the vulnerability has a well-known method of exploitation.",
-        },
-        {
-          name: "Active",
-          description:
-            "Active: Shared, observable, reliable evidence that the exploit is being used in the wild by real attackers; there is credible public reporting.",
-        },
-      ],
-    },
-  ];
+function TopicSSVCElement(props) {
+  const { title, titleDescription, values, value } = props;
+
+  return (
+    <Grid key={title} item xs={6}>
+      <Card variant="outlined" sx={{ p: 3, height: "100%" }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            mb: 1,
+          }}
+        >
+          <Typography sx={{ fontWeight: "bold", pr: 0.5 }}>{title}</Typography>
+          <Tooltip title={titleDescription}>
+            <HelpOutlineOutlinedIcon color="action" fontSize="small" />
+          </Tooltip>
+        </Box>
+        <ToggleButtonGroup
+          color="primary"
+          value={values.filter((item) => value === item.key)[0].key}
+          sx={{ mb: 1 }}
+        >
+          {values.map((value) => (
+            <ToggleButton key={value.key} value={value.key} disabled>
+              {value.name}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <Typography variant="body2" color="textSecondary">
+          {values.filter((item) => value === item.key)[0].valueDescription}
+        </Typography>
+      </Card>
+    </Grid>
+  );
+}
+TopicSSVCElement.propTypes = {
+  title: PropTypes.string.isRequired,
+  titleDescription: PropTypes.string.isRequired,
+  values: PropTypes.array.isRequired,
+  value: PropTypes.string.isRequired,
+};
+
+export function TopicSSVCCards(props) {
+  const { exploitation, automatable } = props;
+
+  const automatableDescription = {
+    title: "Automatable",
+    titleDescription:
+      "Can an attacker reliably automate creating exploitation events for this vulnerability?",
+    values: [
+      {
+        key: "no",
+        name: "No",
+        valueDescription:
+          "No: Attackers cannot reliably automate steps 1-4 of the kill chain for this vulnerability. These steps are (1) reconnaissance, (2) weaponization, (3) delivery, and (4) exploitation.",
+      },
+      {
+        key: "yes",
+        name: "Yes",
+        valueDescription: "Yes: Attackers can reliably automate steps 1-4 of the kill chain.",
+      },
+    ],
+  };
+
+  const exploitationDescription = {
+    title: "Exploitation",
+    titleDescription: "The present state of exploitation of the vulnerability.",
+    values: [
+      {
+        key: "none",
+        name: "None",
+        valueDescription:
+          "None: There is no evidence of active exploitation and no public proof of concept (PoC) of how to exploit the vulnerability.",
+      },
+      {
+        key: "public_poc",
+        name: "Public PoC",
+        valueDescription:
+          "Public PoC: One of the following is true: (1) Typical public PoC exists in sources such as Metasploit or websites like ExploitDB; or (2) the vulnerability has a well-known method of exploitation.",
+      },
+      {
+        key: "active",
+        name: "Active",
+        valueDescription:
+          "Active: Shared, observable, reliable evidence that the exploit is being used in the wild by real attackers; there is credible public reporting.",
+      },
+    ],
+  };
 
   return (
     <Box sx={{ m: 1 }}>
       <Grid container spacing={1}>
-        {decisionPoints.map((decisionPoint) => (
-          <Grid key={decisionPoint.name} item xs={6}>
-            <Card variant="outlined" sx={{ p: 3, height: "100%" }}>
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  mb: 1,
-                }}
-              >
-                <Typography sx={{ fontWeight: "bold", pr: 0.5 }}>{decisionPoint.name}</Typography>
-                <Tooltip title={decisionPoint.description}>
-                  <HelpOutlineOutlinedIcon color="action" fontSize="small" />
-                </Tooltip>
-              </Box>
-              <ToggleButtonGroup
-                color="primary"
-                value={decisionPoint.values[0].name}
-                sx={{ mb: 1 }}
-              >
-                {decisionPoint.values.map((value) => (
-                  <ToggleButton key={value.name} value={value.name} disabled>
-                    {value.name}
-                  </ToggleButton>
-                ))}
-              </ToggleButtonGroup>
-              <Typography variant="body2" color="textSecondary">
-                {decisionPoint.values[0].description}
-              </Typography>
-            </Card>
-          </Grid>
-        ))}
+        <TopicSSVCElement
+          title={automatableDescription.title}
+          titleDescription={automatableDescription.titleDescription}
+          values={automatableDescription.values}
+          value={automatable}
+        />
+        <TopicSSVCElement
+          title={exploitationDescription.title}
+          titleDescription={exploitationDescription.titleDescription}
+          values={exploitationDescription.values}
+          value={exploitation}
+        />
       </Grid>
     </Box>
   );
 }
+TopicSSVCCards.propTypes = {
+  exploitation: PropTypes.string.isRequired,
+  automatable: PropTypes.string.isRequired,
+};

--- a/web/src/components/TopicSSVCCards.jsx
+++ b/web/src/components/TopicSSVCCards.jsx
@@ -1,0 +1,92 @@
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import {
+  Box,
+  Card,
+  Grid,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import React from "react";
+
+export function TopicSSVCCards() {
+  const decisionPoints = [
+    {
+      name: "Automatable",
+      description:
+        "Can an attacker reliably automate creating exploitation events for this vulnerability?",
+      values: [
+        {
+          name: "No",
+          description:
+            "No: Attackers cannot reliably automate steps 1-4 of the kill chain for this vulnerability. These steps are (1) reconnaissance, (2) weaponization, (3) delivery, and (4) exploitation.",
+        },
+        {
+          name: "Yes",
+          description: "Yes: Attackers can reliably automate steps 1-4 of the kill chain.",
+        },
+      ],
+    },
+    {
+      name: "Exploitation",
+      description: "The present state of exploitation of the vulnerability.",
+      values: [
+        {
+          name: "None",
+          description:
+            "None: There is no evidence of active exploitation and no public proof of concept (PoC) of how to exploit the vulnerability.",
+        },
+        {
+          name: "Public PoC",
+          description:
+            "Public PoC: One of the following is true: (1) Typical public PoC exists in sources such as Metasploit or websites like ExploitDB; or (2) the vulnerability has a well-known method of exploitation.",
+        },
+        {
+          name: "Active",
+          description:
+            "Active: Shared, observable, reliable evidence that the exploit is being used in the wild by real attackers; there is credible public reporting.",
+        },
+      ],
+    },
+  ];
+
+  return (
+    <Box sx={{ m: 1 }}>
+      <Grid container spacing={1}>
+        {decisionPoints.map((decisionPoint) => (
+          <Grid key={decisionPoint.name} item xs={6}>
+            <Card variant="outlined" sx={{ p: 3, height: "100%" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  mb: 1,
+                }}
+              >
+                <Typography sx={{ fontWeight: "bold", pr: 0.5 }}>{decisionPoint.name}</Typography>
+                <Tooltip title={decisionPoint.description}>
+                  <HelpOutlineOutlinedIcon color="action" fontSize="small" />
+                </Tooltip>
+              </Box>
+              <ToggleButtonGroup
+                color="primary"
+                value={decisionPoint.values[0].name}
+                sx={{ mb: 1 }}
+              >
+                {decisionPoint.values.map((value) => (
+                  <ToggleButton key={value.name} value={value.name} disabled>
+                    {value.name}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+              <Typography variant="body2" color="textSecondary">
+                {decisionPoint.values[0].description}
+              </Typography>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+}

--- a/web/src/pages/TopicDetail.jsx
+++ b/web/src/pages/TopicDetail.jsx
@@ -6,11 +6,12 @@ import {
 } from "@mui/icons-material";
 import { Badge, Box, Button, Card, Chip, MenuItem, Tooltip, Typography } from "@mui/material";
 import { amber, green, grey, orange, red, yellow } from "@mui/material/colors";
-import React, { Fragment, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import { ActionTypeIcon } from "../components/ActionTypeIcon";
+import { TopicSSVCCards } from "../components/TopicSSVCCards";
 import { getTopic, getActions } from "../slices/topics";
 import { threatImpactNames, threatImpactProps } from "../utils/const";
 
@@ -198,6 +199,8 @@ export function TopicDetail() {
             )}
           </Box>
         </Card>
+        {/* SSVC decision points */}
+        <TopicSSVCCards />
         {/* MISP Tag */}
         <Card variant="outlined" sx={{ margin: 1 }}>
           <Box sx={{ margin: 3 }}>

--- a/web/src/pages/TopicDetail.jsx
+++ b/web/src/pages/TopicDetail.jsx
@@ -200,7 +200,7 @@ export function TopicDetail() {
           </Box>
         </Card>
         {/* SSVC decision points */}
-        <TopicSSVCCards />
+        <TopicSSVCCards exploitation={topic.exploitation} automatable={topic.automatable} />
         {/* MISP Tag */}
         <Card variant="outlined" sx={{ margin: 1 }}>
           <Box sx={{ margin: 3 }}>


### PR DESCRIPTION
## PR の目的

Topic詳細画面にSSVC関連の情報を表示するための改修

## 経緯・意図・意思決定

Topic詳細画面に`Automatable`と`Exploitation`の情報を表示するカードを追加

## 補足情報
- 現在、アクティブステータスと説明文は
`TopicSSVCCards.jsx` `L14`の`decisionPoints`の最初の項目に固定
- [開発者追記] Topicが持つAutomatable、Exploitationを選択状態に指定
