### PR TITLE
change timeout time in vulnrichment2tc

### DIFF
--- a/scripts/vulnrichment2tc.py
+++ b/scripts/vulnrichment2tc.py
@@ -80,7 +80,7 @@ class ThreatconnectomeClient:
                 resp = _func(headers=self.headers)
             except requests.exceptions.Timeout as error:
                 if _retry == 0:
-                    raise error
+                    raise APIError(f"ERROR: Exceeded retry max: {error}")
                 elif _retry > 0:
                     _retry -= 1
                 sleep(3)
@@ -242,7 +242,7 @@ def main() -> None:
         args.url,
         refresh_token,
         retry_max=3,
-        connect_timeout=6.0,
+        connect_timeout=60.0,
         read_timeout=60.0,
     )
 


### PR DESCRIPTION
## PR の目的
- vulnrichment2tcのタイムアウト処理を改善する。
  - connect_timeoutを3秒としていたが、60秒に変更する。
  - タイムアウトでリトライ3回失敗した時のエラーメッセージにおいて、リトライしたことが分かるメッセージに改善する

## 経緯・意図・意思決定
接続に30秒かかるケースがあった。