### PR TITLE
set timeout to TC API in trivydb2tc

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -177,6 +177,8 @@ class ThreatconnectomeClient:
     api_url: str
     refresh_token: str
     retry_max: int  # 0 for never, negative for forever
+    connect_timeout: float
+    read_timeout: float
     headers: dict
 
     def __init__(
@@ -184,18 +186,22 @@ class ThreatconnectomeClient:
         api_url: str,
         refresh_token: str,
         retry_max: int = -1,
+        connect_timeout: float = 60.0,
+        read_timeout: float = 60.0,
     ):
         self.api_url = api_url.rstrip("/")
         self.refresh_token = refresh_token
         self.retry_max = retry_max
-        self.headers = self.refresh_auth_token(
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.headers = self._refresh_auth_token(
             {  # headers except auth token
                 "accept": "application/json",
                 "Content-Type": "application/json",
             }
         )
 
-    def refresh_auth_token(self, headers: dict) -> dict:
+    def _refresh_auth_token(self, headers: dict) -> dict:
         resp = requests.post(
             f"{self.api_url}/auth/refresh",
             headers={"ContentType": "application/json"},
@@ -207,7 +213,7 @@ class ThreatconnectomeClient:
             "Authorization": f"Bearer {new_token}",
         }
 
-    def retry_call(
+    def _retry_call(
         self,
         func: Callable[..., requests.Response],
         *args,
@@ -217,6 +223,7 @@ class ThreatconnectomeClient:
         #   func should have kwarg "headers":
         #     def func(*args, **kwargs, headers={}) -> Response:
         #   self.headers is used for kwarg "headers", and auto-refreshed on 401 error.
+        kwargs["timeout"] = (self.connect_timeout, self.read_timeout)
         _retry = self.retry_max
         _in_auth_retry = False
         _func = partial(func, *args, **{k: v for k, v in kwargs.items() if k != "headers"})
@@ -226,14 +233,22 @@ class ThreatconnectomeClient:
             return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
 
         while True:
-            resp = _func(headers=self.headers)
+            try:
+                resp = _func(headers=self.headers)
+            except requests.exceptions.Timeout as error:
+                if _retry == 0:
+                    raise APIError(f"ERROR: Exceeded retry max: {error}")
+                elif _retry > 0:
+                    _retry -= 1
+                sleep(3)
+                continue
             if resp.status_code in {200, 204}:
                 return resp
             if resp.status_code == 401:
                 if _in_auth_retry:
                     raise APIError(f"ERROR: {_resp_to_msg(resp)}")
                 _in_auth_retry = True
-                self.headers = self.refresh_auth_token(self.headers)
+                self.headers = self._refresh_auth_token(self.headers)
                 continue
             if resp.status_code < 500:
                 # unrecoverable error: raise without retry
@@ -246,17 +261,17 @@ class ThreatconnectomeClient:
             sleep(3)
 
     def get_topics(self) -> dict:
-        response = self.retry_call(requests.get, f"{self.api_url}/topics")
+        response = self._retry_call(requests.get, f"{self.api_url}/topics")
         return response.json()
 
     def get_topic(self, topic_id) -> dict:
-        response = self.retry_call(requests.get, f"{self.api_url}/topics/{topic_id}")
+        response = self._retry_call(requests.get, f"{self.api_url}/topics/{topic_id}")
         return response.json()
 
     def create_tag(self, tag_name: str) -> None:
         api_endpoint = f"{self.api_url}/tags"
         print(f"Post {api_endpoint} to create tag: {tag_name}")
-        response = self.retry_call(requests.post, api_endpoint, json={"tag_name": tag_name})
+        response = self._retry_call(requests.post, api_endpoint, json={"tag_name": tag_name})
         print(f"Http status: {response.status_code} {response.reason}")
 
     def with_auto_create_tags(
@@ -281,7 +296,7 @@ class ThreatconnectomeClient:
     def _create_topic(self, topic_id: str, topic: dict) -> None:
         api_endpoint = f"{self.api_url}/topics/{topic_id}"
         print(f"Post {api_endpoint}")
-        response = self.retry_call(requests.post, api_endpoint, json=topic)
+        response = self._retry_call(requests.post, api_endpoint, json=topic)
         print(f"Http status: {response.status_code} {response.reason}")
 
     def create_topic(self, topic_id: str, topic: dict) -> None:
@@ -290,13 +305,13 @@ class ThreatconnectomeClient:
     def _update_topic_and_actions(self, topic_id: str, topic: dict) -> None:
         api_endpoint = f"{self.api_url}/topics/{topic_id}"
         print(f"Put {api_endpoint}")
-        response = self.retry_call(requests.put, api_endpoint, json=topic)
+        response = self._retry_call(requests.put, api_endpoint, json=topic)
         print(f"Http status: {response.status_code} {response.reason}")
         for action in topic.get("actions") or []:
             try:
                 api_endpoint = f"{self.api_url}/actions"
                 print(f"Post {api_endpoint}")
-                response = self.retry_call(
+                response = self._retry_call(
                     requests.post, api_endpoint, json={**action, "topic_id": topic_id}
                 )
                 print(f"Http status: {response.status_code} {response.reason}")
@@ -304,7 +319,7 @@ class ThreatconnectomeClient:
                 if str(error) == "ERROR: 400: Bad Request: Action id already exists":
                     api_endpoint = f"{self.api_url}/actions/{action['action_id']}"
                     print(f"Put {api_endpoint}")
-                    self.retry_call(requests.put, api_endpoint, json=action)
+                    self._retry_call(requests.put, api_endpoint, json=action)
                     print(f"Http status: {response.status_code} {response.reason}")
                 else:
                     raise error
@@ -552,7 +567,13 @@ def main() -> None:
                 "actions": actions,
             }
 
-    tc_client = ThreatconnectomeClient(args.url, refresh_token, retry_max=3)
+    tc_client = ThreatconnectomeClient(
+        args.url,
+        refresh_token,
+        retry_max=3,
+        connect_timeout=60.0,
+        read_timeout=60.0,
+    )
     data = tc_client.get_topics()
     if len(data) > 0 and not args.update:
         sample_topic = tc_client.get_topic(data[0]["topic_id"])

--- a/scripts/vulnrichment2tc.py
+++ b/scripts/vulnrichment2tc.py
@@ -29,7 +29,7 @@ class ThreatconnectomeClient:
         api_url: str,
         refresh_token: str,
         retry_max: int = -1,
-        connect_timeout: float = 3.0,
+        connect_timeout: float = 60.0,
         read_timeout: float = 60.0,
     ):
         self.api_url = api_url.rstrip("/")


### PR DESCRIPTION
## PR の目的
- trivydb2tc において、threatconnectomeのAPIを実行する際にタイムアウトを設定する。
  - タイムアウト時間を過ぎた場合は、３秒後にリトライする。リトライ回数は３回。
  - タイムアウト時間(秒)
connect_timeout=60.0
read_timeout=60.0

## 経緯・意図・意思決定
本番環境でvlunrichment2tc を実行した際、API実行で応答が帰らないケースがあった。
デモ環境でtrivydb2tc 、vlunrichment2tcが接続タイムアウトすることがあった。この際、接続に30秒かかるケースがあった。
vulnrichment2tcで同様の修正を実施済。
