### PR TITLE
topic/Improved performance of handleUpdateTopic in TopicModal.jsx

### DIFF
--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -216,6 +216,14 @@ export function TopicModal(props) {
 
     const presetActionIds = new Set(presetActions.map((a) => a.action_id));
 
+    const data = {
+      title: title,
+      abstract: abst,
+      threat_impact: parseInt(threatImpact),
+      tags: allTags.filter((tag) => tagIds.includes(tag.tag_id)).map((tag) => tag.tag_name),
+      misp_tags: mispTags?.length > 0 ? mispTags.split(",").map((mispTag) => mispTag.trim()) : [],
+    };
+
     function getNeedUpdateTopic() {
       const presetMispTag = src?.misp_tags?.map((misp_tag) => misp_tag.tag_name).join(",");
 
@@ -241,11 +249,14 @@ export function TopicModal(props) {
       return JSON.stringify(data) !== JSON.stringify(presetData) && src.created_by === user.user_id;
     }
 
-    function getNeedUpdateAction(currentActionIds, presetActionIdsArray) {
+    function getNeedUpdateAction(_actions, _presetActionIds) {
+      const currentActionIds = _actions.map((action) => action.action_id);
+      const presetActionIdsArray = [..._presetActionIds];
+
       if (!arrayComparison(currentActionIds, presetActionIdsArray)) return true;
 
-      for (let i = 0; i < actions.length; i++) {
-        if (actions[i].recommended !== presetActions[i].recommended) {
+      for (let i = 0; i < _actions.length; i++) {
+        if (_actions[i].recommended !== presetActions[i].recommended) {
           return true;
         }
       }
@@ -286,18 +297,7 @@ export function TopicModal(props) {
       return Promise.all(promiseArray);
     }
 
-    const data = {
-      title: title,
-      abstract: abst,
-      threat_impact: parseInt(threatImpact),
-      tags: allTags.filter((tag) => tagIds.includes(tag.tag_id)).map((tag) => tag.tag_name),
-      misp_tags: mispTags?.length > 0 ? mispTags.split(",").map((mispTag) => mispTag.trim()) : [],
-    };
-
-    const currentActionIds = actions.map((action) => action.action_id);
-    const presetActionIdsArray = [...presetActionIds];
-
-    const needUpdateAction = getNeedUpdateAction(currentActionIds, presetActionIdsArray);
+    const needUpdateAction = getNeedUpdateAction(actions, presetActionIds);
     const needUpdateTopic = getNeedUpdateTopic();
 
     if (needUpdateAction) {

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -106,3 +106,18 @@ export const compareSSVCPriority = (prio1, prio2) => {
   else if (int1 < int2) return -1;
   else return 1;
 };
+
+export const arrayComparison = (array1, array2) => {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+  const sortedArray1 = array1.slice().sort();
+  const sortedArray2 = array2.slice().sort();
+
+  for (let i = 0; i < sortedArray1.length; i++) {
+    if (sortedArray1[i] !== sortedArray2[i]) {
+      return false;
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
## PR の目的
- TopicModal.jsxのhandleUpdateTopicの性能改善を行いました。
- 現状
　- actionが追加削除されて場合、topicを更新する必要がないが、action追加削除だけしたくても実装上updateTopicが動作する。またtopicのみ更新したい場合も、updateaction, createactionが動作する。
- 実装後
   - フラグで管理し、actionのみの場合、topicのみの場合、action,topic両方の場合の3つに場合分けしました

## 経緯・意図・意思決定
- fuction getNeedUpdateTopic
   - Topicに関するパラメータの前回値と今回値を比較し、違いがあった場合trueを返します
- function getNeedUpdateAction
   - Actionに関するパラメータの前回値と今回値を比較し、違いがあった場合trueを返します。actionIdが同じでrecommendの値が違っていた場合もtrueを返すようにしています。
 - function updateTopicPromise
    - updateTopic APIを非同期で処理しています。
 - function updateActionPromise
    - actionに関するAPIを非同期で処理しています。
    - awaitをforEach内で使用していた部分をやめてpromise.allで処理するように変更しました。