### PR TITLE
fix ssvc_priority in alert

### DIFF
--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -66,7 +66,7 @@ def create_mail_alert_for_new_topic(
             "A new topic created.",
             "",
             f"Title: {topic_title}",
-            f"ThreatImpact: {ssvc_priority_label}",
+            f"SSVC Priority: {ssvc_priority_label}",
             "",
             f"PTeam: {pteam_name}",
             f"Services: {', '.join(services)}",

--- a/api/app/alert.py
+++ b/api/app/alert.py
@@ -45,7 +45,7 @@ def _pteam_service_tab_link(pteam_id: UUID | str, service_id: UUID | str) -> str
 
 def create_mail_alert_for_new_topic(
     topic_title: str,
-    threat_impact: int,
+    ssvc_priority: models.SSVCDeployerPriorityEnum,
     pteam_name: str,
     pteam_id: UUID | str,
     tag_name: str,  # should be pteamtag, not topictag
@@ -54,19 +54,19 @@ def create_mail_alert_for_new_topic(
 ) -> tuple[str, str]:  # subject, body
     # TODO
     # this mail-spacific-method should be divided away from this file, but to where?
-    threat_impact_label = {
-        1: "Immediate",
-        2: "Off-cycle",
-        3: "Acceptable",
-        4: "None",
-    }.get(threat_impact) or "WrongThreatImpact"
-    subject = f"[Tc Alert] {threat_impact_label}: {topic_title}"
+    ssvc_priority_label = {
+        models.SSVCDeployerPriorityEnum.IMMEDIATE: "Immediate",
+        models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE: "Out-of-cycle",
+        models.SSVCDeployerPriorityEnum.SCHEDULED: "Scheduled",
+        models.SSVCDeployerPriorityEnum.DEFER: "Defer",
+    }.get(ssvc_priority) or "Defer"
+    subject = f"[Tc Alert] {ssvc_priority_label}: {topic_title}"
     body = "<br>".join(
         [
             "A new topic created.",
             "",
             f"Title: {topic_title}",
-            f"ThreatImpact: {threat_impact_label}",
+            f"ThreatImpact: {ssvc_priority_label}",
             "",
             f"PTeam: {pteam_name}",
             f"Services: {', '.join(services)}",
@@ -93,13 +93,6 @@ def send_alert_to_pteam(alert: models.Alert) -> None:
     if not alert_by_slack and not alert_by_mail:
         return None
 
-    tmp_threat_impact = {  # WORKAROUND
-        models.SSVCDeployerPriorityEnum.IMMEDIATE: 1,
-        models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE: 2,
-        models.SSVCDeployerPriorityEnum.SCHEDULED: 3,
-        models.SSVCDeployerPriorityEnum.DEFER: 4,
-    }.get(ticket.ssvc_deployer_priority, 4)
-
     if alert_by_slack:
         try:
             slack_message_blocks = create_slack_pteam_alert_blocks_for_new_topic(
@@ -109,7 +102,7 @@ def send_alert_to_pteam(alert: models.Alert) -> None:
                 tag.tag_name,
                 topic.topic_id,
                 topic.title,  # WORKAROUND
-                tmp_threat_impact,  # WORKAROUND
+                ticket.ssvc_deployer_priority,
                 [service.service_name],  # WORKAROUND
             )
             send_slack(pteam.alert_slack.webhook_url, slack_message_blocks)
@@ -120,7 +113,7 @@ def send_alert_to_pteam(alert: models.Alert) -> None:
         try:
             mail_subject, mail_body = create_mail_alert_for_new_topic(
                 topic.title,  # WORKAROUND
-                tmp_threat_impact,  # WORKAROUND
+                ticket.ssvc_deployer_priority,
                 pteam.pteam_name,
                 pteam.pteam_id,
                 tag.tag_name,

--- a/api/app/slack.py
+++ b/api/app/slack.py
@@ -6,17 +6,19 @@ from fastapi import HTTPException, status
 from slack_sdk.errors import SlackApiError
 from slack_sdk.webhook import WebhookClient
 
+from app import models
+
 WEBUI_URL = os.getenv("WEBUI_URL", "http://localhost")
 WEBUI_URL += "" if WEBUI_URL.endswith("/") else "/"  # for the case baseurl has subpath
 # CAUTION: do *NOT* urljoin subpath which starts with "/"
 STATUS_URL = urljoin(WEBUI_URL, "")
 TAG_URL = urljoin(WEBUI_URL, "tags/")
 ANALYSIS_URL = urljoin(WEBUI_URL, "analysis/")
-THREAT_IMPACT_LABEL = {
-    1: ":red_circle: Immediate",
-    2: ":large_orange_circle: Off-cycle",
-    3: ":large_yellow_circle: Acceptable",
-    4: ":white_circle: None",
+SSVC_PRIORITY_LABEL = {
+    models.SSVCDeployerPriorityEnum.IMMEDIATE: ":red_circle: Immediate",
+    models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE: ":large_orange_circle: Out-of-cycle",
+    models.SSVCDeployerPriorityEnum.SCHEDULED: ":large_yellow_circle: Scheduled",
+    models.SSVCDeployerPriorityEnum.DEFER: ":white_circle: Defer",
 }
 
 
@@ -56,7 +58,7 @@ def create_slack_pteam_alert_blocks_for_new_topic(
     tag_name: str,
     topic_id: str,
     title: str,
-    threat_impact: int,
+    ssvc_priority: models.SSVCDeployerPriorityEnum,
     services: list[str],
 ):
     blocks: list[dict[str, str | dict[str, str] | list[dict[str, str]]]]
@@ -73,7 +75,7 @@ def create_slack_pteam_alert_blocks_for_new_topic(
                             f"*<{TAG_URL}{str(tag_id)}?pteamId={pteam_id}|{tag_name}>*",
                             f"*{title}*",
                             f"*{services_name}*",
-                            THREAT_IMPACT_LABEL[threat_impact],
+                            SSVC_PRIORITY_LABEL[ssvc_priority],
                         ]
                     ),
                 },

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -1,6 +1,7 @@
+from app import models
 from app.slack import (
+    SSVC_PRIORITY_LABEL,
     TAG_URL,
-    THREAT_IMPACT_LABEL,
     create_slack_pteam_alert_blocks_for_new_topic,
 )
 
@@ -13,7 +14,7 @@ def test_create_blocks_for_pteam():
         "tag_id": "dd313aab-68aa-4dc4-8362-cec093d5d49b",
         "topic_id": "b1f74d1f-9360-4a8d-86ac-3cf5dd20c75c",
         "title": "test_title1",
-        "threat_impact": 1,
+        "ssvc_priority": models.SSVCDeployerPriorityEnum.IMMEDIATE,
         "services": ["test1_service", "test2_service"],
     }
 
@@ -22,5 +23,5 @@ def test_create_blocks_for_pteam():
     tag_page_url = f"{TAG_URL}{notification_data['tag_id']}?pteamId={notification_data['pteam_id']}"
     assert tag_page_url in blocks[2]["text"]["text"]
     assert notification_data["title"] in blocks[2]["text"]["text"]
-    assert THREAT_IMPACT_LABEL[notification_data["threat_impact"]] in blocks[2]["text"]["text"]
+    assert SSVC_PRIORITY_LABEL[notification_data["ssvc_priority"]] in blocks[2]["text"]["text"]
     assert notification_data["services"][0] in blocks[2]["text"]["text"]


### PR DESCRIPTION
## PR の目的
- アラート判定はThreatImpactからssvc_priorytyに変更したはずだが、slack上にssvc_priorytyにない「None」で通知が来る問題を修正する
  - 原因として、アラート判定はssvc_priorytyだが、アラート通知内容はssvc_priorytyをThreatImpactにマッピングした文字列としていた。