### PR TITLE
bugfix/fix warning in status screen

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -158,5 +158,5 @@ PTeamServiceDetails.propTypes = {
   service: PropTypes.object.isRequired,
   expandService: PropTypes.bool.isRequired,
   onSwitchExpandService: PropTypes.func.isRequired,
-  highestSsvcPriority: PropTypes.object.isRequired,
+  highestSsvcPriority: PropTypes.string.isRequired,
 };

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -108,5 +108,5 @@ export function PTeamStatusSSVCCards(props) {
 
 PTeamStatusSSVCCards.propTypes = {
   service: PropTypes.object.isRequired,
-  highestSsvcPriority: PropTypes.object.isRequired,
+  highestSsvcPriority: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- status画面でリロードするとサービスのSSVC表示においてconsoleに警告文が表示される問題を解決しました
- 警告文
  - `Status.jsx:440 Warning: Failed prop type: Invalid prop highestSsvcPriority of type string supplied to PTeamServiceDetails, expected object.`

## 経緯・意図・意思決定
- PTeamServiceDetails.jsxやPTeamStatusSSVCCards.jsxにhighestSsvcPriorityをstring型で渡しているのに、object型として定義していました
- objectと書かれていた部分をstringに修正しました
