### PR TITLE
de-duplicating alerts

### DIFF
--- a/api/app/common.py
+++ b/api/app/common.py
@@ -562,9 +562,8 @@ def fix_tickets_for_service(db: Session, service: models.Service):
     now = datetime.now()
     for ticket in service.tickets:
         fixed_priority = ssvc_calculator.calculate_ssvc_priority_by_threat(ticket.threat)
-        # TODO: omit redundant alerts
-        # if fixed_priority == ticket.ssvc_deployer_priority:
-        #     continue
+        if fixed_priority == ticket.ssvc_deployer_priority:
+            continue
         ticket.ssvc_deployer_priority = fixed_priority
         # omit flush -- should be flushed in create_alert
         if ticket_meets_condition_to_create_alert(ticket):

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -424,6 +424,8 @@ def update_topic(
             ticket = threat.ticket
             if ticket is not None:
                 _ssvc_deployer_priority = ssvc_calculator.calculate_ssvc_priority_by_threat(threat)
+                if _ssvc_deployer_priority == ticket.ssvc_deployer_priority:
+                    continue
                 ticket.ssvc_deployer_priority = _ssvc_deployer_priority
 
                 if (


### PR DESCRIPTION
## PR の目的
- 過去にアラート発行済のTicketに紐づくSSVC入力情報を変更した場合のアラート発行条件について、以下の仕様とする
  - SVCC計算の入力データ(exploitationなど)変更時において、変更前後でssvc_priorytyに変化があった場合(例：out_of_cycle→immediate)は、前回アラート発行済であっても再度アラートを発行する。
  - 上記の場合、ssvc_priorytyが影響軽微側に変化した場合でも、再アラートする。
　(例：Alert thresholdがout_of_cycleであり、今回操作でimmediate→out_of_cycle)
  - SVCC計算の入力データ(exploitationなど)変更時において、ssvc_priorytyに変化が無ければ再アラート発行しない。
※本PRでは３件目の条件において、従来はアラート発行していたのを修正する

## 経緯・意図・意思決定
  - テストの修正について
test_topics.py、test_pteams.pyにおいて、既存テストにSSVC入力情報を変更した場合にアラート発行を確認するテストがあったが、本修正によりssvc_priorytyに変化が無い場合はアラート発行しないよう変更されたため、ssvc_priorytyが変化するよう更新値を変更した。
また、この理由からアラート閾値もimmediateからout_of_cycleに変更した。
アラート閾値の変更により、既存の閾値を下回るテストについてもssvc_priorytyが新しい閾値以下となるよう更新値を変更した。
その他、今回の修正確認として、SSVC入力情報は変更するがssvc_priorytyは変化しない場合にアラート発行しないことを確認するテストを追加した。
