### PR TITLE
fix StatusRatioGraph for defer

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -77,14 +77,8 @@ function DisableLine() {
 
 function StatusRatioGraph(props) {
   const { counts, ssvcPriority } = props;
-  if ((counts ?? []).length === 0) return "";
-  let keys = [];
-  if (
-    compareSSVCPriority(ssvcPriority, "defer") < 0 ||
-    (compareSSVCPriority(ssvcPriority, "defer") === 0 && counts.completed > 0)
-  ) {
-    keys = ["completed", "scheduled", "acknowledged", "alerted"];
-  }
+  if (!ssvcPriority && (counts ?? []).length === 0) return "";
+  const keys = ["completed", "scheduled", "acknowledged", "alerted"];
   const total = keys.reduce((ret, key) => ret + counts[key] ?? 0, 0);
   const ratios = keys.reduce((ret, key) => {
     ret[key] = (100 * (counts[key] ?? 0)) / total;
@@ -115,7 +109,7 @@ export function PTeamStatusCard(props) {
   const { onHandleClick, pteam, tag, serviceIds } = props;
 
   const ssvcPriority = // detect "safe"
-    ["defer", null].includes(tag.ssvc_priority) && tag.status_count["completed"] > 0
+    !tag.ssvc_priority && tag.status_count["completed"] > 0
       ? "safe" // solved all and at least 1 tickets
       : tag.ssvc_priority || "defer";
   // Change the background color and border based on the Alert Threshold value set by the team.
@@ -158,10 +152,7 @@ export function PTeamStatusCard(props) {
               {`Updated ${calcTimestampDiff(tag.updated_at)}`}
             </Typography>
           </Box>
-          <StatusRatioGraph
-            counts={tag.status_count ?? []}
-            ssvcPriority={tag.ssvc_priority || "defer"}
-          />
+          <StatusRatioGraph counts={tag.status_count} ssvcPriority={tag.ssvc_priority} />
         </Box>
       </TableCell>
     </TableRow>


### PR DESCRIPTION
## PR の目的

- Status ページの progress bar を改修
  - チケットが無い場合はプログレスバーを表示しない
    - 改修前はチケットが無くてもグレー一色のバーが表示されていたが、これはバグだった模様。
  - チケットがある場合は、artifact の highest priority に関わらずプログレスバーを表示
    - artifact のソートキーに updated_at が含まれるのでチケットがある artifact は defer の先頭に配置される

![image](https://github.com/user-attachments/assets/b122fbed-cf71-431f-a61c-aac916896afa)
