### PR TITLE
Add a feature to set the user who made the request in the ticket as the assignee.

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -671,8 +671,8 @@ def set_ticket_status(
         # this is the first update
         if data.topic_status is None:
             data.topic_status = models.TopicStatusType.acknowledged
-    # avoid AttributionError
     if (
+        # there is no ticket_status in initial state
         ticket.current_ticket_status.ticket_status is None
         or ticket.current_ticket_status.ticket_status.assignees == []
     ) and data.assignees is None:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -671,8 +671,12 @@ def set_ticket_status(
         # this is the first update
         if data.topic_status is None:
             data.topic_status = models.TopicStatusType.acknowledged
-        if data.topic_status == models.TopicStatusType.acknowledged and not data.assignees:
-            data.assignees = [UUID(current_user.user_id)]
+    # avoid AttributionError
+    if (
+        ticket.current_ticket_status.ticket_status is None
+        or ticket.current_ticket_status.ticket_status.assignees == []
+    ) and data.assignees is None:
+        data.assignees = [UUID(current_user.user_id)]
 
     # create base status inheriting current status
     if _current := current_ticket_status.ticket_status:

--- a/api/app/tests/medium/routers/test_ateams.py
+++ b/api/app/tests/medium/routers/test_ateams.py
@@ -1822,7 +1822,7 @@ def test_get_topic_status():
     assert st221["scheduled_at"] is None
     st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
-    assert st222["assignees"] == []
+    assert st222["assignees"] == list(map(str, [user1.user_id]))
     assert datetime.fromisoformat(st222["scheduled_at"]) == datetime.fromisoformat(
         request["scheduled_at"]
     )
@@ -1853,7 +1853,7 @@ def test_get_topic_status():
     st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.scheduled
-    assert st211["assignees"] == []
+    assert st211["assignees"] == list(map(str, [user1.user_id]))
     assert datetime.fromisoformat(st211["scheduled_at"]) == datetime.fromisoformat(
         request["scheduled_at"]
     )
@@ -1868,7 +1868,7 @@ def test_get_topic_status():
     assert st221["scheduled_at"] is None
     st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
-    assert st222["assignees"] == []
+    assert st222["assignees"] == list(map(str, [user1.user_id]))
 
     # PTEAM2 complete TOPIC2 TAG1
     request = {
@@ -1896,13 +1896,13 @@ def test_get_topic_status():
     st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211
     assert st211["topic_status"] == models.TopicStatusType.scheduled
-    assert st211["assignees"] == []
+    assert st211["assignees"] == list(map(str, [user1.user_id]))
     tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
     assert len(tmp2["service_statuses"]) == 1
     st222 = _pick_tag(tmp2["service_statuses"], tag2.tag_id)
     assert st222["topic_status"] == models.TopicStatusType.scheduled
-    assert st222["assignees"] == []
+    assert st222["assignees"] == list(map(str, [user1.user_id]))
 
     # PTEAM2 complete TOPIC2 TAG2
     request = {
@@ -1927,7 +1927,7 @@ def test_get_topic_status():
     assert len(tmp1["service_statuses"]) == 1
     st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211["topic_status"] == models.TopicStatusType.scheduled
-    assert st211["assignees"] == []
+    assert st211["assignees"] == list(map(str, [user1.user_id]))
 
     # PTEAM2 ack TOPIC2 TAG1 again
     request = {
@@ -1953,13 +1953,13 @@ def test_get_topic_status():
     assert len(tmp1["service_statuses"]) == 1
     st211 = _pick_tag(tmp1["service_statuses"], tag1.tag_id)
     assert st211["topic_status"] == models.TopicStatusType.scheduled
-    assert st211["assignees"] == []
+    assert st211["assignees"] == list(map(str, [user1.user_id]))
     tmp2 = _pick_pteam(topic_statuses[0]["pteam_statuses"], pteam2.pteam_id)
     assert tmp2
     assert len(tmp2["service_statuses"]) == 1
     st221 = _pick_tag(tmp2["service_statuses"], tag1.tag_id)
     assert st221["topic_status"] == models.TopicStatusType.acknowledged
-    assert st221["assignees"] == []
+    assert st221["assignees"] == list(map(str, [user1.user_id]))
 
 
 class TestGetTopicStatusWithQueryParams:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3246,6 +3246,31 @@ class TestTicketStatus:
 
             assert get_response["scheduled_at"] is None
 
+        def test_it_should_set_requester_as_assignee_if_assignee_is_None_and_saved_assignee_is_empty(
+            self, actionable_topic1
+        ):
+            status_request = {
+                "topic_status": models.TopicStatusType.completed.value,
+                "assignees": None,
+                "note": "assign None",
+            }
+            url = (
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
+                f"/ticketstatus/{self.ticket_id1}"
+            )
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            response = client.post(url, headers=_headers, json=status_request)
+            if response.status_code != 200:
+                raise HTTPError(response)
+
+            data = response.json()
+            assert data["assignees"] == [str(self.user1.user_id)]
+
 
 class TestGetTickets:
 

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3246,7 +3246,7 @@ class TestTicketStatus:
 
             assert get_response["scheduled_at"] is None
 
-        def test_it_should_set_requester_as_assignee_if_assignee_is_None_and_saved_assignee_is_empty(
+        def test_it_should_set_requester_if_assignee_is_None_and_saved_assignee_is_empty(
             self, actionable_topic1
         ):
             status_request = {


### PR DESCRIPTION
## PR の目的
- チケットでリクエストされたAssigneesがNoneかつ現在保存されているAssigneesが空の場合、リクエストしたユーザーをAssigneesに設定する
   - 以下の条件のもと、(a or b) and cのときリクエストしたユーザーをAssigneesに設定
      - a) 現在のチケットステータスが初期状態
      - b) 現在のチケットのAssigneesが未設定
      - c) リクエストのAssigneesが未指定
- テストケースの修正 

## 経緯・意図・意思決定
- 現在チケットのAssigneesに何も設定されておらず、リクエストされたAssigneesもNoneの場合でも、Assigneesを設定する処理を行うため

## 参考文献
- https://gihyo.jp/article/2024/01/automated-test-and-tdd
- https://zenn.dev/miya_tech/articles/4e0de8046f88bf