### PR TITLE
Topic/change empty array of assignees to none

### DIFF
--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -67,7 +67,6 @@ export function ReportCompletedActions(props) {
       await setTicketStatus(pteamId, serviceId, ticketId, {
         topic_status: "completed",
         logging_ids: actionLogs.map((log) => log.logging_id),
-        assignees: None, // clear assignees
         note: note.trim() || null,
         scheduled_at: "1970-01-01T00:00:00", // FIXME: clear scheduled date
       });

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -67,7 +67,7 @@ export function ReportCompletedActions(props) {
       await setTicketStatus(pteamId, serviceId, ticketId, {
         topic_status: "completed",
         logging_ids: actionLogs.map((log) => log.logging_id),
-        assignees: [], // clear assignees
+        assignees: None, // clear assignees
         note: note.trim() || null,
         scheduled_at: "1970-01-01T00:00:00", // FIXME: clear scheduled date
       });


### PR DESCRIPTION
## PR の目的
- ReportCompletedActions.jsxのsetTicketStatusに対し、assigneesを空配列としてリクエストしている部分をNoneでリクエストする仕様に変更

## 経緯・意図・意思決定
- UI側でassigneesを空配列としてリクエストしてしまうと、既に設定されているassigneesが上書きされてしまうため

