### PR TITLE
チケットに「Safety Impact」を表示するUIのモック作成

### DIFF
--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -10,7 +10,7 @@ import { SSVCPriorityCountChip } from "./SSVCPriorityCountChip";
 import { TopicCard } from "./TopicCard";
 
 export function PTeamTaggedTopics(props) {
-  const { pteamId, tagId, serviceId, isSolved, references } = props;
+  const { pteamId, tagId, service, isSolved, references } = props;
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -18,7 +18,7 @@ export function PTeamTaggedTopics(props) {
   const taggedTopics = useSelector((state) => state.pteam.taggedTopics); // dispatched by parent
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
-  const targets = taggedTopics?.[serviceId]?.[tagId]?.[isSolved ? "solved" : "unsolved"];
+  const targets = taggedTopics?.[service?.service_id]?.[tagId]?.[isSolved ? "solved" : "unsolved"];
 
   if (targets === undefined || !allTags) {
     return <>Loading...</>;
@@ -72,7 +72,7 @@ export function PTeamTaggedTopics(props) {
         <PTeamStatusMenu
           presetTagId={presetTagId}
           presetParentTagId={presetParentTagId}
-          serviceId={serviceId}
+          serviceId={service.service_id}
         />
       </Box>
       {paginationRow}
@@ -84,7 +84,7 @@ export function PTeamTaggedTopics(props) {
               pteamId={pteamId}
               topicId={topicId}
               currentTagId={tagId}
-              serviceId={serviceId}
+              service={service}
               references={references}
             />
           </ListItem>
@@ -97,7 +97,7 @@ export function PTeamTaggedTopics(props) {
 PTeamTaggedTopics.propTypes = {
   pteamId: PropTypes.string.isRequired,
   tagId: PropTypes.string.isRequired,
-  serviceId: PropTypes.string.isRequired,
+  service: PropTypes.object.isRequired,
   isSolved: PropTypes.bool.isRequired,
   references: PropTypes.array.isRequired,
 };

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -34,7 +34,7 @@ import { TopicTicketAccordion } from "./TopicTicketAccordion";
 import { UUIDTypography } from "./UUIDTypography";
 
 export function TopicCard(props) {
-  const { pteamId, topicId, currentTagId, serviceId, references } = props;
+  const { pteamId, topicId, currentTagId, service, references } = props;
   const { tagId } = useParams();
 
   const [detailOpen, setDetailOpen] = useState(false);
@@ -48,6 +48,7 @@ export function TopicCard(props) {
   const topics = useSelector((state) => state.topics.topics);
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
+  const serviceId = service?.service_id;
   const dependencies = serviceDependencies[serviceId];
   const topic = topics[topicId];
   const tickets = ticketsDict[serviceId]?.[tagId]?.[topicId];
@@ -374,6 +375,7 @@ export function TopicCard(props) {
               )}
               topicId={topicId}
               ticket={ticket}
+              serviceSafetyImpact={service.safety_impact}
               members={members}
               defaultExpanded={index === 0}
               topicActions={topicActions}
@@ -389,6 +391,6 @@ TopicCard.propTypes = {
   pteamId: PropTypes.string.isRequired,
   topicId: PropTypes.string.isRequired,
   currentTagId: PropTypes.string.isRequired,
-  serviceId: PropTypes.string.isRequired,
+  service: PropTypes.object.isRequired,
   references: PropTypes.array.isRequired,
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -1,14 +1,21 @@
 import { CalendarMonth } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
   Box,
   CardActions,
+  Chip,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
   Typography,
 } from "@mui/material";
+import { tooltipClasses } from "@mui/material/Tooltip";
 import { grey } from "@mui/material/colors";
+import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -28,6 +35,27 @@ export const TopicTicketAccordion = (props) => {
   const target = dependency.target;
   const ticketStatus = ticket.current_ticket_status;
   const ssvcPriority = ticket.ssvc_deployer_priority || "defer";
+
+  const StyledTooltip = styled(({ className, ...props }) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ))(() => ({
+    [`& .${tooltipClasses.arrow}`]: {
+      "&:before": {
+        border: "1px solid #dadde9",
+      },
+      color: "#f5f5f9",
+    },
+    [`& .${tooltipClasses.tooltip}`]: {
+      backgroundColor: "#f5f5f9",
+      color: "rgba(0, 0, 0, 0.87)",
+      border: "1px solid #dadde9",
+    },
+  }));
+
+  const safetyImpact = {
+    description: "The safety impact of the vulnerability. (based on IEC 61508)",
+    values: ["Catastrophic", "Critical", "Marginal", "Negligible"],
+  };
 
   return (
     <Accordion
@@ -50,7 +78,45 @@ export const TopicTicketAccordion = (props) => {
         </Box>
       </AccordionSummary>
       <AccordionDetails>
-        <Box p={2} display="flex" flexDirection="row" alignItems="flex-start">
+        <Box p={2} display="flex" flexDirection="row" alignItems="center">
+          <Box sx={{ display: "flex", justifyContent: "start", minWidth: "110px", mr: 1 }}>
+            <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, mr: 0.5 }}>
+              Safety impact
+            </Typography>
+            <StyledTooltip
+              arrow
+              title={
+                <>
+                  <Typography variant="body2">{safetyImpact.description}</Typography>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "center",
+                      p: 1,
+                    }}
+                  >
+                    <ToggleButtonGroup
+                      color="primary"
+                      size="small"
+                      orientation="vertical"
+                      value={safetyImpact.values[0]}
+                    >
+                      {safetyImpact.values.map((value) => (
+                        <ToggleButton key={value} value={value} disabled>
+                          {value}
+                        </ToggleButton>
+                      ))}
+                    </ToggleButtonGroup>
+                  </Box>
+                </>
+              }
+            >
+              <HelpOutlineOutlinedIcon color="action" fontSize="small" />
+            </StyledTooltip>
+          </Box>
+          <Chip label={safetyImpact.values[0]} />
+        </Box>
+        <Box p={2} display="flex" flexDirection="row" alignItems="center">
           <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
             Status
           </Typography>

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -19,7 +19,12 @@ import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { systemAccount } from "../utils/const";
+import {
+  safetyImpactDescription,
+  safetyImpactProps,
+  sortedSafetyImpacts,
+  systemAccount,
+} from "../utils/const";
 import { dateTimeFormat } from "../utils/func";
 
 import { AssigneesSelector } from "./AssigneesSelector";
@@ -27,8 +32,17 @@ import { SSVCPriorityStatusChip } from "./SSVCPriorityStatusChip";
 import { TopicStatusSelector } from "./TopicStatusSelector";
 import { WarningTooltip } from "./WarningTooltip";
 
-export const TopicTicketAccordion = (props) => {
-  const { pteamId, dependency, topicId, ticket, members, defaultExpanded, topicActions } = props;
+export function TopicTicketAccordion(props) {
+  const {
+    pteamId,
+    dependency,
+    topicId,
+    ticket,
+    serviceSafetyImpact,
+    members,
+    defaultExpanded,
+    topicActions,
+  } = props;
 
   const serviceId = dependency.service_id;
   const tagId = dependency.tag_id;
@@ -52,10 +66,7 @@ export const TopicTicketAccordion = (props) => {
     },
   }));
 
-  const safetyImpact = {
-    description: "The safety impact of the vulnerability. (based on IEC 61508)",
-    values: ["Catastrophic", "Critical", "Marginal", "Negligible"],
-  };
+  const serviceSafetyImpactDisplayName = safetyImpactProps[serviceSafetyImpact].displayName;
 
   return (
     <Accordion
@@ -87,7 +98,7 @@ export const TopicTicketAccordion = (props) => {
               arrow
               title={
                 <>
-                  <Typography variant="body2">{safetyImpact.description}</Typography>
+                  <Typography variant="body2">{safetyImpactDescription}</Typography>
                   <Box
                     sx={{
                       display: "flex",
@@ -99,13 +110,16 @@ export const TopicTicketAccordion = (props) => {
                       color="primary"
                       size="small"
                       orientation="vertical"
-                      value={safetyImpact.values[0]}
+                      value={serviceSafetyImpactDisplayName}
                     >
-                      {safetyImpact.values.map((value) => (
-                        <ToggleButton key={value} value={value} disabled>
-                          {value}
-                        </ToggleButton>
-                      ))}
+                      {sortedSafetyImpacts.map((safetyImpact) => {
+                        const displayName = safetyImpactProps[safetyImpact].displayName;
+                        return (
+                          <ToggleButton key={safetyImpact} value={displayName} disabled>
+                            {displayName}
+                          </ToggleButton>
+                        );
+                      })}
                     </ToggleButtonGroup>
                   </Box>
                 </>
@@ -114,7 +128,7 @@ export const TopicTicketAccordion = (props) => {
               <HelpOutlineOutlinedIcon color="action" fontSize="small" />
             </StyledTooltip>
           </Box>
-          <Chip label={safetyImpact.values[0]} />
+          <Chip label={serviceSafetyImpactDisplayName} />
         </Box>
         <Box p={2} display="flex" flexDirection="row" alignItems="center">
           <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
@@ -184,13 +198,14 @@ export const TopicTicketAccordion = (props) => {
       </AccordionDetails>
     </Accordion>
   );
-};
+}
 
 TopicTicketAccordion.propTypes = {
   pteamId: PropTypes.string.isRequired,
   dependency: PropTypes.object.isRequired,
   topicId: PropTypes.string.isRequired,
   ticket: PropTypes.object.isRequired,
+  serviceSafetyImpact: PropTypes.string.isRequired,
   members: PropTypes.object.isRequired,
   defaultExpanded: PropTypes.bool,
   topicActions: PropTypes.array,

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -154,7 +154,7 @@ export function Tag() {
           <PTeamTaggedTopics
             pteamId={pteamId}
             tagId={tagId}
-            serviceId={serviceDict.service_id}
+            service={serviceDict}
             isSolved={false}
             references={references}
           />
@@ -163,7 +163,7 @@ export function Tag() {
           <PTeamTaggedTopics
             pteamId={pteamId}
             tagId={tagId}
-            serviceId={serviceDict.service_id}
+            service={serviceDict}
             isSolved={true}
             references={references}
           />

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -221,6 +221,39 @@ export const missionImpact = {
   degraded: "Degraded",
 };
 
+/* Safety Impact */
+export const safetyImpactDescription =
+  "The safety impact of the vulnerability. (based on IEC 61508)";
+export const sortedSafetyImpacts = [
+  // should match with strings which api returns
+  "catastrophic",
+  "critical",
+  "marginal",
+  "negligible",
+];
+const propSafetyImpactCatastrophic = {
+  displayName: "Catastrophic",
+};
+const propSafetyImpactCritical = {
+  displayName: "Critical",
+};
+const propSafetyImpactMarginal = {
+  displayName: "Marginal",
+};
+const propSafetyImpactNegligible = {
+  displayName: "Negligible",
+};
+export const safetyImpactProps = {
+  catastrophic: propSafetyImpactCatastrophic,
+  Catastrophic: propSafetyImpactCatastrophic,
+  critical: propSafetyImpactCritical,
+  Critical: propSafetyImpactCritical,
+  marginal: propSafetyImpactMarginal,
+  Marginal: propSafetyImpactMarginal,
+  negligible: propSafetyImpactNegligible,
+  Negligible: propSafetyImpactNegligible,
+};
+
 export const topicStatusProps = {
   alerted: {
     chipLabel: "alerted",


### PR DESCRIPTION
## PR の目的

チケットに「Safety Impact」を表示するための改修

## 経緯・意図・意思決定

- チケットのアコーディオン内に`Safety impact`の項目を追加し、現在のステータスを`Chip`で表示する
- タイトル横に`Tooltip`を設置し、hoverすると説明文とステータスの段階を表示する`ToggleButton`を表示

## 補足情報

- 見かけ上はチケットに紐づくが、実際には Service に設定された SafetyImpact を表示している
  - これを示す意味で変数名を serviceSafetyImpact としている
