### PR TITLE
Topic/change the structure of ssvc priority

### DIFF
--- a/web/src/components/SSVCPriorityStatusChip.jsx
+++ b/web/src/components/SSVCPriorityStatusChip.jsx
@@ -6,8 +6,8 @@ import React from "react";
 import { ssvcPriorityProps } from "../utils/const";
 
 export function SSVCPriorityStatusChip(props) {
-  const { ssvcPriority } = props;
-  const ssvcPriorityProp = ssvcPriorityProps[ssvcPriority];
+  const { displaySSVCPriority } = props;
+  const ssvcPriorityProp = ssvcPriorityProps[displaySSVCPriority];
 
   const Icon = ssvcPriorityProp.icon;
   const StyledTooltip = styled((styledProps) => (
@@ -38,5 +38,5 @@ export function SSVCPriorityStatusChip(props) {
 }
 
 SSVCPriorityStatusChip.propTypes = {
-  ssvcPriority: PropTypes.string.isRequired,
+  displaySSVCPriority: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -83,7 +83,7 @@ export function TopicTicketAccordion(props) {
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor: grey[50] }}>
         <Box sx={{ display: "flex", alignItems: "center" }}>
           <Box sx={{ mr: 1 }}>
-            <SSVCPriorityStatusChip ssvcPriority={ssvcPriority} />
+            <SSVCPriorityStatusChip displaySSVCPriority={ssvcPriority} />
           </Box>
           <Box sx={{ wordBreak: "break-all" }}>{target}</Box>
         </Box>

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -198,6 +198,8 @@ export const ssvcPriorityProps = {
   Defer: prop_defer,
   safe: prop_safe,
   Safe: prop_safe,
+  empty: prop_defer,
+  Empty: prop_defer,
 };
 export const defaultAlertThreshold = sortedSSVCPriorities[0];
 
@@ -221,6 +223,7 @@ export const missionImpact = {
   degraded: "Degraded",
 };
 
+export const sortedTopicStatus = ["alerted", "acknowledged", "scheduled", "completed"];
 export const topicStatusProps = {
   alerted: {
     chipLabel: "alerted",

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -100,6 +100,8 @@ export const compareSSVCPriority = (prio1, prio2) => {
     Defer: 4,
     safe: 4,
     Safe: 4,
+    empty: 4,
+    Empty: 4,
   };
   const [int1, int2] = [toIntDict[prio1], toIntDict[prio2]];
   if (int1 === int2) return 0;


### PR DESCRIPTION
## PR の目的
- statusページでチケットが無い場合は、Updated に - を表示するのでなく、Updated の表示自体を無くすようにしました
- PTeamStatusCard.jsxのssvcPriorityに関する構造を変更しました

## 経緯・意図・意思決定
- web/src/components/PTeamStatusCard.jsx
   - 現状コードでは、"defer"が「ticektを持つとき」と、「ticketを持つが現時点で対応しなくて良い」という2つの意味を持ってました。とても分かりづらいため「"defer"がticektを持つとき」はempyt、「ticketを持つが現時点で対応しなくて良い」はdeferに場合分けしました。
   - またssvcPriority は厳密にいうとsafe、emptyという要素を持っておりssvcではないため、変数名をssvcPriority→displaySsvcPriorityに変更しました。
   - displaySSVCPriorityがsafeかemptyの時に、Updatedを表示させないように三項演算子を使って条件分岐をさせました。
- web/src/components/SSVCPriorityStatusChip.jsx
   -   ssvcPriority→displaySsvcPriorityに変更しました。
- web/src/utils/const.js
   - ssvcPriorityPropsにemptyのstatusを持たせました。valueにはprop_deferを入れて、ユーザから見たときemptyとdeferの違いがないようにしました。
   - TopicStatusの項目を配列に入れたものを追加しました
- web/src/utils/func.js
   - SSVCPriorityの比較する部分にemptyを追加しました。deferと同じようにするためvalueに4を入れました。