### PR TITLE
de-duplicating getThumbnail

### DIFF
--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -167,6 +167,13 @@ const pteamSlice = createSlice({
         [action.payload.serviceId]: action.payload.data,
       },
     }),
+    storeServiceThumbnailDict: (state, action) => ({
+      ...state,
+      serviceThumbnails: {
+        ...state.serviceThumbnails,
+        ...action.payload,
+      },
+    }),
   },
   extraReducers: (builder) => {
     builder
@@ -242,6 +249,12 @@ const pteamSlice = createSlice({
 
 const { actions, reducer } = pteamSlice;
 
-export const { clearPTeam, setPTeamId, invalidateServiceId, storeServiceThumbnail } = actions;
+export const {
+  clearPTeam,
+  setPTeamId,
+  invalidateServiceId,
+  storeServiceThumbnail,
+  storeServiceThumbnailDict,
+} = actions;
 
 export default reducer;


### PR DESCRIPTION
## PR の目的
- Status画面において、[All Services]がONで複数のServiceを持つartifactを選択した際に表示されるService選択画面において、各Serviceのサムネイル画像取得APIを複数回実行していたのを、修正する。
  - 原因として、useEffect内のループ処理でServiceの数だけサムネイル画像を取得してsliceのthumbnailsにセットしていたが、useEffectの依存配列にthumbnailsを持つため、非同期実行された1Serviceの処理が終わる毎にuseEffectが再実行されていた。
  - 対策として、全Serviceのサムネイル画像を取得した後、一括してsliceのthumbnailsにセットする。

## 経緯・意図・意思決定
サービス毎のサブコンポーネントを作り、サブコンポーネント内で1サービスのuseEffectを作って依存配列に1つのthumbnailを指定することを試したが、sliceのthumbnailsに１つのthumbnailをセットした際に配列自体を再生成している関係で、他のサービスのthumbnailも変わったとみなされてuseEffectが再実行されてしまった。
そのため、上記対策を採用した。

