### PR TITLE
omit alerting wrong serviceId

### DIFF
--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -173,7 +173,6 @@ export function Status() {
       navigate(location.pathname + "?" + newParams.toString());
       return;
     } else if (!pteam.services.find((service) => service.service_id === serviceId)) {
-      alert("Invalid serviceId!");
       const newParams = new URLSearchParams();
       newParams.set("pteamId", pteamId);
       navigate("/?" + newParams.toString());


### PR DESCRIPTION
## PR の目的

- 不正なサービスID が指定され自動遷移する際のアラート表示を廃止。
  - 表示中のサービスを削除した際に、タイミングによってこのアラートが誤表示されることがあるため。
  - 本当にサービスID が誤っているケースでは、自動遷移していることに気付きにくくなる。