### PR TITLE
topic/add test of set_ticket_status_api

### DIFF
--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3210,7 +3210,7 @@ class TestTicketStatus:
                 ),
             ],
         )
-        def test_correct_response_is_received_by_changing_the_topicstatus_and_scheduled_at(
+        def test_correct_response_is_received_by_changing_the_topic_status_and_scheduled_at(
             self,
             actionable_topic1,
             topic_status,

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3134,13 +3134,94 @@ class TestTicketStatus:
             }
             assert data == expected_status
 
-        def test_it_should_return_400_when_topic_status_is_scheduled_and_there_is_no_schduled_at(
-            self, actionable_topic1
+        @pytest.mark.parametrize(
+            "topic_status, scheduled_at, expected_response_status_code, expected_response_detail",
+            [
+                (models.TopicStatusType.alerted.value, None, 400, "Wrong topic status"),
+                (
+                    models.TopicStatusType.alerted.value,
+                    str(datetime.fromtimestamp(0)),
+                    400,
+                    "Wrong topic status",
+                ),
+                (
+                    models.TopicStatusType.alerted.value,
+                    "2000-01-01T00:00:00",
+                    400,
+                    "Wrong topic status",
+                ),
+                (
+                    models.TopicStatusType.alerted.value,
+                    "2345-06-07T08:09:10",
+                    400,
+                    "Wrong topic status",
+                ),
+                (models.TopicStatusType.acknowledged.value, None, 200, None),
+                (
+                    models.TopicStatusType.acknowledged.value,
+                    str(datetime.fromtimestamp(0)),
+                    200,
+                    None,
+                ),
+                (
+                    models.TopicStatusType.acknowledged.value,
+                    "2000-01-01T00:00:00",
+                    400,
+                    "If status is not scheduled, do not specify schduled_at",
+                ),
+                (
+                    models.TopicStatusType.acknowledged.value,
+                    "2345-06-07T08:09:10",
+                    400,
+                    "If status is not scheduled, do not specify schduled_at",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    None,
+                    400,
+                    "If status is scheduled, specify schduled_at",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    str(datetime.fromtimestamp(0)),
+                    400,
+                    "If status is scheduled, unable to reset schduled_at",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    "2000-01-01T00:00:00",
+                    400,
+                    "If status is scheduled, schduled_at must be a future time",
+                ),
+                (models.TopicStatusType.scheduled.value, "2345-06-07T08:09:10", 200, None),
+                (models.TopicStatusType.completed.value, None, 200, None),
+                (models.TopicStatusType.completed.value, str(datetime.fromtimestamp(0)), 200, None),
+                (
+                    models.TopicStatusType.completed.value,
+                    "2000-01-01T00:00:00",
+                    400,
+                    "If status is not scheduled, do not specify schduled_at",
+                ),
+                (
+                    models.TopicStatusType.completed.value,
+                    "2345-06-07T08:09:10",
+                    400,
+                    "If status is not scheduled, do not specify schduled_at",
+                ),
+            ],
+        )
+        def test_correct_response_is_received_by_changing_the_topicstatus_and_scheduled_at(
+            self,
+            actionable_topic1,
+            topic_status,
+            scheduled_at,
+            expected_response_status_code,
+            expected_response_detail,
         ):
             status_request = {
-                "topic_status": models.TopicStatusType.scheduled.value,
+                "topic_status": topic_status,
                 "assignees": [str(self.user2.user_id)],
-                "note": "assign user2 and schedule at 2345/6/7",
+                "scheduled_at": scheduled_at,
             }
             url = (
                 f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
@@ -3153,19 +3234,82 @@ class TestTicketStatus:
                 "accept": "application/json",
             }
             response = client.post(url, headers=_headers, json=status_request)
-            assert response.status_code == 400
+            assert response.status_code == expected_response_status_code
 
             set_response = response.json()
-            assert set_response["detail"] == "If status is scheduled, specify schduled_at"
+            if response.status_code == 400:
+                assert set_response["detail"] == expected_response_detail
+            else:
+                assert set_response["ticket_id"] == self.ticket_id1
+                assert set_response["topic_status"] == topic_status
+                assert set_response["user_id"] == str(self.user1.user_id)
+                assert set_response["assignees"] == [str(self.user2.user_id)]
+                _scheduled_at = scheduled_at
+                if scheduled_at == str(datetime.fromtimestamp(0)):
+                    _scheduled_at = None
+                assert set_response["scheduled_at"] == _scheduled_at
 
-        def test_it_should_return_400_when_topic_status_is_acknowledged_and_there_is_schduled_at(
-            self, actionable_topic1
+        @pytest.mark.parametrize(
+            "previous_topic_status, current_topic_status, previous_scheduled_at, "
+            "current_scheduled_at, expected_response_status_code, expected_response_detail",
+            [
+                (
+                    models.TopicStatusType.scheduled.value,
+                    None,
+                    "2345-06-07T08:09:10",
+                    str(datetime.fromtimestamp(0)),
+                    400,
+                    "If status is scheduled, unable to reset schduled_at",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    None,
+                    "2345-06-07T08:09:10",
+                    "2000-01-01T00:00:00",
+                    400,
+                    "If status is scheduled, schduled_at must be a future time",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    None,
+                    "2345-06-07T08:09:10",
+                    None,
+                    200,
+                    None,
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    models.TopicStatusType.completed.value,
+                    "2345-06-07T08:09:10",
+                    None,
+                    400,
+                    "If current status is not scheduled and previous status is schduled, "
+                    "need to reset schduled_at",
+                ),
+                (
+                    models.TopicStatusType.scheduled.value,
+                    models.TopicStatusType.completed.value,
+                    "2345-06-07T08:09:10",
+                    str(datetime.fromtimestamp(0)),
+                    200,
+                    None,
+                ),
+            ],
+        )
+        def test_correct_response_is_received_by_checking_the_previous_value_and_the_current_value(
+            self,
+            actionable_topic1,
+            previous_topic_status,
+            current_topic_status,
+            previous_scheduled_at,
+            current_scheduled_at,
+            expected_response_status_code,
+            expected_response_detail,
         ):
-            status_request = {
-                "topic_status": models.TopicStatusType.completed.value,
+            previous_status_request = {
+                "topic_status": previous_topic_status,
                 "assignees": [str(self.user2.user_id)],
-                "note": "assign user2 and schedule at 2345/6/7",
-                "scheduled_at": "2345-06-07T08:09:10",
+                "scheduled_at": previous_scheduled_at,
             }
             url = (
                 f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
@@ -3177,74 +3321,36 @@ class TestTicketStatus:
                 "Content-Type": "application/json",
                 "accept": "application/json",
             }
-            response = client.post(url, headers=_headers, json=status_request)
-            assert response.status_code == 400
+            previous_response = client.post(url, headers=_headers, json=previous_status_request)
+            assert previous_response.status_code == 200
 
-            set_response = response.json()
-            assert (
-                set_response["detail"] == "If status is not scheduled, do not specify schduled_at"
-            )
-
-        def test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past(
-            self, actionable_topic1
-        ):
-            status_request = {
-                "topic_status": models.TopicStatusType.scheduled.value,
+            current_status_request = {
+                "topic_status": current_topic_status,
                 "assignees": [str(self.user2.user_id)],
-                "note": "assign user2 and schedule at 2345/6/7",
-                "scheduled_at": "2000-01-01T00:00:00",
+                "scheduled_at": current_scheduled_at,
             }
-            url = (
-                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-                f"/ticketstatus/{self.ticket_id1}"
-            )
-            user1_access_token = self._get_access_token(USER1)
-            _headers = {
-                "Authorization": f"Bearer {user1_access_token}",
-                "Content-Type": "application/json",
-                "accept": "application/json",
-            }
-            response = client.post(url, headers=_headers, json=status_request)
-            assert response.status_code == 400
+            current_response = client.post(url, headers=_headers, json=current_status_request)
+            assert current_response.status_code == expected_response_status_code
 
-            set_response = response.json()
-            assert (
-                set_response["detail"]
-                == "If status is scheduled, schduled_at must be a future time"
-            )
+            set_response = current_response.json()
+            if current_response.status_code == 400:
+                assert set_response["detail"] == expected_response_detail
+            else:
+                assert set_response["ticket_id"] == self.ticket_id1
+                assert set_response["user_id"] == str(self.user1.user_id)
+                assert set_response["assignees"] == [str(self.user2.user_id)]
 
-        def test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero(
-            self, actionable_topic1
-        ):
-            status_request = {
-                "topic_status": models.TopicStatusType.completed.value,
-                "assignees": [str(self.user2.user_id)],
-                "note": "assign user2 and schedule at 2345/6/7",
-                "scheduled_at": str(datetime.fromtimestamp(0)),
-            }
-            url = (
-                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-                f"/ticketstatus/{self.ticket_id1}"
-            )
-            user1_access_token = self._get_access_token(USER1)
-            _headers = {
-                "Authorization": f"Bearer {user1_access_token}",
-                "Content-Type": "application/json",
-                "accept": "application/json",
-            }
-            response = client.post(url, headers=_headers, json=status_request)
-            if response.status_code != 200:
-                raise HTTPError(response)
+                _current_topic_status = current_topic_status
+                if current_topic_status is None:
+                    _current_topic_status = models.TopicStatusType.scheduled.value
+                assert set_response["topic_status"] == _current_topic_status
 
-            data = response.json()
-            assert data["scheduled_at"] is None
-
-            # verification of correct registration in DB
-            get_response = self._get_ticket_status(
-                self.pteam1.pteam_id, self.service_id1, self.ticket_id1
-            )
-
-            assert get_response["scheduled_at"] is None
+                _scheduled_at = current_scheduled_at
+                if current_scheduled_at == str(datetime.fromtimestamp(0)):
+                    _scheduled_at = None
+                elif current_scheduled_at is None:
+                    _scheduled_at = previous_scheduled_at
+                assert set_response["scheduled_at"] == _scheduled_at
 
         def test_it_should_set_requester_if_assignee_is_None_and_saved_assignee_is_empty(
             self, actionable_topic1


### PR DESCRIPTION
## PR の目的
- set_ticket_statusにおけるtopic_status、schduled_atに関するテストについて追加しました。
- pteams.py::set_ticket_status 内の以下のコードに関する部分が正しく正誤判定ができているかを検証しています。

```
if data.topic_status == models.TopicStatusType.scheduled or (
        data.topic_status is None
        and ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled
    ):
```

## 経緯・意図・意思決定
- 追加したテストは2つです。また新しく作成したテストと既存のテストと被ってたため、既存のテストを削除しました。削除したテストは4つです。
- 追加したテスト
  - test_correct_response_is_received_by_changing_the_topicstatus_and_scheduled_at
    - topic_statusとscheduled_atを変えて正しく正誤判定が行われているかを検証しています。
    - 400が出るものに関してはエラー文が正しく返ってくるかを確認
    - 200が来るものに関してはticekt_idやtopic_statusなどが正しく返ってくるかを確認
  - test_correct_response_is_received_by_checking_the_previous_value_and_the_current_value
    - 前回値を考慮した正誤判定が正しく行えているかを検証しています。
    - pteams.py::set_ticket_status 内の以下のコードが正しく正誤判定できているかを検証しています。
```
if data.topic_status == models.TopicStatusType.scheduled or (
        data.topic_status is None
        and ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled
    ):
```
```
else:
      if data.scheduled_at is None:
          if ticket.current_ticket_status.topic_status == models.TopicStatusType.scheduled:
```
- 削除したテスト
  - test_it_should_return_400_when_topic_status_is_scheduled_and_there_is_no_schduled_at
  - test_it_should_return_400_when_topic_status_is_acknowledged_and_there_is_schduled_at
  - test_it_should_return_400_when_topic_status_is_scheduled_and_schduled_at_is_in_the_past
  - test_it_should_put_None_in_completed_at_when_schduled_at_is_datetime_fromtimestamp_zero
