### PR TITLE
Topic/api comparable string enum class

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -12,6 +12,40 @@ from typing_extensions import Annotated
 # ENUMs
 
 
+class ComparableStringEnum(str, enum.Enum):
+
+    @property
+    # Note: this method can be a classmethod in python3.10, but chaining classmethod descriptors
+    #       is depricated in python3.11.
+    def _orders_map(self):
+        # Note: list(Enum) returns enums in definition order.
+        #       see enum.EnumMeta.__iter__()
+        return {element.value: index for index, element in enumerate(self.__class__)}
+
+    def _comparable(self, other):
+        return isinstance(other, self.__class__)
+
+    def __lt__(self, other):
+        if not self._comparable(other):
+            return NotImplemented
+        return self._orders_map[self] < self._orders_map[other]
+
+    def __le__(self, other):
+        if not self._comparable(other):
+            return NotImplemented
+        return self._orders_map[self] <= self._orders_map[other]
+
+    def __gt__(self, other):
+        if not self._comparable(other):
+            return NotImplemented
+        return self._orders_map[self] > self._orders_map[other]
+
+    def __ge__(self, other):
+        if not self._comparable(other):
+            return NotImplemented
+        return self._orders_map[self] >= self._orders_map[other]
+
+
 class ActionType(str, enum.Enum):
     elimination = "elimination"
     transfer = "transfer"
@@ -202,41 +236,12 @@ class HumanImpactEnum(str, enum.Enum):
     VERY_HIGH = "very_high"
 
 
-class SSVCDeployerPriorityEnum(str, enum.Enum):
+class SSVCDeployerPriorityEnum(ComparableStringEnum):
     # https://certcc.github.io/SSVC/howto/deployer_tree/#deployer-decision-outcomes
     IMMEDIATE = "immediate"
     OUT_OF_CYCLE = "out_of_cycle"
     SCHEDULED = "scheduled"
     DEFER = "defer"
-
-    @property
-    def orders_map(self):
-        return {
-            SSVCDeployerPriorityEnum.IMMEDIATE: 1,
-            SSVCDeployerPriorityEnum.OUT_OF_CYCLE: 2,
-            SSVCDeployerPriorityEnum.SCHEDULED: 3,
-            SSVCDeployerPriorityEnum.DEFER: 4,
-        }
-
-    def __lt__(self, other):
-        if not isinstance(other, SSVCDeployerPriorityEnum):
-            return NotImplemented
-        return self.orders_map[self] < self.orders_map[other]
-
-    def __le__(self, other):
-        if not isinstance(other, SSVCDeployerPriorityEnum):
-            return NotImplemented
-        return self.orders_map[self] <= self.orders_map[other]
-
-    def __gt__(self, other):
-        if not isinstance(other, SSVCDeployerPriorityEnum):
-            return NotImplemented
-        return self.orders_map[self] > self.orders_map[other]
-
-    def __ge__(self, other):
-        if not isinstance(other, SSVCDeployerPriorityEnum):
-            return NotImplemented
-        return self.orders_map[self] >= self.orders_map[other]
 
 
 # Base class

--- a/api/app/tests/small/test_ssvc_order.py
+++ b/api/app/tests/small/test_ssvc_order.py
@@ -110,3 +110,29 @@ def test_ssvc_priority_enum_comparison_with_different_type():
 )
 def test_ssvc_priority_enum_le(ssvc_priorityA, ssvc_priorityB, expected):
     assert (ssvc_priorityA <= ssvc_priorityB) == expected
+
+
+[_immediate, _out_of_cycle, _scheduled, _defer] = list(models.SSVCDeployerPriorityEnum)
+
+
+@pytest.mark.parametrize("right", [_immediate, _out_of_cycle, _scheduled, _defer])
+@pytest.mark.parametrize("operator", [">", ">=", "==", "!=", "<=", "<"])
+@pytest.mark.parametrize("left", [_immediate, _out_of_cycle, _scheduled, _defer])
+def test_comparison_operators(left, right, operator):
+    expected_order = {_immediate: 1, _out_of_cycle: 2, _scheduled: 3, _defer: 4}
+    left_order = expected_order[left]
+    right_order = expected_order[right]
+
+    operators_equal = {">=", "==", "<="}
+    operators_small = {"<", "<=", "!="}
+    operators_large = {">", ">=", "!="}
+
+    if left_order == right_order:
+        expected_true_operators = operators_equal
+    elif left_order < right_order:
+        expected_true_operators = operators_small
+    else:
+        expected_true_operators = operators_large
+
+    expected = operator in expected_true_operators
+    assert eval(f"left {operator} right") is expected

--- a/api/app/tests/small/test_ssvc_order.py
+++ b/api/app/tests/small/test_ssvc_order.py
@@ -3,15 +3,6 @@ import pytest
 from app import models
 
 
-def test_ssvc_priority_enum_comparison():
-    assert models.SSVCDeployerPriorityEnum.DEFER == models.SSVCDeployerPriorityEnum.DEFER
-    assert models.SSVCDeployerPriorityEnum.DEFER != models.SSVCDeployerPriorityEnum.SCHEDULED
-    assert models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE < models.SSVCDeployerPriorityEnum.SCHEDULED
-    assert models.SSVCDeployerPriorityEnum.SCHEDULED <= models.SSVCDeployerPriorityEnum.DEFER
-    assert models.SSVCDeployerPriorityEnum.DEFER > models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE
-    assert models.SSVCDeployerPriorityEnum.DEFER >= models.SSVCDeployerPriorityEnum.IMMEDIATE
-
-
 def test_ssvc_priority_enum_comparison_with_different_type():
     with pytest.raises(TypeError):
         assert models.SSVCDeployerPriorityEnum.DEFER < 3
@@ -21,95 +12,6 @@ def test_ssvc_priority_enum_comparison_with_different_type():
         assert models.SSVCDeployerPriorityEnum.DEFER <= 3
     with pytest.raises(TypeError):
         assert models.SSVCDeployerPriorityEnum.DEFER <= 3
-
-
-@pytest.mark.parametrize(
-    "ssvc_priorityA, ssvc_priorityB, expected",
-    [
-        (
-            models.SSVCDeployerPriorityEnum.DEFER,
-            models.SSVCDeployerPriorityEnum.DEFER,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.DEFER,
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.DEFER,
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.DEFER,
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            models.SSVCDeployerPriorityEnum.DEFER,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            models.SSVCDeployerPriorityEnum.DEFER,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            False,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            models.SSVCDeployerPriorityEnum.DEFER,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            models.SSVCDeployerPriorityEnum.SCHEDULED,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
-            True,
-        ),
-        (
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            models.SSVCDeployerPriorityEnum.IMMEDIATE,
-            True,
-        ),
-    ],
-)
-def test_ssvc_priority_enum_le(ssvc_priorityA, ssvc_priorityB, expected):
-    assert (ssvc_priorityA <= ssvc_priorityB) == expected
 
 
 [_immediate, _out_of_cycle, _scheduled, _defer] = list(models.SSVCDeployerPriorityEnum)


### PR DESCRIPTION
## PR の目的

- 比較可能な StringEnum のベースクラスを実装し、SSVCDeployerPriorityEnum クラスに適用。
  - 全ての比較演算子を網羅するテストも追加