### PR TITLE
Fix/UI box in listitemtext

### DIFF
--- a/web/src/components/ActionItem.jsx
+++ b/web/src/components/ActionItem.jsx
@@ -91,35 +91,33 @@ export function ActionItem(props) {
     <>
       <ListItem alignItems="flex-start" disablePadding>
         {decoratedAction}
-        <ListItemText
-          primary={action}
-          primaryTypographyProps={{
-            style: {
-              whiteSpace: "normal",
-              overflow: "auto",
-              width: "92%",
-            },
-          }}
-          secondary={
-            <Box flexDirection="column">
-              <Typography
-                sx={{ display: "inline" }}
-                component="span"
-                variant="body2"
-                color="text.primary"
-              >
-                <Box display="flex" flexDirection="column">
-                  {extInfo}
-                  <UUIDTypography>{actionId}</UUIDTypography>
-                  <Typography color={grey[600]} variant="caption">
-                    {dateTimeFormat(createdAt)}
-                  </Typography>
-                </Box>
+        <Box flexDirection="column">
+          <ListItemText
+            primary={action}
+            primaryTypographyProps={{
+              style: {
+                whiteSpace: "normal",
+                overflow: "auto",
+                width: "92%",
+              },
+            }}
+          />
+          <Typography
+            sx={{ display: "inline" }}
+            component="span"
+            variant="body2"
+            color="text.primary"
+          >
+            <Box display="flex" flexDirection="column">
+              {extInfo}
+              <UUIDTypography>{actionId}</UUIDTypography>
+              <Typography color={grey[600]} variant="caption">
+                {dateTimeFormat(createdAt)}
               </Typography>
             </Box>
-          }
-        />
-        {dustbox}
+          </Typography>
+          {dustbox}
+        </Box>
       </ListItem>
     </>
   );

--- a/web/src/components/ActionItem.jsx
+++ b/web/src/components/ActionItem.jsx
@@ -98,7 +98,7 @@ export function ActionItem(props) {
               style: {
                 whiteSpace: "normal",
                 overflow: "auto",
-                width: "92%",
+                width: "100%",
               },
             }}
           />

--- a/web/src/components/AnalysisNoThreatsMsg.jsx
+++ b/web/src/components/AnalysisNoThreatsMsg.jsx
@@ -58,13 +58,12 @@ export function AnalysisNoThreatsMsg(props) {
               <ListItemIcon>
                 <CheckCircleRoundedIcon color="success" fontSize="small" />
               </ListItemIcon>
-              <ListItemText
-                primary={
-                  <Box display="flex" justifyContent="space-between">
-                    <Typography display="flex">{pteam.pteam_name}</Typography>
-                  </Box>
-                }
-              />
+              <Box display="flex" justifyContent="space-between">
+                <ListItemText
+                  primary={pteam.pteam_name}
+                  primaryTypographyProps={{ display: "flex", variant: "body1" }}
+                />
+              </Box>
             </ListItem>
           ))}
         </List>


### PR DESCRIPTION
## PR の目的

- UI のコンソールに出力される `Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.` の対処
  - Typography の子として Box を入れると出力される。
  - ListItemText は（無効化しない限り）自動で Typography でラップされるため、primary, secondary に Box を使うことで抵触していた