### PR TITLE
Change the property name of SSVCPriorityStatusChip to displaySSVCPriority

### DIFF
--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -124,7 +124,9 @@ export function PTeamStatusSSVCCards(props) {
                       <Button
                         display="flex"
                         alignItems="center"
-                        startIcon={<SSVCPriorityStatusChip ssvcPriority={highestSsvcPriority} />}
+                        startIcon={
+                          <SSVCPriorityStatusChip displaySSVCPriority={highestSsvcPriority} />
+                        }
                         sx={{ color: "white" }}
                       >
                         {card.valuePairing[item]}


### PR DESCRIPTION
## PR の目的
- web/src/components/PteamStatusSSVCCards.jsxにて呼び出しているSSVCPriorityStatusChipのプロパティ名をssvcPriority→displaySSVCPriorityに変更

## 経緯・意図・意思決定
- #372にてweb/src/components/SSVCPriorityStatusChip.jsxのSSVCPriorityStatusChipコンポーネントのプロパティ名をssvcPriority→displaySSVCPriorityに変更しているため
