### PR TITLE
sort pteam.services by service name

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -593,7 +593,12 @@ class PTeam(Base):
         collection_class=set,  # avoid duplications
         viewonly=True,  # block updating via this relationship
     )
-    services = relationship("Service", back_populates="pteam", cascade="all, delete-orphan")
+    services = relationship(
+        "Service",
+        order_by="Service.service_name",
+        back_populates="pteam",
+        cascade="all, delete-orphan",
+    )
     members = relationship("Account", secondary=PTeamAccount.__tablename__, back_populates="pteams")
     invitations = relationship("PTeamInvitation", back_populates="pteam")
     ateams = relationship("ATeam", secondary=ATeamPTeam.__tablename__, back_populates="pteams")


### PR DESCRIPTION
## PR の目的

- pteam.services を service_name でソートするように改修
  - 目的は UI の Status ページのサービスタブのソート
  - サービス未指定時の自動遷移先が pteam.services[0] なので、タブの並びと齟齬が生じないよう api 側でソートしている
