### PR TITLE
remove the outer border of the Highest SSVC Priority icons for each service

### DIFF
--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -21,8 +21,6 @@ import {
   missionImpact,
 } from "../utils/const";
 
-import { SSVCPriorityStatusChip } from "./SSVCPriorityStatusChip";
-
 export function PTeamStatusSSVCCards(props) {
   const { service, highestSsvcPriority } = props;
 
@@ -31,6 +29,9 @@ export function PTeamStatusSSVCCards(props) {
     service.system_exposure,
     service.service_mission_impact,
   ];
+
+  const ssvcPriorityProp = ssvcPriorityProps[highestSsvcPriority];
+  const Icon = ssvcPriorityProp.icon;
 
   let ssvcPriority = {
     ...ssvcPriorityProps,
@@ -124,9 +125,7 @@ export function PTeamStatusSSVCCards(props) {
                       <Button
                         display="flex"
                         alignItems="center"
-                        startIcon={
-                          <SSVCPriorityStatusChip displaySSVCPriority={highestSsvcPriority} />
-                        }
+                        startIcon={<Icon />}
                         sx={{ color: "white" }}
                       >
                         {card.valuePairing[item]}


### PR DESCRIPTION
## PR の目的
- Highest SSVC Priorityカードのアラートアイコンの外枠を削除
   - SSVCPriorityStatusChipをimportして利用するのではなく、web/src/utils/const.jsのssvcPriorityPropsコンポーネントにある各SSVCPriorityのiconを利用

## 経緯・意図・意思決定
- Highest SSVC Priorityカードのアラートアイコンに外枠があることでボタンのように見え、修正する必要があるため
