### PR TITLE
apply “disabled” to SSVC-related options that have not been selected

### DIFF
--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -97,31 +97,21 @@ export function PTeamStatusSSVCCards(props) {
                 mb: 1,
               }}
             >
-              <ToggleButtonGroup
-                color="primary"
-                size="small"
-                orientation="vertical"
-                value={card.items.filter((item) => SSVCValueList.find((value) => value === item))}
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  "& .MuiToggleButton-root": {
-                    width: "100%",
-                    "&.Mui-selected": {
-                      backgroundColor:
-                        card.title === "Highest SSVC Priority"
-                          ? ssvcPriorityProps[highestSsvcPriority].style.bgcolor
-                          : "primary",
-                    },
-                  },
-                }}
-              >
+              <ToggleButtonGroup color="primary" size="small" orientation="vertical">
                 {card.items.map((item, index) =>
                   // Highlight the toggle button for Highest SSVC priority
                   index ===
                     sortedSSVCPriorities.findIndex((item) => item === highestSsvcPriority) &&
                   card.title === "Highest SSVC Priority" ? (
-                    <ToggleButton key={item} value={item} disabled>
+                    <ToggleButton
+                      key={item}
+                      value={item}
+                      disabled
+                      sx={{
+                        backgroundColor: ssvcPriorityProps[highestSsvcPriority].style.bgcolor,
+                        "& .MuiToggleButton-root": { width: "100%" },
+                      }}
+                    >
                       <Button
                         display="flex"
                         alignItems="center"
@@ -132,7 +122,15 @@ export function PTeamStatusSSVCCards(props) {
                       </Button>
                     </ToggleButton>
                   ) : (
-                    <ToggleButton key={item} value={item}>
+                    <ToggleButton
+                      key={item}
+                      value={item}
+                      disabled
+                      sx={{
+                        backgroundcolor: "primary",
+                        "& .MuiToggleButton-root": { width: "100%" },
+                      }}
+                    >
                       <Button
                         display="flex"
                         alignItems="center"

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -23,13 +23,11 @@ import {
 
 export function PTeamStatusSSVCCards(props) {
   const { service, highestSsvcPriority } = props;
-
   const SSVCValueList = [
     highestSsvcPriority,
     service.system_exposure,
     service.service_mission_impact,
   ];
-
   const ssvcPriorityProp = ssvcPriorityProps[highestSsvcPriority];
   const Icon = ssvcPriorityProp.icon;
 
@@ -40,13 +38,14 @@ export function PTeamStatusSSVCCards(props) {
     ssvcPriority[key] = ssvcPriorityProps[key]["displayName"];
   });
 
+  const HighestSSVCPriorityList = {
+    title: "Highest SSVC Priority",
+    description: "The most serious security issue of the Service.",
+    items: sortedSSVCPriorities,
+    valuePairing: ssvcPriority,
+  };
+
   const SSVCCardsList = [
-    {
-      title: "Highest SSVC Priority",
-      description: "The most serious security issue of the Service.",
-      items: sortedSSVCPriorities,
-      valuePairing: ssvcPriority,
-    },
     {
       title: "System Exposure",
       description: "The Accessible Attack Surface of the Affected System or Service.",
@@ -62,8 +61,77 @@ export function PTeamStatusSSVCCards(props) {
   ];
 
   return (
+    // Create Highest SSVC Priority card
     <Grid container spacing={2}>
+      <Grid key={HighestSSVCPriorityList.title} item xs={4}>
+        <Paper
+          sx={{
+            textAlign: "center",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", my: 1 }}>
+            <Typography
+              variant="h6"
+              component="div"
+              sx={{
+                pr: 0.5,
+                fontWeight: "bold",
+              }}
+            >
+              {HighestSSVCPriorityList.title}
+            </Typography>
+            <Tooltip title={HighestSSVCPriorityList.description}>
+              <HelpOutlineOutlinedIcon color="action" fontSize="small" />
+            </Tooltip>
+          </Box>
+          <Box
+            sx={{
+              display: "flex",
+              height: "100%",
+              justifyContent: "center",
+              alignItems: "center",
+              mb: 1,
+            }}
+          >
+            <ToggleButtonGroup
+              size="small"
+              orientation="vertical"
+              value={highestSsvcPriority}
+              sx={{
+                "& .MuiToggleButton-root": {
+                  width: "100%",
+                  "&.Mui-selected": {
+                    backgroundColor:
+                      HighestSSVCPriorityList.title === "Highest SSVC Priority"
+                        ? ssvcPriorityProps[highestSsvcPriority].style.bgcolor
+                        : "primary",
+                  },
+                },
+              }}
+            >
+              {HighestSSVCPriorityList.items.map((item) =>
+                item === highestSsvcPriority ? (
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
+                    <Button startIcon={<Icon />} sx={{ color: "white" }}>
+                      {HighestSSVCPriorityList.valuePairing[item]}
+                    </Button>
+                  </ToggleButton>
+                ) : (
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
+                    <Button disabled>{HighestSSVCPriorityList.valuePairing[item]}</Button>
+                  </ToggleButton>
+                ),
+              )}
+            </ToggleButtonGroup>
+          </Box>
+        </Paper>
+      </Grid>
+
       {SSVCCardsList.map((card) => (
+        // Create System Exposure card and Mission Impact
         <Grid key={card.title} item xs={4}>
           <Paper
             sx={{
@@ -97,54 +165,17 @@ export function PTeamStatusSSVCCards(props) {
                 mb: 1,
               }}
             >
-              <ToggleButtonGroup color="primary" size="small" orientation="vertical">
-                {card.items.map((item, index) =>
-                  // Highlight the toggle button for Highest SSVC priority
-                  index ===
-                    sortedSSVCPriorities.findIndex((item) => item === highestSsvcPriority) &&
-                  card.title === "Highest SSVC Priority" ? (
-                    <ToggleButton
-                      key={item}
-                      value={item}
-                      disabled
-                      sx={{
-                        backgroundColor: ssvcPriorityProps[highestSsvcPriority].style.bgcolor,
-                        "& .MuiToggleButton-root": { width: "100%" },
-                      }}
-                    >
-                      <Button
-                        display="flex"
-                        alignItems="center"
-                        startIcon={<Icon />}
-                        sx={{ color: "white" }}
-                      >
-                        {card.valuePairing[item]}
-                      </Button>
-                    </ToggleButton>
-                  ) : (
-                    <ToggleButton
-                      key={item}
-                      value={item}
-                      disabled
-                      sx={{
-                        backgroundcolor: "primary",
-                        "& .MuiToggleButton-root": { width: "100%" },
-                      }}
-                    >
-                      <Button
-                        display="flex"
-                        alignItems="center"
-                        disabled={
-                          item !== highestSsvcPriority &&
-                          item !== service.system_exposure &&
-                          item !== service.service_mission_impact
-                        }
-                      >
-                        {card.valuePairing[item]}
-                      </Button>
-                    </ToggleButton>
-                  ),
-                )}
+              <ToggleButtonGroup
+                color="primary"
+                size="small"
+                orientation="vertical"
+                value={card.items.filter((item) => SSVCValueList.find((value) => value === item))}
+              >
+                {card.items.map((item) => (
+                  <ToggleButton key={item} value={item} disabled>
+                    {card.valuePairing[item]}
+                  </ToggleButton>
+                ))}
               </ToggleButtonGroup>
             </Box>
           </Paper>

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -132,8 +132,16 @@ export function PTeamStatusSSVCCards(props) {
                       </Button>
                     </ToggleButton>
                   ) : (
-                    <ToggleButton key={item} value={item} disabled>
-                      <Button display="flex" alignItems="center">
+                    <ToggleButton key={item} value={item}>
+                      <Button
+                        display="flex"
+                        alignItems="center"
+                        disabled={
+                          item !== highestSsvcPriority &&
+                          item !== service.system_exposure &&
+                          item !== service.service_mission_impact
+                        }
+                      >
                         {card.valuePairing[item]}
                       </Button>
                     </ToggleButton>

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -104,10 +104,7 @@ export function PTeamStatusSSVCCards(props) {
                 "& .MuiToggleButton-root": {
                   width: "100%",
                   "&.Mui-selected": {
-                    backgroundColor:
-                      HighestSSVCPriorityList.title === "Highest SSVC Priority"
-                        ? ssvcPriorityProps[highestSsvcPriority].style.bgcolor
-                        : "primary",
+                    backgroundColor: ssvcPriorityProps[highestSsvcPriority].style.bgcolor,
                   },
                 },
               }}

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -114,13 +114,13 @@ export function PTeamStatusSSVCCards(props) {
             >
               {HighestSSVCPriorityList.items.map((item) =>
                 item === highestSsvcPriority ? (
-                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }}>
                     <Button startIcon={<Icon />} sx={{ color: "white" }}>
                       {HighestSSVCPriorityList.valuePairing[item]}
                     </Button>
                   </ToggleButton>
                 ) : (
-                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }}>
                     <Button disabled>{HighestSSVCPriorityList.valuePairing[item]}</Button>
                   </ToggleButton>
                 ),


### PR DESCRIPTION
## PR の目的
- Status画面におけるサービスのHighest SSVC Priorityカード、System Exposureカード、Mission Impactカードにおいて選択されていない選択肢をグレーにする
   - System Exposureカード、Mission Impactカードに関しては、#328のコードをそのまま実装
   - Highest SSVC Priorityカードのみ別コンポーネントで実装し、disabledの設定をToggleButtonコンポーネントからButtonコンポーネントに変更（ToggleButtonコンポーネントのなかにButtonコンポーネントが配置されているため）
      - 現在のHighest SSVC Priorityには、強調表現のため、背景色の変更とアラートアイコンの追加をしているため

## 経緯・意図・意思決定
- Highest SSVC Priorityカード、System Exposureカード、Mission Impactカードにおいて選択されていない選択肢のグレー表記が適用されていなかったため
   - #380のHighest SSVC Priorityカードの強調表現の実装により、#328で実装したdisabledがうまく適用されなくなったため
      - Highest SSVC Priorityカードの強調表現をToggleButtonコンポーネントのなかにButtonコンポーネントを配置することで実装した結果、ToggleButtonコンポーネントに設定されていたdisabledが適用されなくなっていたため
      - #380の実装そのものが複雑な条件分岐であったため、分かりづらいのでHighest SSVC Priorityカードのみ別コンポーネントを作成し、再実装
