### PR TITLE
ステータス詳細画面のチケットのデザイン修正

### DIFF
--- a/web/src/components/AssigneesSelector.jsx
+++ b/web/src/components/AssigneesSelector.jsx
@@ -1,4 +1,4 @@
-import { Checkbox, ListItemText, MenuItem, Input, Select } from "@mui/material";
+import { Checkbox, ListItemText, MenuItem, Input, Select, FormControl } from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
@@ -58,16 +58,16 @@ export function AssigneesSelector(props) {
   if (!pteamId || !serviceId || !topicId || !tagId || !ticketId || !members) return <></>;
 
   return (
-    <>
+    <FormControl size="small">
       <Select
         multiple
         displayEmpty
         value={assigneeEmails}
         onChange={handleAssigneesChange}
         onClose={handleApply}
-        input={<Input sx={{ display: "flex" }} />}
+        input={<Input sx={{ display: "flex", fontSize: 14 }} />}
         renderValue={(selected) => {
-          return selected.length === 0 ? <em>select</em> : selected.join(", ");
+          return selected.length === 0 ? <em>Select assignees</em> : selected.join(", ");
         }}
         MenuProps={{
           PaperProps: {
@@ -79,17 +79,17 @@ export function AssigneesSelector(props) {
         }}
         notched="true" /* to avoid Warning: Received `true` for a non-boolean attribute `notched` */
       >
-        <MenuItem disabled value="">
-          <em>select assignees</em>
+        <MenuItem disabled value="" sx={{ fontSize: 14 }}>
+          <em>Select assignees</em>
         </MenuItem>
         {Object.values(members).map((member) => (
           <MenuItem key={member.user_id} value={member.email}>
             <Checkbox checked={assigneeEmails.includes(member.email)} />
-            <ListItemText primary={member.email} />
+            <ListItemText primary={member.email} sx={{ "& span": { fontSize: 14 } }} />
           </MenuItem>
         ))}
       </Select>
-    </>
+    </FormControl>
   );
 }
 

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -362,8 +362,8 @@ export function TopicCard(props) {
         <Box
           sx={{
             overflowY: "auto",
-            minWidth: "320px",
-            maxWidth: "350px",
+            minWidth: "480px",
+            maxWidth: "480px",
           }}
         >
           {tickets.map((ticket, index) => (

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -158,12 +158,11 @@ export function TopicStatusSelector(props) {
         endIcon={<ArrowDropDownIcon />}
         sx={{
           ...topicStatusProps[currentStatus.topic_status].buttonStyle,
-          fontSize: 12,
+          fontSize: 14,
           padding: "1px 3px",
           minHeight: "25px",
           maxHeight: "25px",
           textTransform: "none",
-          fontWeight: 900,
           borderStyle: "none",
           mr: 1,
           "&:hover": {

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -184,15 +184,13 @@ export function TopicTicketAccordion(props) {
           </Grid>
         </Grid>
         {(ticketStatus.topic_status ?? "alerted") !== "alerted" && (
-          <Box display="flex" justifyContent="flex-end" sx={{ color: grey[600] }}>
-            <Box display="flex" alignItems="flex-end">
-              <Typography variant="caption">Last updated by</Typography>
-              <Typography ml={0.5} variant="caption" fontWeight={900}>
-                {ticketStatus.user_id === systemAccount.uuid
-                  ? systemAccount.email
-                  : members[ticketStatus.user_id]?.email ?? "not a pteam member"}
-              </Typography>
-            </Box>
+          <Box sx={{ textAlign: "right", color: grey[600] }}>
+            <Typography variant="caption">Last updated by</Typography>
+            <Typography ml={0.5} variant="caption" fontWeight={900}>
+              {ticketStatus.user_id === systemAccount.uuid
+                ? systemAccount.email
+                : members[ticketStatus.user_id]?.email ?? "not a pteam member"}
+            </Typography>
           </Box>
         )}
       </AccordionDetails>

--- a/web/src/components/TopicTicketAccordion.jsx
+++ b/web/src/components/TopicTicketAccordion.jsx
@@ -6,8 +6,8 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
-  CardActions,
   Chip,
+  Grid,
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
@@ -88,10 +88,10 @@ export function TopicTicketAccordion(props) {
           <Box sx={{ wordBreak: "break-all" }}>{target}</Box>
         </Box>
       </AccordionSummary>
-      <AccordionDetails>
-        <Box p={2} display="flex" flexDirection="row" alignItems="center">
-          <Box sx={{ display: "flex", justifyContent: "start", minWidth: "110px", mr: 1 }}>
-            <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, mr: 0.5 }}>
+      <AccordionDetails sx={{ p: 3 }}>
+        <Grid container sx={{ alignItems: "center", pb: 2 }}>
+          <Grid item xs={5} sx={{ display: "flex" }}>
+            <Typography mr={1} variant="subtitle2" sx={{ fontWeight: "bold", mr: 0.5 }}>
               Safety impact
             </Typography>
             <StyledTooltip
@@ -127,14 +127,18 @@ export function TopicTicketAccordion(props) {
             >
               <HelpOutlineOutlinedIcon color="action" fontSize="small" />
             </StyledTooltip>
-          </Box>
-          <Chip label={serviceSafetyImpactDisplayName} />
-        </Box>
-        <Box p={2} display="flex" flexDirection="row" alignItems="center">
-          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-            Status
-          </Typography>
-          <Box display="flex" flexDirection="column">
+          </Grid>
+          <Grid item xs={7}>
+            <Chip label={serviceSafetyImpactDisplayName} />
+          </Grid>
+        </Grid>
+        <Grid container sx={{ alignItems: "center", pb: 2 }}>
+          <Grid item xs={5}>
+            <Typography mr={1} variant="subtitle2" sx={{ fontWeight: "bold", minWidth: "110px" }}>
+              Status
+            </Typography>
+          </Grid>
+          <Grid item xs={7}>
             <Box display="flex" alignItems="center">
               <TopicStatusSelector
                 pteamId={pteamId}
@@ -158,13 +162,15 @@ export function TopicTicketAccordion(props) {
                   </Typography>
                 </Box>
               )}
-          </Box>
-        </Box>
-        <CardActions sx={{ display: "flex", alignItems: "center", p: 2 }}>
-          <Typography mr={1} variant="subtitle2" sx={{ fontWeight: 900, minWidth: "110px" }}>
-            Assignees
-          </Typography>
-          <Box sx={{ maxWidth: 150 }}>
+          </Grid>
+        </Grid>
+        <Grid container sx={{ alignItems: "center", pb: 2 }}>
+          <Grid item xs={5}>
+            <Typography mr={1} variant="subtitle2" sx={{ fontWeight: "bold", minWidth: "110px" }}>
+              Assignees
+            </Typography>
+          </Grid>
+          <Grid item xs={7}>
             <AssigneesSelector
               key={ticketStatus.assignees.join("")}
               pteamId={pteamId}
@@ -175,16 +181,10 @@ export function TopicTicketAccordion(props) {
               currentAssigneeIds={ticketStatus.assignees}
               members={members}
             />
-          </Box>
-        </CardActions>
+          </Grid>
+        </Grid>
         {(ticketStatus.topic_status ?? "alerted") !== "alerted" && (
-          <Box
-            p={1.5}
-            display="flex"
-            flexDirection="row"
-            justifyContent="flex-end"
-            sx={{ color: grey[600] }}
-          >
+          <Box display="flex" justifyContent="flex-end" sx={{ color: grey[600] }}>
             <Box display="flex" alignItems="flex-end">
               <Typography variant="caption">Last updated by</Typography>
               <Typography ml={0.5} variant="caption" fontWeight={900}>


### PR DESCRIPTION
## PR の目的

ステータス詳細画面のチケットのデザイン修正

## 経緯・意図・意思決定

- `Grid`を使用し、アコーディオン内の項目について先頭の位置を揃える
- フォントサイズを統一
- `Assignees`のフォームに表示される文言を`select`から`Select assignees`に変更
- アコーディオンのサイズは`width`だけで指定すると横幅にズレが生じることがあるので、`minWidth`と`maxWidth`を`480px`とすることで横幅を固定している

## 補足情報
- APIの繋ぎ込みは不要
