### PR TITLE
topic/fixed vertical size of rows in status screen

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -156,10 +156,16 @@ export function PTeamStatusCard(props) {
       <TableCell align="right" style={{ width: "30%" }}>
         <Box display="flex" flexDirection="column">
           <Box display="flex" flexDirection="row" justifyContent="space-between">
-            <Typography variant="body2">
-              {displaySSVCPriority === "safe" || displaySSVCPriority === "empty"
-                ? ""
-                : `Updated ${calcTimestampDiff(tag.updated_at)}`}
+            <Typography
+              variant="body2"
+              sx={{
+                visibility:
+                  displaySSVCPriority === "safe" || displaySSVCPriority === "empty"
+                    ? "hidden"
+                    : "visible",
+              }}
+            >
+              Updated ${calcTimestampDiff(tag.updated_at)}
             </Typography>
           </Box>
           <StatusRatioGraph counts={tag.status_count} displaySSVCPriority={tag.ssvc_priority} />


### PR DESCRIPTION
## PR の目的
- displaySSVCPriorityがsafe, emptyものに関して、updatedを表示しないようにした際に、Status画面の行の縦サイズがバラバラになった問題について修正しました。

## 経緯・意図・意思決定
- material uiのvisibilityを使用して、updatedの文字が非表示になるようにしました