### PR TITLE
delete hover action for Highest SSVC Priority card

### DIFF
--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -111,13 +111,13 @@ export function PTeamStatusSSVCCards(props) {
             >
               {HighestSSVCPriorityList.items.map((item) =>
                 item === highestSsvcPriority ? (
-                  <ToggleButton key={item} value={item} sx={{ padding: "0" }}>
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
                     <Button startIcon={<Icon />} sx={{ color: "white" }}>
                       {HighestSSVCPriorityList.valuePairing[item]}
                     </Button>
                   </ToggleButton>
                 ) : (
-                  <ToggleButton key={item} value={item} sx={{ padding: "0" }}>
+                  <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
                     <Button disabled>{HighestSSVCPriorityList.valuePairing[item]}</Button>
                   </ToggleButton>
                 ),


### PR DESCRIPTION
## PR の目的
- Highest SSVC Priorityカードの各ToggleButtonのホバーアクション機能を削除
   - Highest SSVC Priorityカードを作成するコンポーネントのToggleButtonにdisabledを設定

## 経緯・意図・意思決定
- Highest SSVC Priorityカードにボタンとしての機能はないため
   - 機能としては各サービスのHighest SSVC Priorityを表示するだけであり、ボタンとして何らかのアクションを提供するものではないため

