### PR TITLE
topic/fix link content in alert notifications

### DIFF
--- a/api/app/slack.py
+++ b/api/app/slack.py
@@ -59,6 +59,7 @@ def create_slack_pteam_alert_blocks_for_new_topic(
     topic_id: str,
     title: str,
     ssvc_priority: models.SSVCDeployerPriorityEnum,
+    service_id: str,
     services: list[str],
 ):
     blocks: list[dict[str, str | dict[str, str] | list[dict[str, str]]]]
@@ -72,7 +73,7 @@ def create_slack_pteam_alert_blocks_for_new_topic(
                     "type": "mrkdwn",
                     "text": "\n".join(
                         [
-                            f"*<{TAG_URL}{str(tag_id)}?pteamId={pteam_id}|{tag_name}>*",
+                            f"*<{TAG_URL}{str(tag_id)}?pteamId={pteam_id}&serviceId={service_id}|{tag_name}>*",
                             f"*{title}*",
                             f"*{services_name}*",
                             SSVC_PRIORITY_LABEL[ssvc_priority],

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -72,6 +72,11 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(testdb, 
     pteam0 = create_pteam(USER1, _gen_pteam_params(0))
     ext_tags = {child_tag11.tag_name: [("api/Pipfile.lock", "1.0.0")]}
     upload_pteam_tags(USER1, pteam0.pteam_id, SERVICE1, ext_tags)
+    response = client.get(f"/pteams/{pteam0.pteam_id}/services", headers=headers(USER1))
+    assert response.status_code == 200
+    data = response.json()
+    service = next(filter(lambda x: x["service_name"] == SERVICE1, data))
+    service_id = service["service_id"]
 
     # topic0: no tags
     send_email = mocker.patch("app.alert.send_email")
@@ -93,6 +98,7 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(testdb, 
         pteam0.pteam_id,
         child_tag11.tag_name,  # pteamtag, not topictag
         child_tag11.tag_id,  # pteamtag, not topictag
+        service_id,
         [SERVICE1],
     )
     send_email.assert_called_once()
@@ -122,6 +128,7 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(testdb, 
         pteam0.pteam_id,
         child_tag11.tag_name,  # pteamtag, not topictag
         child_tag11.tag_id,  # pteamtag, not topictag
+        service_id,
         [SERVICE1],
     )
     send_email.assert_called_once()

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -15,12 +15,16 @@ def test_create_blocks_for_pteam():
         "topic_id": "b1f74d1f-9360-4a8d-86ac-3cf5dd20c75c",
         "title": "test_title1",
         "ssvc_priority": models.SSVCDeployerPriorityEnum.IMMEDIATE,
+        "service_id": "4e74fbde-82fe-4d0a-a2bf-3c405c3b0814",
         "services": ["test1_service", "test2_service"],
     }
 
     blocks = create_slack_pteam_alert_blocks_for_new_topic(**notification_data)
     assert notification_data["pteam_name"] in blocks[0]["text"]["text"]
-    tag_page_url = f"{TAG_URL}{notification_data['tag_id']}?pteamId={notification_data['pteam_id']}"
+    tag_page_url = (
+        f"{TAG_URL}{notification_data['tag_id']}?pteamId={notification_data['pteam_id']}&"
+        f"serviceId={notification_data['service_id']}"
+    )
     assert tag_page_url in blocks[2]["text"]["text"]
     assert notification_data["title"] in blocks[2]["text"]["text"]
     assert SSVC_PRIORITY_LABEL[notification_data["ssvc_priority"]] in blocks[2]["text"]["text"]


### PR DESCRIPTION
## PR の目的
- アラート通知にあるリンクにserviceIdが抜けており、リンクが開なかった問題について対処しました。
## 経緯・意図・意思決定
- mail, slackどちらともserviceIdが抜けていたため、追加しました。
- serviceId追加に伴い、テストについても修正を行いました。
