### PR TITLE
bugfix/delete-$

### DIFF
--- a/web/src/components/PTeamStatusCard.jsx
+++ b/web/src/components/PTeamStatusCard.jsx
@@ -165,7 +165,7 @@ export function PTeamStatusCard(props) {
                     : "visible",
               }}
             >
-              Updated ${calcTimestampDiff(tag.updated_at)}
+              Updated {calcTimestampDiff(tag.updated_at)}
             </Typography>
           </Box>
           <StatusRatioGraph counts={tag.status_count} displaySSVCPriority={tag.ssvc_priority} />


### PR DESCRIPTION
## PR の目的
- Status画面にあった$マークを削除しました。

## 経緯・意図・意思決定
`Updated ${calcTimestampDiff(tag.updated_at)}`
- 上記の文字列は元々javascript上の{}内にあり、文字列に変数を入れる書き方(シングルクフォーテーション内に$をつけて表示)になっていました。

https://github.com/nttcom/threatconnectome/commit/795a437431efc1ecc0054b3e684c31dbe5441c96#diff-49fdc0c2010ab2847052ef5734d53d39cc491652d57bc87cc727e864f5d8561fL161
- 上記の変更後にHTML上にそのまま文字として表示するようになったため、$が必要なくなったのですが、そのままの状態になっていました。