### PR TITLE
bugfix/UI button in button

### DIFF
--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -112,13 +112,15 @@ export function PTeamStatusSSVCCards(props) {
               {HighestSSVCPriorityList.items.map((item) =>
                 item === highestSsvcPriority ? (
                   <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
-                    <Button startIcon={<Icon />} sx={{ color: "white" }}>
+                    <Button component="div" startIcon={<Icon />} sx={{ color: "white" }}>
                       {HighestSSVCPriorityList.valuePairing[item]}
                     </Button>
                   </ToggleButton>
                 ) : (
                   <ToggleButton key={item} value={item} sx={{ padding: "0" }} disabled>
-                    <Button disabled>{HighestSSVCPriorityList.valuePairing[item]}</Button>
+                    <Button component="div" disabled>
+                      {HighestSSVCPriorityList.valuePairing[item]}
+                    </Button>
                   </ToggleButton>
                 ),
               )}


### PR DESCRIPTION
## PR の目的
- コンソールに以下の警告が出ていた問題を解決しました。
`Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.`

## 経緯・意図・意思決定
- 警告が発生している原因はbuttonタグの中にbuttonタグが入っていることでした。
- propsのcomponetを使用し、buttonタグからdivタグになるようにしました。


## 参考文献
- https://mui.com/material-ui/guides/composition/#component-prop
- https://mui.com/material-ui/api/button/#:~:text=customization%20guide.-,component,-elementType