### PR TITLE
Topic/UI rtkq search topics

### DIFF
--- a/web/src/hooks/auth.js
+++ b/web/src/hooks/auth.js
@@ -1,0 +1,7 @@
+import { useSelector } from "react-redux";
+
+export function useSkipUntilAuthTokenIsReady() {
+  const authToken = useSelector((state) => state.auth.token);
+  const skip = authToken === undefined;
+  return skip;
+}

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -142,8 +142,9 @@ export function TopicManagement() {
     isLoading: searchResultIsLoading,
   } = useSearchTopicsQuery(searchParams, { skip, refetchOnMountOrArgChange: true });
 
+  if (skip) return <>Now loading auth token...</>;
   if (searchResultError) return <>{`Search topics failed: ${errorToString(searchResultError)}`}</>;
-  if (searchResultIsLoading || !searchResult) return <>Now searching topics...</>;
+  if (searchResultIsLoading) return <>Now searching topics...</>;
 
   const topics = searchResult.topics;
   const pageMax = Math.ceil((searchResult?.num_topics ?? 0) / perPage);

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -131,8 +131,8 @@ export function TopicManagement() {
     offset: perPage * (page - 1),
     limit: perPage,
     sort_key: "updated_at_desc",
-    pteam_id: (checkedPteam === true && pteamId) ? pteamId : null,
-    ateam_id: (checkedAteam === true && ateamId) ? ateamId : null,
+    pteam_id: checkedPteam === true && pteamId ? pteamId : null,
+    ateam_id: checkedAteam === true && ateamId ? ateamId : null,
     ...searchConditions,
   };
   const {

--- a/web/src/pages/TopicManagement.jsx
+++ b/web/src/pages/TopicManagement.jsx
@@ -34,6 +34,7 @@ import { useLocation } from "react-router-dom";
 import { FormattedDateTimeWithTooltip } from "../components/FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "../components/TopicSearchModal";
 import styles from "../cssModule/button.module.css";
+import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useSearchTopicsQuery } from "../services/tcApi";
 import { getActions, getTopic } from "../slices/topics";
 import { difficulty, difficultyColors } from "../utils/const";
@@ -121,7 +122,7 @@ export function TopicManagement() {
   const [perPage, setPerPage] = useState(perPageItems[0]);
   const [searchConditions, setSearchConditions] = useState({});
 
-  const user = useSelector((state) => state.user.user);
+  const skip = useSkipUntilAuthTokenIsReady();
 
   const params = new URLSearchParams(useLocation().search);
   const pteamId = params.get("pteamId");
@@ -139,11 +140,10 @@ export function TopicManagement() {
     data: searchResult,
     error: searchResultError,
     isLoading: searchResultIsLoading,
-  } = useSearchTopicsQuery(searchParams, { refetchOnMountOrArgChange: true });
+  } = useSearchTopicsQuery(searchParams, { skip, refetchOnMountOrArgChange: true });
 
-  if (!user.user_id) return <></>;
   if (searchResultError) return <>{`Search topics failed: ${errorToString(searchResultError)}`}</>;
-  if (searchResultIsLoading) return <>Now searching topics...</>;
+  if (searchResultIsLoading || !searchResult) return <>Now searching topics...</>;
 
   const topics = searchResult.topics;
   const pageMax = Math.ceil((searchResult?.num_topics ?? 0) / perPage);

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -28,6 +28,15 @@ export const tcApi = createApi({
       }
       return headers;
     },
+    paramsSerializer: (params) =>
+      Object.keys(params)
+        .filter((key) => ![null, undefined].includes(params[key]))
+        .flatMap((key) =>
+          params[key] instanceof Array
+            ? params[key].map((item) => `${encodeURIComponent(key)}=${encodeURIComponent(item)}`)
+            : `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`,
+        )
+        .join("&"),
   }),
   endpoints: (builder) => ({
     /* PTeam */
@@ -79,6 +88,14 @@ export const tcApi = createApi({
         };
       },
     }),
+
+    /* Topics */
+    searchTopics: builder.query({
+      query: (params) => ({
+        url: "topics/search",
+        params: params,
+      }),
+    }),
   }),
 });
 
@@ -89,4 +106,5 @@ export const {
   useGetPTeamAuthQuery,
   useGetPTeamMembersQuery,
   useUploadSBOMFileMutation,
+  useSearchTopicsQuery,
 } = tcApi;

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -62,7 +62,11 @@ export const validateUUID = (str) =>
 
 export const errorToString = (error) => {
   if (typeof error === "string") return error;
-  if (error.status && error.data?.detail) return `${error.status}: ${error.data.detail}`; // RTKQ
+  if (error.status && error.data?.detail) { // RTKQ
+    if (typeof error.data?.detail === "string")
+      return `${error.status}: ${error.data.detail}`;
+    return `${error.status}: ${JSON.stringify(error.data.detail)}`; // maybe 422
+  }
   if (typeof error.response?.data?.detail === "string")
     // error message from api
     return error.response.data.detail;

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -62,9 +62,9 @@ export const validateUUID = (str) =>
 
 export const errorToString = (error) => {
   if (typeof error === "string") return error;
-  if (error.status && error.data?.detail) { // RTKQ
-    if (typeof error.data?.detail === "string")
-      return `${error.status}: ${error.data.detail}`;
+  if (error.status && error.data?.detail) {
+    // RTKQ
+    if (typeof error.data?.detail === "string") return `${error.status}: ${error.data.detail}`;
     return `${error.status}: ${JSON.stringify(error.data.detail)}`; // maybe 422
   }
   if (typeof error.response?.data?.detail === "string")


### PR DESCRIPTION
## PR の目的

- searchTopics の RTKQ 対応
  - query params で array を指定するケースで api (fastapi) と適合するように、paramsSerializer を実装。
  - 検索処理なので useQuery の第二引数で refreshOnMountOrArgChange を true に設定。
    - 名称のとおり、マウント時・引数変化時にキャッシュ参照せず再フェッチする。
  - Pydantic の 422 エラーが正しく処理できていなかったため、errorToString を微修正。

## 既知の不具合

- ~~Topics ページでリロードした際、searchTopics が 401 エラーになるケースがある。~~
  - ~~cookie から取得した accessToken の格納が完了する前に fetch しているような感触。~~
    - ~~従来の user.user_id でのログイン完了判定に替わる処理が必要か？~~
    - ~~getState().auth.token が undefined なら fetch skip するようにするとか？~~
  - ~~本 PR に限らない問題と思われるため、別タスクで対応する。~~
  - auth token の有無で skip の値を返すカスタムフックを定義して対応した。
