### PR TITLE
disable devtools for production

### DIFF
--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -28,6 +28,7 @@ const store = configureStore({
     })
       .concat(tcApi.middleware)
       .concat(firebaseApi.middleware),
+  devTools: process.env.NODE_ENV !== "production",
 });
 
 export default store;


### PR DESCRIPTION
## PR の目的

- production mode で devtools を無効化
  - redux-toolkit の configureStore を利用している Tc では、devtools が有効化（デフォルト）されていた。
  - 本番環境では無効となるように、 NODE_ENV で切り替えるよう改修。
    - `npm run build` した場合は NODE_ENV = "production" となるので devtools 無効。
    - `npm run start` した場合は NODE_ENV = "development" となるので devtools 有効。