### PR TITLE
refine creating & updating user using RTKQ

### DIFF
--- a/web/src/pages/Account.jsx
+++ b/web/src/pages/Account.jsx
@@ -10,17 +10,24 @@ import {
   Typography,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
+import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { UUIDTypography } from "../components/UUIDTypography";
-import { updateUser } from "../slices/user";
+import { useUpdateUserMutation } from "../services/tcApi";
+import { getUser } from "../slices/user";
+import { errorToString } from "../utils/func";
 
 export function Account() {
   const [editInfo, setEditInfo] = useState({
     years: 0,
   });
   const [editMode, setEditMode] = useState(false);
+
+  const [updateUser] = useUpdateUserMutation();
+
+  const { enqueueSnackbar } = useSnackbar();
 
   const dispatch = useDispatch();
   const user = useSelector((state) => state.user.user);
@@ -40,13 +47,17 @@ export function Account() {
   };
 
   const handleSave = async () => {
-    dispatch(
-      updateUser({
-        userId: user.user_id,
-        user: { years: editInfo.years },
-      }),
-    );
-    handleEditMode();
+    updateUser({
+      userId: user.user_id,
+      data: { years: editInfo.years },
+    })
+      .unwrap()
+      .then((succeeded) => {
+        enqueueSnackbar("Update user info succeeded", { variant: "success" });
+        dispatch(getUser());
+        handleEditMode();
+      })
+      .catch((error) => enqueueSnackbar(errorToString(error), { variant: "error" }));
   };
 
   return (

--- a/web/src/pages/Login.jsx
+++ b/web/src/pages/Login.jsx
@@ -24,12 +24,13 @@ import {
   useSignInWithEmailAndPasswordMutation,
   useSignInWithSamlPopupMutation,
 } from "../services/firebaseApi";
+import { useCreateUserMutation } from "../services/tcApi";
 import { clearATeam } from "../slices/ateam";
 import { clearAuth } from "../slices/auth";
 import { clearPTeam } from "../slices/pteam";
 import { clearTopics } from "../slices/topics";
 import { clearUser } from "../slices/user";
-import { createUser, getMyUserInfo, removeToken, setToken } from "../utils/api";
+import { getMyUserInfo, removeToken, setToken } from "../utils/api";
 import { samlProvider } from "../utils/firebase";
 
 export const authCookieName = "Authorization";
@@ -50,6 +51,7 @@ export function Login() {
 
   const [signInWithEmailAndPassword] = useSignInWithEmailAndPasswordMutation();
   const [signInWithSamlPopup] = useSignInWithSamlPopupMutation();
+  const [createUser] = useCreateUserMutation();
 
   useEffect(() => {
     dispatch(clearAuth());
@@ -112,7 +114,7 @@ export function Login() {
           break;
         }
         case "No such user":
-          await createUser({}); // other values are default
+          await createUser({}); // should get uid & email via firebase credential in api.
           // TODO: navigate to the first time login page, or say hello on snackbar.
           navigate("/account", {
             state: {

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -79,6 +79,22 @@ export const tcApi = createApi({
         };
       },
     }),
+
+    /* User */
+    createUser: builder.mutation({
+      query: (data) => ({
+        url: "/users",
+        method: "POST",
+        body: data,
+      }),
+    }),
+    updateUser: builder.mutation({
+      query: ({ userId, data }) => ({
+        url: `/users/${userId}`,
+        method: "PUT",
+        body: data,
+      }),
+    }),
   }),
 });
 
@@ -89,4 +105,6 @@ export const {
   useGetPTeamAuthQuery,
   useGetPTeamMembersQuery,
   useUploadSBOMFileMutation,
+  useCreateUserMutation,
+  useUpdateUserMutation,
 } = tcApi;


### PR DESCRIPTION
## PR の目的

- ユーザ作成およびユーザ情報更新機能を RTKQ に移行
  - updateUser は（Tc ではめずらしく）put のレスポンスで store を更新する形式になっていた。
    - が、他と合わせて dispatch する形式に変更。
  - 成否判定と snackbar 表示が無かったので、追加。
