### PR TITLE
refine checking slack & mail using RTKQ

### DIFF
--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -24,19 +24,17 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { useCheckMailMutation, useCheckSlackMutation } from "../services/tcApi";
 import { getPTeam } from "../slices/pteam";
 import { getUser } from "../slices/user";
-import {
-  updatePTeam,
-  checkSlack as postCheckSlack,
-  checkMail as postCheckMail,
-} from "../utils/api";
+import { updatePTeam } from "../utils/api";
 import {
   defaultAlertThreshold,
   modalCommonButtonStyle,
   sortedSSVCPriorities,
   ssvcPriorityProps,
 } from "../utils/const";
+import { errorToString } from "../utils/func";
 
 import { CheckButton } from "./CheckButton";
 
@@ -54,6 +52,9 @@ export function PTeamNotificationSetting(props) {
   const [emailMessage, setEmailMessage] = useState();
 
   const { enqueueSnackbar } = useSnackbar();
+
+  const [postCheckMail] = useCheckMailMutation();
+  const [postCheckSlack] = useCheckSlackMutation();
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
   const pteam = useSelector((state) => state.pteam.pteam);
@@ -93,7 +94,7 @@ export function PTeamNotificationSetting(props) {
     return (
       <Box display="flex" sx={{ color: "error.main" }}>
         <ErrorOutlineIcon />
-        <Typography>Connection failed. Reason: {error.response?.data.detail} </Typography>
+        <Typography>Connection failed. Reason: {errorToString(error)}</Typography>
       </Box>
     );
   };
@@ -117,6 +118,7 @@ export function PTeamNotificationSetting(props) {
     setCheckSlack(true);
     setSlackMessage();
     await postCheckSlack({ slack_webhook_url: slackUrl })
+      .unwrap()
       .then(() => {
         setCheckSlack(false);
         setSlackMessage(connectSuccessMessage);
@@ -131,6 +133,7 @@ export function PTeamNotificationSetting(props) {
     setCheckEmail(true);
     setEmailMessage();
     await postCheckMail({ email: mailAddress })
+      .unwrap()
       .then(() => {
         setCheckEmail(false);
         setEmailMessage(connectSuccessMessage);

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -24,7 +24,11 @@ import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { useCheckMailMutation, useCheckSlackMutation, useUpdatePTeamMutation  } from "../services/tcApi";
+import {
+  useCheckMailMutation,
+  useCheckSlackMutation,
+  useUpdatePTeamMutation,
+} from "../services/tcApi";
 import { getPTeam } from "../slices/pteam";
 import { getUser } from "../slices/user";
 import {

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -27,9 +27,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { useCheckMailMutation, useCheckSlackMutation, useUpdatePTeamMutation  } from "../services/tcApi";
 import { getPTeam } from "../slices/pteam";
 import { getUser } from "../slices/user";
-import { } from "../services/tcApi";
-import { getPTeam } from "../slices/pteam";
-import { getUser } from "../slices/user";
 import {
   defaultAlertThreshold,
   modalCommonButtonStyle,

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -96,6 +96,22 @@ export const tcApi = createApi({
         params: params,
       }),
     }),
+
+    /* External */
+    checkMail: builder.mutation({
+      query: (data) => ({
+        url: "external/email/check",
+        method: "POST",
+        body: data,
+      }),
+    }),
+    checkSlack: builder.mutation({
+      query: (data) => ({
+        url: "external/slack/check",
+        method: "POST",
+        body: data,
+      }),
+    }),
   }),
 });
 
@@ -107,4 +123,6 @@ export const {
   useGetPTeamMembersQuery,
   useUploadSBOMFileMutation,
   useSearchTopicsQuery,
+  useCheckMailMutation,
+  useCheckSlackMutation,
 } = tcApi;


### PR DESCRIPTION
## PR の目的

- slack, email の疎通確認を RTKQ 化。
  - これらはリソースの更新を行っているわけではないので query でも良さそうだが、POST メソッドなので mutation。
  - mutation だとキャッシュ適用されないし、実行結果を chain して画面更新しているので、mutation の方が都合がよい。