### PR TITLE
fix error handling

### DIFF
--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -31,7 +31,12 @@ import { useCreateTopicMutation } from "../services/tcApi";
 import { getATeamTopics } from "../slices/ateam";
 import { getTopic } from "../slices/topics";
 import { actionTypes } from "../utils/const";
-import { pickMismatchedTopicActionTags, validateNotEmpty, validateUUID } from "../utils/func";
+import {
+  errorToString,
+  pickMismatchedTopicActionTags,
+  validateNotEmpty,
+  validateUUID,
+} from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
 import { ActionItem } from "./ActionItem";
@@ -69,13 +74,6 @@ export function ATeamTopicCreateModal(props) {
     setThreatImpact(1);
     setTagIds([]);
     setActions([]);
-  };
-
-  const operationError = (error) => {
-    const resp = error.response ?? { status: "???", statusText: error.toString() };
-    enqueueSnackbar(`Operation failed: ${resp.status} ${resp.statusText} - ${resp.data?.detail}`, {
-      variant: "error",
-    });
   };
 
   const validateTopicParams = () => validateUUID(topicId) && validateNotEmpty(title);
@@ -128,7 +126,11 @@ export function ATeamTopicCreateModal(props) {
           dispatch(getATeamTopics(ateamId)),
         ]);
       })
-      .catch((error) => operationError(error));
+      .catch((error) =>
+        enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+          variant: "error",
+        }),
+      );
     resetParams();
     onSetOpen(false);
   };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -43,7 +43,7 @@ import {
   deleteAction,
 } from "../utils/api";
 import { actionTypes } from "../utils/const";
-import { validateNotEmpty, validateUUID, setEquals } from "../utils/func";
+import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
 import { ActionItem } from "./ActionItem";
@@ -211,7 +211,11 @@ export function TopicModal(props) {
         reloadTopicAfterAPI();
         onSetOpen(false);
       })
-      .catch((error) => operationError(error));
+      .catch((error) =>
+        enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+          variant: "error",
+        }),
+      );
   };
 
   const handleUpdateTopic = async () => {


### PR DESCRIPTION
## PR の目的
- 下記のPRのエラーハンドリング部分でoperationErrorを使用していた部分をerrorToStringに修正しました。 
- https://github.com/nttcom/threatconnectome/pull/414
- operationErrorは、RTKクエリのデータ構造に対応していないため、errorToStringに変更しています。