### PR TITLE
bugfix/delete-slash

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -144,7 +144,7 @@ export const tcApi = createApi({
     /* PTeam Service */
     updatePTeamService: builder.mutation({
       query: ({ pteamId, serviceId, data }) => ({
-        url: `pteams/${pteamId}/services/${serviceId}/`,
+        url: `pteams/${pteamId}/services/${serviceId}`,
         method: "PUT",
         body: data,
       }),


### PR DESCRIPTION
## PR の目的
- 本番環境でupdatePTeamServiceができない問題について対応
- urlの末尾についていたスラッシュを削除しました
