### PR TITLE
refine getting pteam service thumbnail using RTKQ

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -14,12 +14,9 @@ import {
   Typography,
 } from "@mui/material";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useState } from "react";
 
-import { storeServiceThumbnail } from "../slices/pteam";
-import { getServiceThumbnail } from "../utils/api";
-import { blobToDataURL } from "../utils/func";
+import { useGetPTeamServiceThumbnailQuery } from "../services/tcApi";
 
 import { PTeamStatusSSVCCards } from "./PTeamStatusSSVCCards";
 
@@ -71,37 +68,15 @@ ServiceIDCopyButton.propTypes = {
 export function PTeamServiceDetails(props) {
   const { pteamId, service, expandService, onSwitchExpandService, highestSsvcPriority } = props;
 
-  const dispatch = useDispatch();
+  const { data: thumbnail } = useGetPTeamServiceThumbnailQuery({
+    pteamId,
+    serviceId: service.service_id,
+  });
 
-  const thumbnails = useSelector((state) => state.pteam.serviceThumbnails);
-
-  const [image, setImage] = useState(noImageAvailableUrl);
-
-  const thumbnail = thumbnails[service.service_id];
+  const image = thumbnail ?? noImageAvailableUrl;
   const serviceName = service.service_name;
   const description = service.description;
   const keywords = service.keywords;
-
-  useEffect(() => {
-    if (thumbnail === undefined) {
-      getServiceThumbnail(pteamId, service.service_id)
-        .then(async (response) => {
-          const dataUrl = await blobToDataURL(response.data);
-          dispatch(storeServiceThumbnail({ serviceId: service.service_id, data: dataUrl }));
-        })
-        .catch((error) => {
-          dispatch(
-            storeServiceThumbnail({ serviceId: service.service_id, data: noImageAvailableUrl }),
-          );
-        });
-    }
-  }, [pteamId, service.service_id, thumbnail, dispatch]);
-
-  useEffect(() => {
-    if (thumbnail !== undefined && image !== thumbnail) {
-      setImage(thumbnail);
-    }
-  }, [thumbnail, image]);
 
   return (
     <>

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -1,5 +1,7 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
+import { blobToDataURL } from "../utils/func";
+
 const _responseListToDictConverter =
   (keyName, valueName = undefined) =>
   async (response) =>
@@ -150,6 +152,14 @@ export const tcApi = createApi({
       }),
     }),
 
+    /* PTeam Service Thumbnail */
+    getPTeamServiceThumbnail: builder.query({
+      query: ({ pteamId, serviceId }) => ({
+        url: `pteams/${pteamId}/services/${serviceId}/thumbnail`,
+        responseHandler: async (response) => await blobToDataURL(await response.blob()),
+      }),
+    }),
+
     /* SBOM */
     uploadSBOMFile: builder.mutation({
       query: ({ pteamId, serviceName, sbomFile, forceMode = true }) => {
@@ -249,6 +259,7 @@ export const {
   useDeletePTeamMemberMutation,
   useUploadSBOMFileMutation,
   useUpdatePTeamServiceMutation,
+  useGetPTeamServiceThumbnailQuery,
   useCreateTicketStatusMutation,
   useSearchTopicsQuery,
   useCreateUserMutation,


### PR DESCRIPTION
## PR の目的

- サムネイル取得処理を RTKQ 化
  - 登録機能は UI では未実装なので、cache tag は未設定。
  - バイナリデータの DataURL 化は responseHandler で実施。
    - ここでシリアライズ可能データに加工しておかないと non-serializable 云々と怒られる。
  - error, isLoading な場合はデフォルト画像を表示するので、他の RTKQ 処理とは少し違っている。
  - ListModal の方は、不特定多数の query が必要なケースの一例。
    - 個々の query をサブコンポーネントで処理する形にせざるを得ない？