### PR TITLE
replace the API for deleteTopic's RTK Query mutation

### DIFF
--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -15,12 +15,13 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { deleteTopic } from "../utils/api";
+import { useDeleteTopicMutation } from "../services/tcApi";
 import { commonButtonStyle } from "../utils/const";
 
 export function TopicDeleteModal(props) {
   const { topicId, onSetOpenTopicModal, onDelete } = props;
   const [open, setOpen] = useState(false);
+  const [deleteTopic] = useDeleteTopicMutation();
 
   const { enqueueSnackbar } = useSnackbar();
 

--- a/web/src/components/TopicDeleteModal.jsx
+++ b/web/src/components/TopicDeleteModal.jsx
@@ -34,6 +34,7 @@ export function TopicDeleteModal(props) {
 
   function handleDelete() {
     deleteTopic(topicId)
+      .unwrap()
       .then(async () => {
         await Promise.all([
           onDelete && onDelete(),

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -197,6 +197,13 @@ export const tcApi = createApi({
       }),
     }),
 
+    deleteTopic: builder.mutation({
+      query: (topicId) => ({
+        url: `topics/${topicId}`,
+        method: "DELETE",
+      }),
+    }),
+
     /* User */
     createUser: builder.mutation({
       query: (data) => ({
@@ -247,6 +254,7 @@ export const {
   useApplyPTeamInvitationMutation,
   useGetPTeamMembersQuery,
   useDeletePTeamMemberMutation,
+  useDeleteTopicMutation,
   useUploadSBOMFileMutation,
   useUpdatePTeamServiceMutation,
   useCreateTicketStatusMutation,


### PR DESCRIPTION
## PR の目的
- deleteTopicのRTKquery導入によるMutationのAPI入替

## 経緯・意図・意思決定
- delete Topic APIの管理をRTK Queryを用いて行うため

