### PR TITLE
use transformResponse instead of responseHandler

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -4,10 +4,8 @@ import { blobToDataURL } from "../utils/func";
 
 const _responseListToDictConverter =
   (keyName, valueName = undefined) =>
-  async (response) => {
-    const jsonData = await response.json();
-    if (response.status !== 200) return jsonData; // error
-    return jsonData.reduce((ret, item) => {
+  (data, meta, arg) => {
+    return data.reduce((ret, item) => {
       /* convert array to dict,
        *    [{x: a, y: b}, ...] => {a: {x: a, y: b}, ...} // if keyName = "x"
        * or [{x: a, y: b}, ...] => {a: b, ...} // and if valueName = "y"
@@ -172,10 +170,8 @@ export const tcApi = createApi({
 
     /* PTeam Auth */
     getPTeamAuth: builder.query({
-      query: (pteamId) => ({
-        url: `pteams/${pteamId}/authority`,
-        responseHandler: _responseListToDictConverter("user_id", "authorities"),
-      }),
+      query: (pteamId) => `pteams/${pteamId}/authority`,
+      transformResponse: _responseListToDictConverter("user_id", "authorities"),
       providesTags: (result, error, pteamId) => [{ type: "PTeamAuth", id: pteamId }],
     }),
     updatePTeamAuth: builder.mutation({
@@ -205,10 +201,8 @@ export const tcApi = createApi({
 
     /* PTeam Members */
     getPTeamMembers: builder.query({
-      query: (pteamId) => ({
-        url: `pteams/${pteamId}/members`,
-        responseHandler: _responseListToDictConverter("user_id"),
-      }),
+      query: (pteamId) => `pteams/${pteamId}/members`,
+      transformResponse: _responseListToDictConverter("user_id"),
     }),
     deletePTeamMember: builder.mutation({
       query: ({ pteamId, userId }) => ({


### PR DESCRIPTION
## PR の目的

- レスポンスデータの構造変更処理を、responseHandler でなく transformResponse で行うように修正
  - responseHandler は response 自体を処理する必要があり、エラー処理も必要。
  - transformResponse は success 時の response.data が渡されるのでエラー処理は不要。
    - ドキュメントでは引数名が response なので紛らわしいが、`{ data } = useFooQuery()` の data が渡される。
    - エラー処理をしたい場合は、別途 transformErrorResponse を登録する。