### PR TITLE
replace the API for AteamTopicCommentmutation

### DIFF
--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -43,10 +43,10 @@ import { WarningTooltip } from "../components/WarningTooltip";
 import styles from "../cssModule/button.module.css";
 import { getActions, getTopic } from "../slices/topics";
 import {
-  createATeamTopicComment as apiCreateATeamTopicComment,
-  getATeamTopicComments as apiGetATeamTopicComments,
-  updateATeamTopicComment as apiUpdateATeamTopicComment,
-} from "../utils/api";
+  useCreateATeamTopicCommentMutation,
+  useUpdateATeamTopicCommentMutation,
+} from "../services/tcApi";
+import { getATeamTopicComments as apiGetATeamTopicComments } from "../utils/api";
 import { rootPrefix, threatImpactNames } from "../utils/const";
 import { a11yProps, dateTimeFormat, tagsMatched } from "../utils/func.js";
 
@@ -62,6 +62,8 @@ export function AnalysisTopic(props) {
   const [listHeight, setListHeight] = useState(0);
   const [detailOpen, setDetailOpen] = useState(false);
   const [actionExpanded, setActionExpanded] = useState(false);
+  const [apiCreateATeamTopicComment] = useCreateATeamTopicCommentMutation();
+  const [apiUpdateATeamTopicComment] = useUpdateATeamTopicCommentMutation();
 
   const topics = useSelector((state) => state.topics.topics);
   const actions = useSelector((state) => state.topics.actions);
@@ -112,6 +114,7 @@ export function AnalysisTopic(props) {
     await apiCreateATeamTopicComment(ateam.ateam_id, targetTopic.topic_id, {
       comment: newComment.trim(),
     })
+      .unwrap()
       .then(() => {
         handleReloadComments(targetTopic.topic_id);
         setNewComment("");
@@ -127,6 +130,7 @@ export function AnalysisTopic(props) {
     await apiUpdateATeamTopicComment(ateam.ateam_id, targetTopic.topic_id, commentId, {
       comment: editComment.trim(),
     })
+      .unwrap()
       .then(() => {
         handleReloadComments(targetTopic.topic_id);
         setEditComment("");

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -111,8 +111,12 @@ export function AnalysisTopic(props) {
       enqueueSnackbar("Invalid comment", { variant: "error" });
       return;
     }
-    await apiCreateATeamTopicComment(ateam.ateam_id, targetTopic.topic_id, {
-      comment: newComment.trim(),
+    await apiCreateATeamTopicComment({
+      ateamId: ateam.ateam_id,
+      topicId: targetTopic.topic_id,
+      data: {
+        comment: newComment.trim(),
+      },
     })
       .unwrap()
       .then(() => {
@@ -127,8 +131,13 @@ export function AnalysisTopic(props) {
       enqueueSnackbar("Invalid comment", { variant: "error" });
       return;
     }
-    await apiUpdateATeamTopicComment(ateam.ateam_id, targetTopic.topic_id, commentId, {
-      comment: editComment.trim(),
+    await apiUpdateATeamTopicComment({
+      ateamId: ateam.ateam_id,
+      topicId: targetTopic.topic_id,
+      commentId,
+      data: {
+        comment: editComment.trim(),
+      },
     })
       .unwrap()
       .then(() => {

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -48,7 +48,7 @@ import {
 import { getActions, getTopic } from "../slices/topics";
 import { getATeamTopicComments as apiGetATeamTopicComments } from "../utils/api";
 import { rootPrefix, threatImpactNames } from "../utils/const";
-import { a11yProps, dateTimeFormat, tagsMatched } from "../utils/func.js";
+import { a11yProps, dateTimeFormat, errorToString, tagsMatched } from "../utils/func.js";
 
 export function AnalysisTopic(props) {
   const { user, ateam, targetTopic, isAdmin = false } = props;
@@ -123,7 +123,11 @@ export function AnalysisTopic(props) {
         handleReloadComments(targetTopic.topic_id);
         setNewComment("");
       })
-      .catch((error) => operationError(error));
+      .catch((error) =>
+        enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+          variant: "error",
+        }),
+      );
   };
 
   const handleUpdateComment = async (commentId) => {
@@ -145,7 +149,11 @@ export function AnalysisTopic(props) {
         setEditComment("");
         setEditable(false);
       })
-      .catch((error) => operationError(error));
+      .catch((error) =>
+        enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+          variant: "error",
+        }),
+      );
   };
 
   const pteamServiceTagLinkURL = (pteamId, serviceId, tagId) => {

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -41,11 +41,11 @@ import { TopicEditModal } from "../components/TopicEditModal";
 import { UUIDTypography } from "../components/UUIDTypography";
 import { WarningTooltip } from "../components/WarningTooltip";
 import styles from "../cssModule/button.module.css";
-import { getActions, getTopic } from "../slices/topics";
 import {
   useCreateATeamTopicCommentMutation,
   useUpdateATeamTopicCommentMutation,
 } from "../services/tcApi";
+import { getActions, getTopic } from "../slices/topics";
 import { getATeamTopicComments as apiGetATeamTopicComments } from "../utils/api";
 import { rootPrefix, threatImpactNames } from "../utils/const";
 import { a11yProps, dateTimeFormat, tagsMatched } from "../utils/func.js";

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -62,8 +62,8 @@ export function AnalysisTopic(props) {
   const [listHeight, setListHeight] = useState(0);
   const [detailOpen, setDetailOpen] = useState(false);
   const [actionExpanded, setActionExpanded] = useState(false);
-  const [apiCreateATeamTopicComment] = useCreateATeamTopicCommentMutation();
-  const [apiUpdateATeamTopicComment] = useUpdateATeamTopicCommentMutation();
+  const [createATeamTopicComment] = useCreateATeamTopicCommentMutation();
+  const [updateATeamTopicComment] = useUpdateATeamTopicCommentMutation();
 
   const topics = useSelector((state) => state.topics.topics);
   const actions = useSelector((state) => state.topics.actions);
@@ -111,7 +111,7 @@ export function AnalysisTopic(props) {
       enqueueSnackbar("Invalid comment", { variant: "error" });
       return;
     }
-    await apiCreateATeamTopicComment({
+    await createATeamTopicComment({
       ateamId: ateam.ateam_id,
       topicId: targetTopic.topic_id,
       data: {
@@ -131,10 +131,10 @@ export function AnalysisTopic(props) {
       enqueueSnackbar("Invalid comment", { variant: "error" });
       return;
     }
-    await apiUpdateATeamTopicComment({
+    await updateATeamTopicComment({
       ateamId: ateam.ateam_id,
       topicId: targetTopic.topic_id,
-      commentId,
+      commentId: commentId,
       data: {
         comment: editComment.trim(),
       },

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -23,10 +23,10 @@ export function CommentDeleteModal(props) {
   const { comment, onClose } = props;
 
   const { enqueueSnackbar } = useSnackbar();
-  const [apiDeleteATeamTopicComment] = useDeleteATeamTopicCommentMutation();
+  const [deleteATeamTopicComment] = useDeleteATeamTopicCommentMutation();
 
   const handleAction = async () => {
-    await apiDeleteATeamTopicComment({
+    await deleteATeamTopicComment({
       ateamId: comment.ateam_id,
       topicId: comment.topic_id,
       commentId: comment.comment_id,

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -26,7 +26,11 @@ export function CommentDeleteModal(props) {
   const [apiDeleteATeamTopicComment] = useDeleteATeamTopicCommentMutation();
 
   const handleAction = async () => {
-    await apiDeleteATeamTopicComment(comment.ateam_id, comment.topic_id, comment.comment_id)
+    await apiDeleteATeamTopicComment({
+      ateamId: comment.ateam_id,
+      topicId: comment.topic_id,
+      commentId: comment.comment_id,
+    })
       .unwrap()
       .then(() => onClose())
       .catch((error) => {

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -17,7 +17,7 @@ import React from "react";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useDeleteATeamTopicCommentMutation } from "../services/tcApi";
-import { dateTimeFormat } from "../utils/func";
+import { dateTimeFormat, errorToString } from "../utils/func";
 
 export function CommentDeleteModal(props) {
   const { comment, onClose } = props;
@@ -33,13 +33,11 @@ export function CommentDeleteModal(props) {
     })
       .unwrap()
       .then(() => onClose())
-      .catch((error) => {
-        enqueueSnackbar(
-          "Operation failed: " +
-            `${error.response.status} ${error.response.statusText} ${error.response.data?.detail}`,
-          { variant: "error" },
-        );
-      });
+      .catch((error) =>
+        enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+          variant: "error",
+        }),
+      );
   };
 
   return (

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -16,16 +16,18 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import { deleteATeamTopicComment as apiDeleteATeamTopicComment } from "../utils/api";
+import useDeleteATeamTopicCommentMutation from "../services/tcApi";
 import { dateTimeFormat } from "../utils/func";
 
 export function CommentDeleteModal(props) {
   const { comment, onClose } = props;
 
   const { enqueueSnackbar } = useSnackbar();
+  const [apiDeleteATeamTopicComment] = useDeleteATeamTopicCommentMutation();
 
   const handleAction = async () => {
     await apiDeleteATeamTopicComment(comment.ateam_id, comment.topic_id, comment.comment_id)
+      .unwrap()
       .then(() => onClose())
       .catch((error) => {
         enqueueSnackbar(

--- a/web/src/components/CommentDeleteModal.jsx
+++ b/web/src/components/CommentDeleteModal.jsx
@@ -16,7 +16,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import dialogStyle from "../cssModule/dialog.module.css";
-import useDeleteATeamTopicCommentMutation from "../services/tcApi";
+import { useDeleteATeamTopicCommentMutation } from "../services/tcApi";
 import { dateTimeFormat } from "../utils/func";
 
 export function CommentDeleteModal(props) {

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -249,6 +249,30 @@ export const tcApi = createApi({
       }),
     }),
 
+    /* Topic Comment */
+    createATeamTopicComment: builder.mutation({
+      query: ({ ateamId, topicId, data }) => ({
+        url: `ateams/${ateamId}/topiccomment/${topicId}`,
+        method: "POST",
+        body: data,
+      }),
+    }),
+
+    updateATeamTopicComment: builder.mutation({
+      query: ({ ateamId, topicId, commentId, data }) => ({
+        url: `ateams/${ateamId}/topiccomment/${topicId}/${commentId}`,
+        method: "PUT",
+        body: data,
+      }),
+    }),
+
+    deleteATeamTopicComment: builder.mutation({
+      query: ({ ateamId, topicId, commentId }) => ({
+        url: `ateams/${ateamId}/topiccomment/${topicId}/${commentId}`,
+        method: "DELETE",
+      }),
+    }),
+
     /* Topics */
     searchTopics: builder.query({
       query: (params) => ({
@@ -323,11 +347,14 @@ export const {
   useCreateATeamInvitationMutation,
   useApplyATeamInvitationMutation,
   useDeleteATeamMemberMutation,
+  useDeleteATeamTopicCommentMutation,
+  useCreateATeamTopicCommentMutation,
   useCreateATeamWatchingRequestMutation,
   useApplyATeamWatchingRequestMutation,
   useRemoveWatchingPTeamMutation,
   useGetPTeamQuery,
   useCreatePTeamMutation,
+  useUpdateATeamTopicCommentMutation,
   useUpdatePTeamMutation,
   useUpdatePTeamAuthMutation,
   useUpdateTopicMutation,


### PR DESCRIPTION
## PR の目的
- AteamTopicCommentmutation関連のAPI入替
   - createATeamTopicComment、updateATeamTopicComment、deleteATeamTopicComment
   - 
## 経緯・意図・意思決定
- AteamTopicCommentmutation関連のAPIをRTKqueryを使用したものに変更するため
