### PR TITLE
replace_createTag_with_RTKQuery

### DIFF
--- a/web/src/components/TopicTagSelector.jsx
+++ b/web/src/components/TopicTagSelector.jsx
@@ -22,9 +22,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { FixedSizeList } from "react-window";
 
 import dialogStyle from "../cssModule/dialog.module.css";
+import { useCreateTagMutation } from "../services/tcApi";
 import { getTags } from "../slices/tags";
-import { createTag } from "../utils/api";
 import { commonButtonStyle } from "../utils/const";
+import { errorToString } from "../utils/func";
 
 export function TopicTagSelector(props) {
   const { currentSelectedIds, onCancel, onApply, sx } = props;
@@ -36,6 +37,8 @@ export function TopicTagSelector(props) {
   const { enqueueSnackbar } = useSnackbar();
 
   const dispatch = useDispatch();
+
+  const [createTag] = useCreateTagMutation();
 
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
@@ -57,6 +60,7 @@ export function TopicTagSelector(props) {
       enqueueSnackbar(`Create tag failed: ${error.response?.data?.detail}`, { variant: "error" });
     }
     await createTag({ tag_name: search.trim() })
+      .unwrap()
       .then((success) => onSuccess(success))
       .catch((error) => onError(error));
   };

--- a/web/src/components/TopicTagSelector.jsx
+++ b/web/src/components/TopicTagSelector.jsx
@@ -57,7 +57,7 @@ export function TopicTagSelector(props) {
       setSearch("");
     }
     function onError(error) {
-      enqueueSnackbar(`Create tag failed: ${error.response?.data?.detail}`, { variant: "error" });
+      enqueueSnackbar(`Create tag failed: ${errorToString(error)}`, { variant: "error" });
     }
     await createTag({ tag_name: search.trim() })
       .unwrap()

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -312,7 +312,14 @@ export const tcApi = createApi({
         body: data,
       }),
     }),
-
+    /* tags */
+    createTag: builder.mutation({
+      query: (data) => ({
+        url: "/tags",
+        method: "POST",
+        body: data,
+      }),
+    }),
     /* External */
     checkMail: builder.mutation({
       query: (data) => ({
@@ -367,6 +374,7 @@ export const {
   useCreateUserMutation,
   useUpdateUserMutation,
   useCreateTopicMutation,
+  useCreateTagMutation,
   useCheckMailMutation,
   useCheckSlackMutation,
 } = tcApi;


### PR DESCRIPTION
## PR の目的
  - createTag機能に関連するAPI関連処理をRTKQueryを用いたものに改修
