### PR TITLE
replace the API for updateTopic in TopicModal.jsx to use RTK Query

### DIFF
--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -29,6 +29,7 @@ import { useDispatch, useSelector } from "react-redux";
 import dialogStyle from "../cssModule/dialog.module.css";
 import {
   useCreateTopicMutation,
+  useUpdateTopicMutation,
   useCreateActionMutation,
   useUpdateActionMutation,
   useDeleteActionMutation,
@@ -40,7 +41,6 @@ import {
   getPTeamTagsSummary,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
-import { useUpdateTopicMutation } from "../services/tcApi";
 import { fetchFlashsense } from "../utils/api";
 import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -40,7 +40,8 @@ import {
   getPTeamTagsSummary,
 } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
-import { fetchFlashsense, updateTopic } from "../utils/api";
+import { useUpdateTopicMutation } from "../services/tcApi";
+import { fetchFlashsense } from "../utils/api";
 import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";
 
@@ -91,6 +92,7 @@ export function TopicModal(props) {
   const [updateAction] = useUpdateActionMutation();
   const [deleteAction] = useDeleteActionMutation();
   const [createTopic] = useCreateTopicMutation();
+  const [updateTopic] = useUpdateTopicMutation();
 
   const dispatch = useDispatch();
 
@@ -272,7 +274,13 @@ export function TopicModal(props) {
     }
 
     async function updateTopicPromise() {
-      return updateTopic(topicId, data).catch((error) => operationError(error));
+      return updateTopic({ topicId: topicId, data: data })
+        .unwrap()
+        .catch((error) =>
+          enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
+            variant: "error",
+          }),
+        );
     }
 
     async function updateActionPromise() {


### PR DESCRIPTION
## PR の目的
- web/src/components/TopicModal.jsxにおけるupdateTopicのRTKquery導入によるMutationのAPI入替

## 経緯・意図・意思決定
- 以前のupdateTopic APIの移行作業にて、TopicModal.jsxのupdateTopicの移行作業漏れがあったため。
