### PR TITLE
replacement process for ateam member

### DIFF
--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -8,7 +8,7 @@ import { ATeamWatching } from "../components/ATeamWatching";
 import { TabPanel } from "../components/TabPanel";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useGetATeamMembersQuery, useGetUserMeQuery } from "../services/tcApi";
-import { getATeam, getATeamAuth, getATeamMembers } from "../slices/ateam";
+import { getATeam, getATeamAuth } from "../slices/ateam";
 import { noATeamMessage, experienceColors } from "../utils/const";
 import { a11yProps, errorToString } from "../utils/func.js";
 
@@ -40,9 +40,8 @@ export function ATeam() {
   useEffect(() => {
     if (!ateamId) return;
     if (!ateam) dispatch(getATeam(ateamId));
-    if (!members) dispatch(getATeamMembers(ateamId));
     if (!authorities) dispatch(getATeamAuth(ateamId));
-  }, [dispatch, ateamId, ateam, members, authorities]);
+  }, [dispatch, ateamId, ateam, authorities]);
 
   const tabHandleChange = (event, newValue) => {
     setTabValue(newValue);

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -127,7 +127,7 @@ export const tcApi = createApi({
     /* ATeam Members */
     getATeamMembers: builder.query({
       query: (ateamId) => ({
-        url: `/ateams/${ateamId}/members`,
+        url: `ateams/${ateamId}/members`,
         method: "GET",
       }),
       providesTags: (result, error, arg) => [

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -4,7 +4,6 @@ import {
   getATeam as apiGetATeam,
   getATeamAuth as apiGetATeamAuth,
   getATeamAuthInfo as apiGetATeamAuthInfo,
-  getATeamMembers as apiGetATeamMembers,
   getATeamTopics as apiGetATeamTopics,
 } from "../utils/api";
 
@@ -34,21 +33,6 @@ export const getATeamAuth = createAsyncThunk(
     })),
 );
 
-export const getATeamMembers = createAsyncThunk(
-  "ateam/getATeamMembers",
-  async (ateamId) =>
-    await apiGetATeamMembers(ateamId).then((response) => ({
-      data: response.data.reduce(
-        (ret, val) => ({
-          ...ret,
-          [val.user_id]: val,
-        }),
-        {},
-      ),
-      ateamId: ateamId,
-    })),
-);
-
 export const getATeamTopics = createAsyncThunk(
   "ateam/getATeamTopics",
   async (ateamId) =>
@@ -63,7 +47,6 @@ const _initialState = {
   ateam: undefined,
   authInfo: undefined,
   authorities: undefined,
-  members: undefined,
   ateamTopics: undefined,
 };
 
@@ -95,10 +78,6 @@ const ateamSlice = createSlice({
       .addCase(getATeamAuth.fulfilled, (state, action) => ({
         ...state,
         authorities: action.payload.data,
-      }))
-      .addCase(getATeamMembers.fulfilled, (state, action) => ({
-        ...state,
-        members: action.payload.data,
       }))
       .addCase(getATeamTopics.fulfilled, (state, action) => ({
         ...state,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -40,8 +40,6 @@ export const getServiceThumbnail = async (pteamId, serviceId) =>
 // ateams
 export const getATeam = async (ateamId) => axios.get(`/ateams/${ateamId}`);
 
-export const getATeamMembers = async (ateamId) => axios.get(`/ateams/${ateamId}/members`);
-
 export const getATeamInvited = async (tokenId) => axios.get(`/ateams/invitation/${tokenId}`);
 
 export const getATeamAuthInfo = async () => axios.get("/ateams/auth_info");


### PR DESCRIPTION
## PR の目的
- 下記のPRでできていなかった、Queryの置き換え処理を行いました
- https://github.com/nttcom/threatconnectome/pull/436

## 経緯・意図・意思決定
- api.js からgeAteamMembersに関するAPIを削除しました
- slices/ateam.jsからgetATeamMembersに関する部分を削除しました
- tcApi.jsで定義するurlで先頭の「/」を削除しました
- dispatch(getATeamMembers(ateamId))を行っている部分を削除しました