### PR TITLE
add TRIVY_DB_REPOSITORY to use ecr trivydb repo

### DIFF
--- a/.github/workflows/trivy-api.yml
+++ b/.github/workflows/trivy-api.yml
@@ -25,3 +25,6 @@ jobs:
           scan-type: "fs"
           scan-ref: "./api"
           trivy-config: trivy.yaml
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db

--- a/.github/workflows/trivy-web.yml
+++ b/.github/workflows/trivy-web.yml
@@ -38,3 +38,6 @@ jobs:
           scan-type: "fs"
           scan-ref: "./web"
           trivy-config: trivy.yaml
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db,public.ecr.aws/aquasecurity/trivy-java-db


### PR DESCRIPTION
## PR の目的

GitHub Actionsによるtrivyスキャンが、trivydbダウンロードエラーにより失敗する事象への対処。
trivydbのダウンロードrepoを複数指定することにより、ghcr.io からのダウンロードに失敗した場合に ecr.aws からのダウンロードを試行するように変更

## 経緯・意図・意思決定
環境変数 `TRIVY_DB_REPOSITORY` 、 `TRIVY_JAVA_DB_REPOSITORY` にdbのrepository url を指定できる。
またカンマ区切りにすることで、複数のrepoを指定できるようになりる。
今回は ecr.aws のrepositoryを記載することで、 ghcr のrepoのダウンロードに失敗した場合に ecr.aws repo からDBをダウンロードできるように設定した

`TRIVY_DB_REPOSITORY`  は、 `--db-repository` オプションと同一の効果がある。 `----db-repository` で複数指定できる旨は以下に記載されている。
https://github.com/aquasecurity/trivy/discussions/7640

## 参考文献
同一の問題について議論したissue
https://github.com/aquasecurity/trivy-action/issues/389

解決方法の例を示したコメント
https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2401703776

同様の指定を行っている事例
https://github.com/SpecterOps/BloodHound/blob/5cccec61e50844b67f89273aaf777a62f3fcf16b/.github/workflows/vuln-scan.yml#L41
