### PR TITLE
refine getting pteam topic_ids using RTKQ

### DIFF
--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -10,20 +10,18 @@ import { SSVCPriorityCountChip } from "./SSVCPriorityCountChip";
 import { TopicCard } from "./TopicCard";
 
 export function PTeamTaggedTopics(props) {
-  const { pteamId, tagId, service, isSolved, references, taggedTopics } = props;
+  const { pteamId, tagId, service, references, taggedTopics } = props;
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
 
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
-  const targets = taggedTopics?.[isSolved ? "solved" : "unsolved"];
-
-  if (targets === undefined || !allTags) {
+  if (taggedTopics === undefined || !allTags) {
     return <>Loading...</>;
   }
 
-  const targetTopicIds = targets.topic_ids.slice(perPage * (page - 1), perPage * page);
+  const targetTopicIds = taggedTopics.topic_ids.slice(perPage * (page - 1), perPage * page);
   const presetTagId = tagId;
   const presetParentTagId = allTags.find((tag) => tag.tag_id === tagId)?.parent_id;
 
@@ -32,7 +30,7 @@ export function PTeamTaggedTopics(props) {
       <Pagination
         shape="rounded"
         page={page}
-        count={Math.ceil(targets.topic_ids.length / perPage)}
+        count={Math.ceil(taggedTopics.topic_ids.length / perPage)}
         onChange={(event, value) => setPage(value)}
       />
       <Select
@@ -63,7 +61,7 @@ export function PTeamTaggedTopics(props) {
           <SSVCPriorityCountChip
             key={ssvcPriority}
             ssvcPriority={ssvcPriority}
-            count={targets.ssvc_priority_count[ssvcPriority]}
+            count={taggedTopics.ssvc_priority_count[ssvcPriority]}
             outerSx={{ mr: "10px" }}
           />
         ))}
@@ -97,7 +95,6 @@ PTeamTaggedTopics.propTypes = {
   pteamId: PropTypes.string.isRequired,
   tagId: PropTypes.string.isRequired,
   service: PropTypes.object.isRequired,
-  isSolved: PropTypes.bool.isRequired,
   references: PropTypes.array.isRequired,
   taggedTopics: PropTypes.object.isRequired,
 };

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -10,15 +10,14 @@ import { SSVCPriorityCountChip } from "./SSVCPriorityCountChip";
 import { TopicCard } from "./TopicCard";
 
 export function PTeamTaggedTopics(props) {
-  const { pteamId, tagId, service, isSolved, references } = props;
+  const { pteamId, tagId, service, isSolved, references, taggedTopics } = props;
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
 
-  const taggedTopics = useSelector((state) => state.pteam.taggedTopics); // dispatched by parent
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
 
-  const targets = taggedTopics?.[service?.service_id]?.[tagId]?.[isSolved ? "solved" : "unsolved"];
+  const targets = taggedTopics?.[isSolved ? "solved" : "unsolved"];
 
   if (targets === undefined || !allTags) {
     return <>Loading...</>;
@@ -100,4 +99,5 @@ PTeamTaggedTopics.propTypes = {
   service: PropTypes.object.isRequired,
   isSolved: PropTypes.bool.isRequired,
   references: PropTypes.array.isRequired,
+  taggedTopics: PropTypes.object.isRequired,
 };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -36,11 +36,7 @@ import {
   useUpdateActionMutation,
   useDeleteActionMutation,
 } from "../services/tcApi";
-import {
-  getPTeamServiceTaggedTopicIds,
-  getPTeamServiceTagsSummary,
-  getPTeamTagsSummary,
-} from "../slices/pteam";
+import { getPTeamServiceTagsSummary, getPTeamTagsSummary } from "../slices/pteam";
 import { getTopic } from "../slices/topics";
 import { fetchFlashsense } from "../utils/api";
 import { actionTypes } from "../utils/const";
@@ -188,18 +184,6 @@ export function TopicModal(props) {
       dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
       dispatch(getPTeamTagsSummary({ pteamId: pteamId })),
     ]);
-    // update only if needed
-    if (pteamId && presetTagId) {
-      await Promise.all([
-        dispatch(
-          getPTeamServiceTaggedTopicIds({
-            pteamId: pteamId,
-            serviceId: serviceId,
-            tagId: presetTagId,
-          }),
-        ),
-      ]);
-    }
   };
 
   const handleCreateTopic = async () => {
@@ -303,7 +287,7 @@ export function TopicModal(props) {
         };
         if (action.action_id === null) {
           promiseArray.push(
-            createAction({ actionRequest })
+            createAction(actionRequest)
               .unwrap()
               .catch((error) => {
                 enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
@@ -443,15 +427,6 @@ export function TopicModal(props) {
   };
 
   const handleDeleteTopic = () => {
-    if (presetTagId) {
-      dispatch(
-        getPTeamServiceTaggedTopicIds({
-          pteamId: pteamId,
-          serviceId: serviceId,
-          tagId: presetTagId,
-        }),
-      );
-    }
     dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
     dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
   };

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -27,7 +27,6 @@ import { useDispatch } from "react-redux";
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useCreateTicketStatusMutation } from "../services/tcApi";
 import {
-  getPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary,
   getPTeamTagsSummary,
   getTicketsRelatedToServiceTopicTag,
@@ -78,13 +77,6 @@ export function TopicStatusSelector(props) {
     );
     dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
     dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
-    dispatch(
-      getPTeamServiceTaggedTopicIds({
-        pteamId: pteamId,
-        serviceId: serviceId,
-        tagId: tagId,
-      }),
-    );
   };
 
   const modifyTicketStatus = async (selectedStatus) => {

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -17,7 +17,7 @@ import { a11yProps, errorToString } from "../utils/func.js";
 export function Tag() {
   const [tabValue, setTabValue] = useState(0);
 
-  const skip = useSkipUntilAuthTokenIsReady();
+  const skipByAuth = useSkipUntilAuthTokenIsReady();
 
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by App
   const pteam = useSelector((state) => state.pteam.pteam);
@@ -40,7 +40,7 @@ export function Tag() {
   } = useGetPTeamServiceTaggedTopicIdsQuery(
     { pteamId, serviceId, tagId },
     {
-      skip: skip || !pteamId || !serviceId || !tagId,
+      skip: skipByAuth || !pteamId || !serviceId || !tagId,
     },
   );
 
@@ -48,7 +48,7 @@ export function Tag() {
   const currentTagDependencies = dependencies?.filter((dependency) => dependency.tag_id === tagId);
 
   useEffect(() => {
-    if (skip) return; // wait login completed
+    if (skipByAuth) return; // wait login completed
     if (!pteamId) return; // wait fixed by App
     if (!pteam) {
       dispatch(getPTeam(pteamId));
@@ -75,7 +75,7 @@ export function Tag() {
       return;
     }
   }, [
-    skip,
+    skipByAuth,
     pteam,
     dependencies,
     currentTagDependencies,
@@ -89,14 +89,14 @@ export function Tag() {
   ]);
 
   useEffect(() => {
-    if (skip) return;
+    if (skipByAuth) return;
     if (!pteamId) return;
     if (!members) {
       dispatch(getPTeamMembers(pteamId));
     }
-  }, [dispatch, skip, pteamId, members]);
+  }, [dispatch, skipByAuth, pteamId, members]);
 
-  if (skip || !allTags || !pteam || !members || !currentTagDependencies) {
+  if (skipByAuth || !allTags || !pteam || !members || !currentTagDependencies) {
     return <>Now loading...</>;
   }
 
@@ -114,6 +114,9 @@ export function Tag() {
     version: dependency.version,
     service: serviceDict.service_name,
   }));
+
+  const taggedTopicsUnsolved = taggedTopics?.["unsolved"];
+  const taggedTopicsSolved = taggedTopics?.["solved"];
 
   const handleTabChange = (event, value) => setTabValue(value);
 
@@ -158,9 +161,8 @@ export function Tag() {
             pteamId={pteamId}
             tagId={tagId}
             service={serviceDict}
-            isSolved={false}
             references={references}
-            taggedTopics={taggedTopics}
+            taggedTopics={taggedTopicsUnsolved}
           />
         </TabPanel>
         <TabPanel value={tabValue} index={1}>
@@ -168,9 +170,8 @@ export function Tag() {
             pteamId={pteamId}
             tagId={tagId}
             service={serviceDict}
-            isSolved={true}
             references={references}
-            taggedTopics={taggedTopics}
+            taggedTopics={taggedTopicsSolved}
           />
         </TabPanel>
       </Box>

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -49,7 +49,10 @@ export const tcApi = createApi({
         method: "POST",
         body: data,
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "TopicAction", id: "ALL" }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "TopicAction", id: "ALL" },
+        { type: "Ticket", id: "ALL" },
+      ],
     }),
     updateAction: builder.mutation({
       query: ({ actionId, data }) => ({
@@ -64,7 +67,10 @@ export const tcApi = createApi({
         url: `/actions/${actionId}`,
         method: "DELETE",
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "TopicAction", id: arg.actionId }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "TopicAction", id: arg.actionId },
+        { type: "Ticket", id: "ALL" },
+      ],
     }),
 
     /* Action Log */
@@ -313,7 +319,10 @@ export const tcApi = createApi({
         method: "PUT",
         body: data,
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "Service", id: arg.serviceId }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "Service", id: arg.serviceId },
+        { type: "Ticket", id: "ALL" },
+      ],
     }),
     deletePTeamService: builder.mutation({
       query: ({ pteamId, serviceName }) => ({
@@ -322,6 +331,20 @@ export const tcApi = createApi({
         method: "DELETE",
       }),
       invalidatesTags: (result, error, arg) => [{ type: "Service", id: "ALL" }],
+    }),
+
+    /* PTeam Service Tagged TopicId */
+    getPTeamServiceTaggedTopicIds: builder.query({
+      query: ({ pteamId, serviceId, tagId }) => ({
+        url: `pteams/${pteamId}/services/${serviceId}/tags/${tagId}/topic_ids`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "Ticket", id: "ALL" },
+        { type: "Threat", id: "ALL" },
+        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "Service", id: "ALL" },
+      ],
     }),
 
     /* PTeam Service Thumbnail */
@@ -365,6 +388,7 @@ export const tcApi = createApi({
         method: "POST",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [{ type: "CurrentTicketStatus", id: "ALL" }],
     }),
 
     /* TopicAction */
@@ -420,6 +444,7 @@ export const tcApi = createApi({
         method: "POST",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
     }),
 
     updateTopic: builder.mutation({
@@ -428,6 +453,7 @@ export const tcApi = createApi({
         method: "PUT",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
     }),
 
     deleteTopic: builder.mutation({
@@ -435,6 +461,7 @@ export const tcApi = createApi({
         url: `topics/${topicId}`,
         method: "DELETE",
       }),
+      invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
     }),
 
     /* User */
@@ -540,6 +567,7 @@ export const {
   useUploadSBOMFileMutation,
   useUpdatePTeamServiceMutation,
   useDeletePTeamServiceMutation,
+  useGetPTeamServiceTaggedTopicIdsQuery,
   useGetPTeamServiceThumbnailQuery,
   useRemoveWatcherATeamMutation,
   useCreateTicketStatusMutation,

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -6,7 +6,6 @@ import {
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
   getPTeamMembers as apiGetPTeamMembers,
-  getPTeamServiceTaggedTopicIds as apiGetPTeamServiceTaggedTopicIds,
   getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
   getTicketsRelatedToServiceTopicTag as apiGetTicketsRelatedToServiceTopicTag,
@@ -61,19 +60,6 @@ export const getDependencies = createAsyncThunk(
       serviceId: data.serviceId,
       data: response.data,
     })),
-);
-
-export const getPTeamServiceTaggedTopicIds = createAsyncThunk(
-  "pteam/getPTeamServiceTaggedTopicIds",
-  async (data) =>
-    await apiGetPTeamServiceTaggedTopicIds(data.pteamId, data.serviceId, data.tagId).then(
-      (response) => ({
-        pteamId: data.pteamId,
-        serviceId: data.serviceId,
-        tagId: data.tagId,
-        data: response.data,
-      }),
-    ),
 );
 
 export const getTicketsRelatedToServiceTopicTag = createAsyncThunk(
@@ -186,16 +172,6 @@ const pteamSlice = createSlice({
         serviceDependencies: {
           ...state.serviceDependencies,
           [action.payload.serviceId]: action.payload.data,
-        },
-      }))
-      .addCase(getPTeamServiceTaggedTopicIds.fulfilled, (state, action) => ({
-        ...state,
-        taggedTopics: {
-          ...state.taggedTopics,
-          [action.payload.serviceId]: {
-            ...state.taggedTopics[action.payload.serviceId],
-            [action.payload.tagId]: action.payload.data,
-          },
         },
       }))
       .addCase(getTicketsRelatedToServiceTopicTag.fulfilled, (state, action) => ({

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -105,7 +105,6 @@ const _initialState = {
   authorities: undefined,
   members: undefined,
   serviceDependencies: {}, // dict[serviceId: list[dependency]]
-  taggedTopics: {},
   tickets: {}, // dict[serviceId: dict[tagId: dict[topicId: list[ticket]]]]
   serviceTagsSummaries: {},
   pteamTagsSummaries: {},

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -17,9 +17,6 @@ export const getPTeamAuthInfo = async () => axios.get("/pteams/auth_info");
 
 export const getPTeamAuth = async (pteamId) => axios.get(`/pteams/${pteamId}/authority`);
 
-export const getPTeamServiceTaggedTopicIds = async (pteamId, serviceId, tagId) =>
-  axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/${tagId}/topic_ids`);
-
 export const getTicketsRelatedToServiceTopicTag = async (pteamId, serviceId, topicId, tagId) =>
   axios.get(`/pteams/${pteamId}/services/${serviceId}/topics/${topicId}/tags/${tagId}/tickets`);
 


### PR DESCRIPTION
## PR の目的
- getPTeamServiceTaggedTopicIdsをRTKQ化しました。

## 経緯・意図・意思決定
- tcApi.js
   - invalidatesTagsとprovidesTagsの紐付けを行いました
- Tag.jsx
   - useSelectorを使用して情報を取ってきていたところをuseGetPTeamServiceTaggedTopicIdsQueryを使用するようにしました。
   - useSelectorで取ってきていたtaggedTopicsDictについて、従来のreduxでは取得したデータを一旦ルートstate以下に格納してから取り出す必要があり、取り出すキーを必要としました。そのためserviceIdとtagIdをキーとしていましたが、RTKクエリにしたことで必要なくなり、43行目のようなデータを抽出するようなコードを削除しました
- PTeamTaggedTopics.jsx
  - 従来 useSelectorで取ってきていた部分を親コンポーネットからpropsで受け取るように変更しました。
- 削除した部分
  - api.jsとpteam.jsでgetPTeamServiceTaggedTopicIdsに関係している部分を削除しました
  - TopicModal.jsx, TopicStatusSelector.jsx, Tag.jsxにあったdispatcjについて削除しました
