### PR TITLE
replace the API for the AcceptAteamInvitation RTK query

### DIFF
--- a/web/src/pages/AcceptATeamInvitation.jsx
+++ b/web/src/pages/AcceptATeamInvitation.jsx
@@ -26,8 +26,8 @@ export function AcceptATeamInvitation() {
   } = useGetATeamInvitedQuery(tokenId, { skip });
 
   if (skip) return <></>;
-  if (invitationError) return <>{`Cannot get Members: ${errorToString(invitationError)}`}</>;
-  if (invitationIsLoading) return <>Now loading Members...</>;
+  if (invitationError) return <>This invitation is invalid or already expired.</>;
+  if (invitationIsLoading) return <>Now loading ATeamInvitation...</>;
 
   const handleAccept = async (event) => {
     event.preventDefault();

--- a/web/src/pages/AcceptATeamInvitation.jsx
+++ b/web/src/pages/AcceptATeamInvitation.jsx
@@ -1,17 +1,14 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import { useApplyATeamInvitationMutation } from "../services/tcApi";
-import { getATeamInvited } from "../utils/api";
+import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
+import { useApplyATeamInvitationMutation, useGetATeamInvitedQuery } from "../services/tcApi";
 import { commonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 export function AcceptATeamInvitation() {
-  const [detail, setDetail] = useState({});
-  const [errorMessage, setErrorMessage] = useState(null);
-
   const { enqueueSnackbar } = useSnackbar();
   const [applyATeamInvitation] = useApplyATeamInvitationMutation();
 
@@ -20,13 +17,17 @@ export function AcceptATeamInvitation() {
   const params = new URLSearchParams(useLocation().search);
   const tokenId = params.get("token");
 
-  useEffect(() => {
-    getATeamInvited(tokenId)
-      .then((response) => setDetail(response.data))
-      .catch((error) => {
-        setErrorMessage(<Typography>This invitation is invalid or already expired.</Typography>);
-      });
-  }, [tokenId]);
+  const skipByAuth = useSkipUntilAuthTokenIsReady();
+  const skip = skipByAuth || tokenId === undefined;
+  const {
+    data: detail,
+    error: invitationError,
+    isLoading: invitationIsLoading,
+  } = useGetATeamInvitedQuery(tokenId, { skip });
+
+  if (skip) return <></>;
+  if (invitationError) return <>{`Cannot get Members: ${errorToString(invitationError)}`}</>;
+  if (invitationIsLoading) return <>Now loading Members...</>;
 
   const handleAccept = async (event) => {
     event.preventDefault();
@@ -47,7 +48,7 @@ export function AcceptATeamInvitation() {
       .catch((error) => onError(error));
   };
 
-  return detail.ateam_id ? (
+  return (
     <>
       <Typography variant="h6">Do you accept the invitation to the ateam below?</Typography>
       <Typography>ATeam Name: {detail.ateam_name}</Typography>
@@ -61,7 +62,5 @@ export function AcceptATeamInvitation() {
         </Button>
       </Box>
     </>
-  ) : (
-    <>{errorMessage}</>
   );
 }

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -107,12 +107,23 @@ export const tcApi = createApi({
     }),
 
     /* ATeam Invitation */
+    getATeamInvited: builder.query({
+      query: (invitationId) => ({
+        url: `ateams/invitation/${invitationId}`,
+        method: "GET",
+      }),
+      providesTags: (result, error, invitationId) => [
+        { type: "AteamInvitation", id: "ALL" },
+        { type: "Ateam", id: "ateamId" },
+      ],
+    }),
     createATeamInvitation: builder.mutation({
       query: ({ ateamId, data }) => ({
         url: `ateams/${ateamId}/invitation`,
         method: "POST",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [{ type: "ATeamInvitation", id: "ALL" }],
     }),
     applyATeamInvitation: builder.mutation({
       query: (data) => ({
@@ -515,6 +526,7 @@ export const {
   useUpdateATeamAuthMutation,
   useCreateATeamInvitationMutation,
   useApplyATeamInvitationMutation,
+  useGetATeamInvitedQuery,
   useGetATeamMembersQuery,
   useGetPTeamTopicActionsQuery,
   useDeleteATeamMemberMutation,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -37,8 +37,6 @@ export const getServiceThumbnail = async (pteamId, serviceId) =>
 // ateams
 export const getATeam = async (ateamId) => axios.get(`/ateams/${ateamId}`);
 
-export const getATeamInvited = async (tokenId) => axios.get(`/ateams/invitation/${tokenId}`);
-
 export const getATeamAuthInfo = async () => axios.get("/ateams/auth_info");
 
 export const getATeamAuth = async (ateamId) => axios.get(`/ateams/${ateamId}/authority`);


### PR DESCRIPTION
## PR の目的
- /ateams/invitation/${invitationId}のRTKクエリAPI入替作業の実施

## 経緯・意図・意思決定
- web/src/pages/AcceptATeamInvitation.jsx
   - useGetATeamInvitedQueryフックを使ってAPIからデータを取得するコードの実装
- web/src/services/tcApi.js
   - getATeamInvitedのAPIのクエリを定義
- web/src/utils/api.js
   - getATeamInvitedメソッドの削除
