### PR TITLE
refine getPTeam using RTKQ

### DIFF
--- a/web/src/components/PTeamMemberMenu.jsx
+++ b/web/src/components/PTeamMemberMenu.jsx
@@ -24,20 +24,19 @@ export function PTeamMemberMenu(props) {
 
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
-  const skipByAuth = useSkipUntilAuthTokenIsReady();
-  const skipByPTeamId = pteamId === undefined;
+  const skip = useSkipUntilAuthTokenIsReady() || !pteamId;
   const {
     data: userMe,
     error: userMeError,
     isLoading: userMeIsLoading,
-  } = useGetUserMeQuery(undefined, { skip: skipByAuth });
+  } = useGetUserMeQuery(undefined, { skip });
   const {
     data: pteam,
     error: pteamError,
     isLoading: pteamIsLoading,
-  } = useGetPTeamQuery(pteamId, { skip: skipByAuth || skipByPTeamId });
+  } = useGetPTeamQuery(pteamId, { skip });
 
-  if (skipByAuth || skipByPTeamId) return <></>;
+  if (skip) return <></>;
   if (userMeError) return <>{`Cannot get userInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;

--- a/web/src/components/PTeamNotificationSetting.jsx
+++ b/web/src/components/PTeamNotificationSetting.jsx
@@ -21,33 +21,27 @@ import {
 import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useState } from "react";
 
 import {
   useCheckMailMutation,
   useCheckSlackMutation,
   useUpdatePTeamMutation,
 } from "../services/tcApi";
-import { getPTeam } from "../slices/pteam";
-import {
-  defaultAlertThreshold,
-  modalCommonButtonStyle,
-  sortedSSVCPriorities,
-  ssvcPriorityProps,
-} from "../utils/const";
+import { modalCommonButtonStyle, sortedSSVCPriorities, ssvcPriorityProps } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 import { CheckButton } from "./CheckButton";
 
 export function PTeamNotificationSetting(props) {
-  const { show } = props;
+  const { pteam } = props;
+
   const [edittingSlackUrl, setEdittingSlackUrl] = useState(false);
-  const [slackUrl, setSlackUrl] = useState("");
-  const [slackEnable, setSlackEnable] = useState(false);
-  const [mailAddress, setMailAddress] = useState("");
-  const [mailEnable, setMailEnable] = useState(false);
-  const [alertThreshold, setAlertThreshold] = useState(defaultAlertThreshold);
+  const [slackUrl, setSlackUrl] = useState(pteam.alert_slack.webhook_url);
+  const [slackEnable, setSlackEnable] = useState(pteam.alert_slack.enable);
+  const [mailAddress, setMailAddress] = useState(pteam.alert_mail.address);
+  const [mailEnable, setMailEnable] = useState(pteam.alert_mail.enable);
+  const [alertThreshold, setAlertThreshold] = useState(pteam.alert_ssvc_priority);
   const [checkSlack, setCheckSlack] = useState(false);
   const [checkEmail, setCheckEmail] = useState(false);
   const [slackMessage, setSlackMessage] = useState();
@@ -58,24 +52,6 @@ export function PTeamNotificationSetting(props) {
   const [postCheckMail] = useCheckMailMutation();
   const [postCheckSlack] = useCheckSlackMutation();
   const [updatePTeam] = useUpdatePTeamMutation();
-
-  const pteamId = useSelector((state) => state.pteam.pteamId);
-  const pteam = useSelector((state) => state.pteam.pteam);
-
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    if (pteam) {
-      setSlackUrl(pteam.alert_slack.webhook_url);
-      setSlackEnable(pteam.alert_slack.enable);
-      setMailAddress(pteam.alert_mail.address);
-      setMailEnable(pteam.alert_mail.enable);
-      setAlertThreshold(pteam.alert_ssvc_priority);
-    }
-    setEdittingSlackUrl(false);
-    setCheckSlack(false);
-    setSlackMessage();
-  }, [show, pteam]);
 
   const operationError = (error) =>
     enqueueSnackbar(`Operation failed: ${errorToString(error)}`, { variant: "error" });
@@ -104,10 +80,9 @@ export function PTeamNotificationSetting(props) {
       alert_mail: { enable: mailEnable, address: mailAddress },
       alert_ssvc_priority: alertThreshold,
     };
-    await updatePTeam({ pteamId, data })
+    await updatePTeam({ pteamId: pteam.pteam_id, data })
       .unwrap()
       .then(() => {
-        dispatch(getPTeam(pteamId));
         enqueueSnackbar("update pteam info succeeded", { variant: "success" });
       })
       .catch((error) => operationError(error));
@@ -280,5 +255,5 @@ export function PTeamNotificationSetting(props) {
   );
 }
 PTeamNotificationSetting.propTypes = {
-  show: PropTypes.bool.isRequired,
+  pteam: PropTypes.object.isRequired,
 };

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -18,7 +18,7 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { useUpdatePTeamServiceMutation } from "../services/tcApi";
-import { getPTeam, getPTeamServiceTagsSummary } from "../slices/pteam";
+import { getPTeamServiceTagsSummary } from "../slices/pteam";
 import {
   sortedSSVCPriorities,
   ssvcPriorityProps,
@@ -59,7 +59,6 @@ export function PTeamStatusSSVCCards(props) {
     await updatePTeamService({ pteamId, serviceId, data })
       .unwrap()
       .then(() => {
-        dispatch(getPTeam(pteamId));
         dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
         enqueueSnackbar("Update succeeded", { variant: "success" });
       })

--- a/web/src/components/PTeamWatcherMenu.jsx
+++ b/web/src/components/PTeamWatcherMenu.jsx
@@ -2,10 +2,8 @@ import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui
 import { Button, Dialog, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
 
 import { PTeamWatcherRemoveModal } from "../components/PTeamWatcherRemoveModal";
-import { getPTeam } from "../slices/pteam";
 
 export function PTeamWatcherMenu(props) {
   const { pteam, watcherAteamId, watcherAteamName, isAdmin } = props;
@@ -13,8 +11,6 @@ export function PTeamWatcherMenu(props) {
   const [openRemove, setOpenRemove] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
-
-  const dispatch = useDispatch();
 
   const handleClick = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -66,10 +62,7 @@ export function PTeamWatcherMenu(props) {
           watcherAteamName={watcherAteamName}
           pteamId={pteam.pteam_id}
           pteamName={pteam.pteam_name}
-          onClose={() => {
-            dispatch(getPTeam(pteam.pteam_id)); // update pteam.pteams
-            setOpenRemove(false);
-          }}
+          onClose={() => setOpenRemove(false)}
         />
       </Dialog>
     </>

--- a/web/src/components/PTeamWatcherRemoveModal.jsx
+++ b/web/src/components/PTeamWatcherRemoveModal.jsx
@@ -11,11 +11,9 @@ import {
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
-import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useRemoveWatcherATeamMutation } from "../services/tcApi";
-import { getPTeam } from "../slices/pteam";
 import { errorToString } from "../utils/func";
 
 export function PTeamWatcherRemoveModal(props) {
@@ -24,11 +22,8 @@ export function PTeamWatcherRemoveModal(props) {
   const { enqueueSnackbar } = useSnackbar();
   const [removeWatcherATeam] = useRemoveWatcherATeamMutation();
 
-  const dispatch = useDispatch();
-
   const handleRemove = async () => {
     function onSuccess(success) {
-      dispatch(getPTeam(pteamId));
       enqueueSnackbar(`Remove watcher ${watcherAteamName} succeeded`, {
         variant: "success",
       });

--- a/web/src/pages/PTeam.jsx
+++ b/web/src/pages/PTeam.jsx
@@ -20,16 +20,14 @@ export function PTeam() {
   const [filterMode, setFilterMode] = useState("PTeam");
   const [tabValue, setTabValue] = useState(0);
 
-  const skipByAuth = useSkipUntilAuthTokenIsReady();
-
   const pteamId = useSelector((state) => state.pteam.pteamId); // TODO: RTKQ or QueryParam?
 
-  const skip = skipByAuth || pteamId === undefined;
+  const skip = useSkipUntilAuthTokenIsReady() || !pteamId;
   const {
     data: userMe,
     error: userMeError,
     isLoading: userMeIsLoading,
-  } = useGetUserMeQuery(undefined, { skip: skipByAuth });
+  } = useGetUserMeQuery(undefined, { skip });
   const {
     data: authorities,
     error: authoritiesError,

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -472,6 +472,7 @@ export const tcApi = createApi({
         ...(result?.ateams.reduce(
           (ret, ateam) => [
             ...ret,
+            { type: "ATeam", id: ateam.ateam_id },
             { type: "ATeamAccount", id: `${ateam.ateam_id}:${result?.user_id}` },
           ],
           [{ type: "ATeamAccount", id: "ALL" }],
@@ -479,6 +480,7 @@ export const tcApi = createApi({
         ...(result?.pteams.reduce(
           (ret, pteam) => [
             ...ret,
+            { type: "PTeam", id: pteam.pteam_id },
             { type: "PTeamAccount", id: `${pteam.pteam_id}:${result?.user_id}` },
           ],
           [{ type: "PTeamAccount", id: "ALL" }],

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -2,7 +2,6 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 import {
   getDependencies as apiGetDependencies,
-  getPTeam as apiGetPTeam,
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
   getPTeamMembers as apiGetPTeamMembers,
@@ -10,15 +9,6 @@ import {
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
   getTicketsRelatedToServiceTopicTag as apiGetTicketsRelatedToServiceTopicTag,
 } from "../utils/api";
-
-export const getPTeam = createAsyncThunk(
-  "pteam/getPTeam",
-  async (pteamId) =>
-    await apiGetPTeam(pteamId).then((response) => ({
-      data: response.data,
-      pteamId: pteamId,
-    })),
-);
 
 export const getPTeamAuthInfo = createAsyncThunk(
   "pteams/getAuthInfo",
@@ -100,7 +90,6 @@ export const getPTeamTagsSummary = createAsyncThunk(
 
 const _initialState = {
   pteamId: undefined,
-  pteam: undefined,
   authInfo: undefined,
   authorities: undefined,
   members: undefined,
@@ -150,10 +139,6 @@ const pteamSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
-      .addCase(getPTeam.fulfilled, (state, action) => ({
-        ...state,
-        pteam: action.payload.data,
-      }))
       .addCase(getPTeamAuthInfo.fulfilled, (state, action) => ({
         ...state,
         authInfo: action.payload.data,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -9,8 +9,6 @@ export const removeToken = () => {
 };
 
 // pteams
-export const getPTeam = async (pteamId) => axios.get(`/pteams/${pteamId}`);
-
 export const getPTeamMembers = async (pteamId) => axios.get(`/pteams/${pteamId}/members`);
 
 export const getPTeamAuthInfo = async () => axios.get("/pteams/auth_info");


### PR DESCRIPTION
## PR の目的

- getPTeam を RTKQ 化
  - PTeamSettingsModal.jsx では、子コンポーネントが編集用初期値として pteam を必要とするため、親側で getPTeam して子に渡す形にした。
  - 動作確認中、ユーザが所属する最後の PTeam から脱退した後に遷移するページが正しく表示されない不具合を発見。別タスクで対応する（おそらく RTKQ とは無関係な既存のバグと思われる）。