### PR TITLE
refine getPTeamMembers using RTKQ

### DIFF
--- a/web/src/components/PTeamMemberRemoveModal.jsx
+++ b/web/src/components/PTeamMemberRemoveModal.jsx
@@ -15,7 +15,7 @@ import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useDeletePTeamMemberMutation } from "../services/tcApi";
-import { getPTeamAuth, getPTeamMembers } from "../slices/pteam";
+import { getPTeamAuth } from "../slices/pteam";
 import { errorToString } from "../utils/func";
 
 export function PTeamMemberRemoveModal(props) {
@@ -30,7 +30,6 @@ export function PTeamMemberRemoveModal(props) {
   const handleRemove = async () => {
     function onSuccess(success) {
       dispatch(getPTeamAuth(pteamId));
-      dispatch(getPTeamMembers(pteamId));
       enqueueSnackbar(`Remove ${userName} from ${pteamName} succeeded`, { variant: "success" });
       if (onClose) onClose();
     }

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -4,7 +4,10 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import { PTeamStatusMenu } from "../components/PTeamStatusMenu";
+import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
+import { useGetPTeamMembersQuery } from "../services/tcApi";
 import { sortedSSVCPriorities } from "../utils/const";
+import { errorToString } from "../utils/func";
 
 import { SSVCPriorityCountChip } from "./SSVCPriorityCountChip";
 import { TopicCard } from "./TopicCard";
@@ -16,6 +19,17 @@ export function PTeamTaggedTopics(props) {
   const [perPage, setPerPage] = useState(10);
 
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by parent
+
+  const skip = useSkipUntilAuthTokenIsReady() || !pteamId;
+  const {
+    data: members,
+    error: membersError,
+    isLoading: membersIsLoading,
+  } = useGetPTeamMembersQuery(pteamId, { skip });
+
+  if (skip) return <></>;
+  if (membersError) return <>{`Cannot get PTeamMembers: ${errorToString(membersError)}`}</>;
+  if (membersIsLoading) return <>Now loading PTeamMembers...</>;
 
   if (taggedTopics === undefined || !allTags) {
     return <>Loading...</>;
@@ -83,6 +97,7 @@ export function PTeamTaggedTopics(props) {
               currentTagId={tagId}
               service={service}
               references={references}
+              members={members}
             />
           </ListItem>
         ))}

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -32,14 +32,13 @@ import { TopicTicketAccordion } from "./TopicTicketAccordion";
 import { UUIDTypography } from "./UUIDTypography";
 
 export function TopicCard(props) {
-  const { pteamId, topicId, currentTagId, service, references } = props;
+  const { pteamId, topicId, currentTagId, service, references, members } = props;
   const { tagId } = useParams();
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [topicModalOpen, setTopicModalOpen] = useState(false);
   const [actionFilter, setActionFilter] = useState(true);
 
-  const members = useSelector((state) => state.pteam.members); // dispatched by Tag.jsx
   const serviceDependencies = useSelector((state) => state.pteam.serviceDependencies);
   const ticketsDict = useSelector((state) => state.pteam.tickets);
   const topics = useSelector((state) => state.topics.topics);
@@ -400,4 +399,5 @@ TopicCard.propTypes = {
   currentTagId: PropTypes.string.isRequired,
   service: PropTypes.object.isRequired,
   references: PropTypes.array.isRequired,
+  members: PropTypes.object.isRequired,
 };

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -11,14 +11,13 @@ import { TagReferences } from "../components/TagReferences";
 import { UUIDTypography } from "../components/UUIDTypography";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useGetPTeamQuery, useGetPTeamServiceTaggedTopicIdsQuery } from "../services/tcApi";
-import { getDependencies, getPTeamMembers } from "../slices/pteam";
+import { getDependencies } from "../slices/pteam";
 import { a11yProps, errorToString } from "../utils/func.js";
 
 export function Tag() {
   const [tabValue, setTabValue] = useState(0);
 
   const allTags = useSelector((state) => state.tags.allTags); // dispatched by App
-  const members = useSelector((state) => state.pteam.members);
   const serviceDependencies = useSelector((state) => state.pteam.serviceDependencies);
 
   const dispatch = useDispatch();
@@ -85,14 +84,6 @@ export function Tag() {
     navigate,
   ]);
 
-  useEffect(() => {
-    if (skipByAuth) return;
-    if (!pteamId) return;
-    if (!members) {
-      dispatch(getPTeamMembers(pteamId));
-    }
-  }, [dispatch, skipByAuth, pteamId, members]);
-
   if (!getTopicIdsReady) return <></>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
@@ -100,7 +91,7 @@ export function Tag() {
     return <>{`Cannot get TaggedTopics: ${errorToString(taggedTopicsError)}`}</>;
   if (taggedTopicsIsLoading) return <>Now loading TaggedTopics...</>;
 
-  if (!allTags || !members || !currentTagDependencies) return <>Now loading...</>;
+  if (!allTags || !currentTagDependencies) return <>Now loading...</>;
 
   const numSolved = taggedTopics.solved?.topic_ids?.length ?? 0;
   const numUnsolved = taggedTopics.unsolved?.topic_ids?.length ?? 0;

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -4,7 +4,6 @@ import {
   getDependencies as apiGetDependencies,
   getPTeamAuth as apiGetPTeamAuth,
   getPTeamAuthInfo as apiGetPTeamAuthInfo,
-  getPTeamMembers as apiGetPTeamMembers,
   getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
   getTicketsRelatedToServiceTopicTag as apiGetTicketsRelatedToServiceTopicTag,
@@ -23,21 +22,6 @@ export const getPTeamAuth = createAsyncThunk(
   async (pteamId) =>
     await apiGetPTeamAuth(pteamId).then((response) => ({
       data: response.data,
-      pteamId: pteamId,
-    })),
-);
-
-export const getPTeamMembers = createAsyncThunk(
-  "pteam/getPTeamMembers",
-  async (pteamId) =>
-    await apiGetPTeamMembers(pteamId).then((response) => ({
-      data: response.data.reduce(
-        (ret, val) => ({
-          ...ret,
-          [val.user_id]: val,
-        }),
-        {},
-      ),
       pteamId: pteamId,
     })),
 );
@@ -92,7 +76,6 @@ const _initialState = {
   pteamId: undefined,
   authInfo: undefined,
   authorities: undefined,
-  members: undefined,
   serviceDependencies: {}, // dict[serviceId: list[dependency]]
   tickets: {}, // dict[serviceId: dict[tagId: dict[topicId: list[ticket]]]]
   serviceTagsSummaries: {},
@@ -146,10 +129,6 @@ const pteamSlice = createSlice({
       .addCase(getPTeamAuth.fulfilled, (state, action) => ({
         ...state,
         authorities: action.payload.data,
-      }))
-      .addCase(getPTeamMembers.fulfilled, (state, action) => ({
-        ...state,
-        members: action.payload.data,
       }))
       .addCase(getDependencies.fulfilled, (state, action) => ({
         ...state,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -9,8 +9,6 @@ export const removeToken = () => {
 };
 
 // pteams
-export const getPTeamMembers = async (pteamId) => axios.get(`/pteams/${pteamId}/members`);
-
 export const getPTeamAuthInfo = async () => axios.get("/pteams/auth_info");
 
 export const getPTeamAuth = async (pteamId) => axios.get(`/pteams/${pteamId}/authority`);


### PR DESCRIPTION
## PR の目的

- getPTeamMembers を RTKQ 化
  - 多数の TopicCard それぞれで getPTeamMembers するのは非効率なので親コンポーネントから渡す形に変更
  - 2層上の Tag でなく、直上の PTeamTaggedTopics で getPTeamMembers して TopicCard に渡している
