### PR TITLE
fix getting thumbnail not to reuse another thumbnail

### DIFF
--- a/web/src/components/PTeamServiceDetails.jsx
+++ b/web/src/components/PTeamServiceDetails.jsx
@@ -68,12 +68,17 @@ ServiceIDCopyButton.propTypes = {
 export function PTeamServiceDetails(props) {
   const { pteamId, service, expandService, onSwitchExpandService, highestSsvcPriority } = props;
 
-  const { data: thumbnail } = useGetPTeamServiceThumbnailQuery({
+  const {
+    data: thumbnail,
+    isError: thumbnailIsError,
+    isLoading: thumbnailIsLoading,
+  } = useGetPTeamServiceThumbnailQuery({
     pteamId,
     serviceId: service.service_id,
   });
 
-  const image = thumbnail ?? noImageAvailableUrl;
+  const image =
+    thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageAvailableUrl : thumbnail;
   const serviceName = service.service_name;
   const description = service.description;
   const keywords = service.keywords;

--- a/web/src/components/PTeamServicesListModal.jsx
+++ b/web/src/components/PTeamServicesListModal.jsx
@@ -31,11 +31,16 @@ const noImageAvailableUrl = "images/no-image-available-720x480.png";
 function ServiceCard(props) {
   const { pteamId, service, onClickService } = props;
 
-  const { data: thumbnail } = useGetPTeamServiceThumbnailQuery({
+  const {
+    data: thumbnail,
+    isError: thumbnailIsError,
+    isLoading: thumbnailIsLoading,
+  } = useGetPTeamServiceThumbnailQuery({
     pteamId,
     serviceId: service.service_id,
   });
-  const image = thumbnail ?? noImageAvailableUrl;
+  const image =
+    thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageAvailableUrl : thumbnail;
 
   return (
     <Card


### PR DESCRIPTION
## PR の目的

- PTeam Status 画面のサービスタブで、サムネイル画像が登録済・未登録のサービスを行き来すると noImageAvailable が表示されないバグを修正
  - data でなく currentData を参照するか、isError でハンドルする必要があるらしい。
    - currentData は他で使っていないので後者を採用
  - 同一コンポーネントでサービスを切り替えない限りは発生しないため、PTeamServicesListModal では必要ないが、コードの対称性のために同じ処理を適用した。