### PR TITLE
replace the API for the getATeamRequested RTK query

### DIFF
--- a/web/src/pages/AcceptATeamWatchingRequest.jsx
+++ b/web/src/pages/AcceptATeamWatchingRequest.jsx
@@ -23,18 +23,18 @@ export function AcceptATeamWatchingRequest() {
   const tokenId = params.get("token");
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
-  const skip = useSkipUntilAuthTokenIsReady();
+  const skipByAuth = useSkipUntilAuthTokenIsReady();
   const {
     data: pteam,
     error: pteamError,
     isLoading: pteamIsLoading,
-  } = useGetPTeamQuery(pteamId, { skip: skip || !pteamId });
+  } = useGetPTeamQuery(pteamId, { skipByAuth: skipByAuth || !pteamId });
   const {
     data: detail,
     error: ateamRequestedError,
     isLoading: ateamRequestedIsLoading,
-  } = useGetATeamRequestedQuery(tokenId, { skip: skip || !tokenId });
-  if (skip) return <></>;
+  } = useGetATeamRequestedQuery(tokenId, { skipByAuth: skipByAuth || !tokenId });
+  if (skipByAuth) return <></>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
   if (ateamRequestedError) return <>This request is invalid or already expired.</>;

--- a/web/src/pages/AcceptATeamWatchingRequest.jsx
+++ b/web/src/pages/AcceptATeamWatchingRequest.jsx
@@ -1,6 +1,6 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 

--- a/web/src/pages/AcceptATeamWatchingRequest.jsx
+++ b/web/src/pages/AcceptATeamWatchingRequest.jsx
@@ -5,15 +5,15 @@ import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
-import { useApplyATeamWatchingRequestMutation, useGetPTeamQuery } from "../services/tcApi";
-import { getATeamRequested } from "../utils/api";
+import {
+  useApplyATeamWatchingRequestMutation,
+  useGetATeamRequestedQuery,
+  useGetPTeamQuery,
+} from "../services/tcApi";
 import { commonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
 export function AcceptATeamWatchingRequest() {
-  const [detail, setDetail] = useState({});
-  const [errorMessage, setErrorMessage] = useState(null);
-
   const { enqueueSnackbar } = useSnackbar();
   const [applyATeamWatchingRequest] = useApplyATeamWatchingRequestMutation();
 
@@ -23,24 +23,22 @@ export function AcceptATeamWatchingRequest() {
   const tokenId = params.get("token");
   const pteamId = useSelector((state) => state.pteam.pteamId);
 
-  useEffect(() => {
-    getATeamRequested(tokenId)
-      .then((response) => setDetail(response.data))
-      .catch((error) => {
-        setErrorMessage(<Typography>This request is invalid or already expired.</Typography>);
-      });
-  }, [tokenId]);
-
-  const skip = useSkipUntilAuthTokenIsReady() || !pteamId;
+  const skip = useSkipUntilAuthTokenIsReady();
   const {
     data: pteam,
     error: pteamError,
     isLoading: pteamIsLoading,
-  } = useGetPTeamQuery(pteamId, { skip });
-
+  } = useGetPTeamQuery(pteamId, { skip: skip || !pteamId });
+  const {
+    data: detail,
+    error: ateamRequestedError,
+    isLoading: ateamRequestedIsLoading,
+  } = useGetATeamRequestedQuery(tokenId, { skip: skip || !tokenId });
   if (skip) return <></>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (ateamRequestedError) return <>This request is invalid or already expired.</>;
+  if (ateamRequestedIsLoading) return <>Now loading ATeamRequested...</>;
 
   const handleAccept = async (event) => {
     event.preventDefault();
@@ -68,7 +66,7 @@ export function AcceptATeamWatchingRequest() {
       .catch((error) => onError(error));
   };
 
-  return detail.ateam_id ? (
+  return (
     <>
       <Typography variant="h6">
         Does your pteam ({pteam?.pteam_name}) accept the watching request from the ateam below?
@@ -84,7 +82,5 @@ export function AcceptATeamWatchingRequest() {
         </Button>
       </Box>
     </>
-  ) : (
-    <>{errorMessage}</>
   );
 }

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -184,6 +184,7 @@ export const tcApi = createApi({
         method: "POST",
         body: date,
       }),
+      invalidateTags: (result, error, arg) => [{ type: "ATeamWatchingRequest", id: "ALL" }],
     }),
     applyATeamWatchingRequest: builder.mutation({
       query: (data) => ({
@@ -191,7 +192,17 @@ export const tcApi = createApi({
         method: "POST",
         body: data,
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "ATeamPTeam", id: "ALL" }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "ATeamPTeam", id: "ALL" },
+        { type: "ATeamWatchingRequest", id: "ALL" },
+      ],
+    }),
+    getATeamRequested: builder.query({
+      query: (tokenId) => ({
+        url: `ateams/watching_request/${tokenId}`,
+        method: "GET",
+      }),
+      providesTags: (result, error, tokenId) => [{ type: "AteamWatchingRequest", id: "ALL" }],
     }),
     removeWatchingPTeam: builder.mutation({
       query: ({ ateamId, pteamId }) => ({
@@ -570,6 +581,7 @@ export const {
   useApplyATeamInvitationMutation,
   useGetATeamInvitedQuery,
   useGetATeamMembersQuery,
+  useGetATeamRequestedQuery,
   useGetPTeamTopicActionsQuery,
   useGetTopicActionsQuery,
   useDeleteATeamMemberMutation,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -34,9 +34,6 @@ export const getATeamAuthInfo = async () => axios.get("/ateams/auth_info");
 
 export const getATeamAuth = async (ateamId) => axios.get(`/ateams/${ateamId}/authority`);
 
-export const getATeamRequested = async (tokenId) =>
-  axios.get(`/ateams/watching_request/${tokenId}`);
-
 export const getATeamTopics = async (ateamId, params) =>
   axios.get(`/ateams/${ateamId}/topicstatus`, { params: params ?? {} });
 


### PR DESCRIPTION
## PR の目的
- /ateams/watching_request/${tokenId}のRTKクエリAPI入替作業の実施

## 経緯・意図・意思決定
- web/src/pages/AcceptATeamWatchingRequest.jsx
   - useGetATeamRequestedQueryフックを使ってAPIからデータを取得するコードの実装
- web/src/services/tcApi.js
   - getATeamRequestedのAPIのクエリを定義
- web/src/utils/api.js
   - getATeamRequestedメソッドの削除
