### PR TITLE
refine getATeamTopicComment using RTKQ

### DIFF
--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -298,91 +298,90 @@ export function AnalysisTopic(props) {
                 <>{`Cannot get ATeamTopicComment: ${errorToString(commentsError)}`}</>
               )}
               {commentsIsLoading && <>Now loading ATeamTopicComments...</>}
-              {comments &&
-                comments.map((comment, index) => (
-                  <Box key={comment.comment_id} mb={2} sx={{ width: 1 }}>
-                    <Box display="flex" alignItems="center" mb={1}>
-                      <Typography variant="subtitle2" fontWeight="900" mr={2}>
-                        {comment.email}
+              {(comments ?? []).map((comment, index) => (
+                <Box key={comment.comment_id} mb={2} sx={{ width: 1 }}>
+                  <Box display="flex" alignItems="center" mb={1}>
+                    <Typography variant="subtitle2" fontWeight="900" mr={2}>
+                      {comment.email}
+                    </Typography>
+                    <Typography variant="subtitle2">
+                      {dateTimeFormat(comment.created_at)}
+                    </Typography>
+                    {comment.updated_at && (
+                      <Typography variant="subtitle2" sx={{ ml: 1 }}>
+                        {`(updated at ${dateTimeFormat(comment.updated_at)})`}
                       </Typography>
-                      <Typography variant="subtitle2">
-                        {dateTimeFormat(comment.created_at)}
+                    )}
+                  </Box>
+                  <Box mb={1} sx={{ backgroundColor: grey[100], padding: "10px" }}>
+                    {editable === index ? (
+                      <TextField
+                        id="outlined-multiline-static"
+                        multiline
+                        fullWidth
+                        rows={3}
+                        defaultValue={comment.comment}
+                        onChange={(event) => setEditComment(event.target.value)}
+                        sx={{ backgroundColor: "white" }}
+                      />
+                    ) : (
+                      <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                        {comment.comment}
                       </Typography>
-                      {comment.updated_at && (
-                        <Typography variant="subtitle2" sx={{ ml: 1 }}>
-                          {`(updated at ${dateTimeFormat(comment.updated_at)})`}
-                        </Typography>
-                      )}
-                    </Box>
-                    <Box mb={1} sx={{ backgroundColor: grey[100], padding: "10px" }}>
-                      {editable === index ? (
-                        <TextField
-                          id="outlined-multiline-static"
-                          multiline
-                          fullWidth
-                          rows={3}
-                          defaultValue={comment.comment}
-                          onChange={(event) => setEditComment(event.target.value)}
-                          sx={{ backgroundColor: "white" }}
-                        />
-                      ) : (
-                        <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                          {comment.comment}
-                        </Typography>
-                      )}
-                      <Box>
-                        {(isAdmin || comment.user_id === user.user_id) && (
-                          <Box mt={2}>
-                            {editable === index ? (
-                              <Box display="flex" justifyContent="flex-end">
-                                <Button
-                                  sx={{
-                                    textTransform: "none",
-                                    marginRight: 1,
-                                  }}
-                                  onClick={() => setEditable(null)}
-                                >
-                                  Cancel
-                                </Button>
-                                <Button
-                                  variant="outlined"
-                                  color="success"
-                                  onClick={() => handleUpdateComment(comment.comment_id)}
-                                  sx={{
-                                    textTransform: "none",
-                                  }}
-                                >
-                                  Edit
-                                </Button>
-                              </Box>
-                            ) : (
-                              <Box display="flex" justifyContent="flex-end">
-                                {comment.user_id === user.user_id && (
-                                  <IconButton
-                                    aria-label="delete"
-                                    size="small"
-                                    onClick={() => {
-                                      setEditable(index);
-                                    }}
-                                  >
-                                    <EditIcon fontSize="inherit" />
-                                  </IconButton>
-                                )}
+                    )}
+                    <Box>
+                      {(isAdmin || comment.user_id === user.user_id) && (
+                        <Box mt={2}>
+                          {editable === index ? (
+                            <Box display="flex" justifyContent="flex-end">
+                              <Button
+                                sx={{
+                                  textTransform: "none",
+                                  marginRight: 1,
+                                }}
+                                onClick={() => setEditable(null)}
+                              >
+                                Cancel
+                              </Button>
+                              <Button
+                                variant="outlined"
+                                color="success"
+                                onClick={() => handleUpdateComment(comment.comment_id)}
+                                sx={{
+                                  textTransform: "none",
+                                }}
+                              >
+                                Edit
+                              </Button>
+                            </Box>
+                          ) : (
+                            <Box display="flex" justifyContent="flex-end">
+                              {comment.user_id === user.user_id && (
                                 <IconButton
                                   aria-label="delete"
                                   size="small"
-                                  onClick={() => setDeleteComment(comment)}
+                                  onClick={() => {
+                                    setEditable(index);
+                                  }}
                                 >
-                                  <DeleteIcon fontSize="inherit" />
+                                  <EditIcon fontSize="inherit" />
                                 </IconButton>
-                              </Box>
-                            )}
-                          </Box>
-                        )}
-                      </Box>
+                              )}
+                              <IconButton
+                                aria-label="delete"
+                                size="small"
+                                onClick={() => setDeleteComment(comment)}
+                              >
+                                <DeleteIcon fontSize="inherit" />
+                              </IconButton>
+                            </Box>
+                          )}
+                        </Box>
+                      )}
                     </Box>
                   </Box>
-                ))}
+                </Box>
+              ))}
             </Box>
           </Box>
         </TabPanel>

--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -44,11 +44,11 @@ import styles from "../cssModule/button.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import {
   useCreateATeamTopicCommentMutation,
+  useGetATeamTopicCommentQuery,
   useGetTopicActionsQuery,
   useUpdateATeamTopicCommentMutation,
 } from "../services/tcApi";
 import { getTopic } from "../slices/topics";
-import { getATeamTopicComments as apiGetATeamTopicComments } from "../utils/api";
 import { rootPrefix, threatImpactNames } from "../utils/const";
 import { a11yProps, dateTimeFormat, errorToString, tagsMatched } from "../utils/func.js";
 
@@ -58,7 +58,6 @@ export function AnalysisTopic(props) {
   const [newComment, setNewComment] = useState("");
   const [deleteComment, setDeleteComment] = useState(null);
   const [editComment, setEditComment] = useState("");
-  const [comments, setComments] = useState([]);
   const [tab, setTab] = useState(0);
   const [topicModalOpen, setTopicModalOpen] = useState(false);
   const [listHeight, setListHeight] = useState(0);
@@ -84,9 +83,16 @@ export function AnalysisTopic(props) {
     error: topicActionsError,
     isLoading: topicActionsIsLoading,
   } = useGetTopicActionsQuery(targetTopic.topic_id, { skip });
+  const {
+    data: comments,
+    error: commentsError,
+    isLoading: commentsIsLoading,
+  } = useGetATeamTopicCommentQuery(
+    { ateamId: ateam.ateam_id, topicId: targetTopic.topic_id },
+    { skip },
+  );
 
   useEffect(() => {
-    handleReloadComments(targetTopic.topic_id);
     if (topics?.[targetTopic.topic_id] === undefined) dispatch(getTopic(targetTopic.topic_id));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetTopic.topic_id]);
@@ -98,20 +104,7 @@ export function AnalysisTopic(props) {
     }
   }, []);
 
-  const operationError = (error) =>
-    enqueueSnackbar(
-      "Operation failed: " +
-        `${error.response.status} ${error.response.statusText} ${error.response.data?.detail}`,
-      { variant: "error" },
-    );
-
   const handleChangeTab = (_, newTab) => setTab(newTab);
-
-  const handleReloadComments = async (topicId) => {
-    await apiGetATeamTopicComments(ateam.ateam_id, topicId)
-      .then((response) => setComments(response.data))
-      .catch((error) => operationError(error));
-  };
 
   const handleCreateComment = async () => {
     if (newComment.trim().length === 0) {
@@ -126,10 +119,7 @@ export function AnalysisTopic(props) {
       },
     })
       .unwrap()
-      .then(() => {
-        handleReloadComments(targetTopic.topic_id);
-        setNewComment("");
-      })
+      .then(() => setNewComment(""))
       .catch((error) =>
         enqueueSnackbar(`Operation failed: ${errorToString(error)}`, {
           variant: "error",
@@ -152,7 +142,6 @@ export function AnalysisTopic(props) {
     })
       .unwrap()
       .then(() => {
-        handleReloadComments(targetTopic.topic_id);
         setEditComment("");
         setEditable(false);
       })
@@ -305,90 +294,95 @@ export function AnalysisTopic(props) {
               >
                 Comment
               </Button>
-              {comments.map((comment, index) => (
-                <Box key={index} mb={2} sx={{ width: 1 }}>
-                  <Box display="flex" alignItems="center" mb={1}>
-                    <Typography variant="subtitle2" fontWeight="900" mr={2}>
-                      {comment.email}
-                    </Typography>
-                    <Typography variant="subtitle2">
-                      {dateTimeFormat(comment.created_at)}
-                    </Typography>
-                    {comment.updated_at && (
-                      <Typography variant="subtitle2" sx={{ ml: 1 }}>
-                        {`(updated at ${dateTimeFormat(comment.updated_at)})`}
+              {commentsError && (
+                <>{`Cannot get ATeamTopicComment: ${errorToString(commentsError)}`}</>
+              )}
+              {commentsIsLoading && <>Now loading ATeamTopicComments...</>}
+              {comments &&
+                comments.map((comment, index) => (
+                  <Box key={comment.comment_id} mb={2} sx={{ width: 1 }}>
+                    <Box display="flex" alignItems="center" mb={1}>
+                      <Typography variant="subtitle2" fontWeight="900" mr={2}>
+                        {comment.email}
                       </Typography>
-                    )}
-                  </Box>
-                  <Box mb={1} sx={{ backgroundColor: grey[100], padding: "10px" }}>
-                    {editable === index ? (
-                      <TextField
-                        id="outlined-multiline-static"
-                        multiline
-                        fullWidth
-                        rows={3}
-                        defaultValue={comment.comment}
-                        onChange={(event) => setEditComment(event.target.value)}
-                        sx={{ backgroundColor: "white" }}
-                      />
-                    ) : (
-                      <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
-                        {comment.comment}
+                      <Typography variant="subtitle2">
+                        {dateTimeFormat(comment.created_at)}
                       </Typography>
-                    )}
-                    <Box>
-                      {(isAdmin || comment.user_id === user.user_id) && (
-                        <Box mt={2}>
-                          {editable === index ? (
-                            <Box display="flex" justifyContent="flex-end">
-                              <Button
-                                sx={{
-                                  textTransform: "none",
-                                  marginRight: 1,
-                                }}
-                                onClick={() => setEditable(null)}
-                              >
-                                Cancel
-                              </Button>
-                              <Button
-                                variant="outlined"
-                                color="success"
-                                onClick={() => handleUpdateComment(comment.comment_id)}
-                                sx={{
-                                  textTransform: "none",
-                                }}
-                              >
-                                Edit
-                              </Button>
-                            </Box>
-                          ) : (
-                            <Box display="flex" justifyContent="flex-end">
-                              {comment.user_id === user.user_id && (
+                      {comment.updated_at && (
+                        <Typography variant="subtitle2" sx={{ ml: 1 }}>
+                          {`(updated at ${dateTimeFormat(comment.updated_at)})`}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Box mb={1} sx={{ backgroundColor: grey[100], padding: "10px" }}>
+                      {editable === index ? (
+                        <TextField
+                          id="outlined-multiline-static"
+                          multiline
+                          fullWidth
+                          rows={3}
+                          defaultValue={comment.comment}
+                          onChange={(event) => setEditComment(event.target.value)}
+                          sx={{ backgroundColor: "white" }}
+                        />
+                      ) : (
+                        <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                          {comment.comment}
+                        </Typography>
+                      )}
+                      <Box>
+                        {(isAdmin || comment.user_id === user.user_id) && (
+                          <Box mt={2}>
+                            {editable === index ? (
+                              <Box display="flex" justifyContent="flex-end">
+                                <Button
+                                  sx={{
+                                    textTransform: "none",
+                                    marginRight: 1,
+                                  }}
+                                  onClick={() => setEditable(null)}
+                                >
+                                  Cancel
+                                </Button>
+                                <Button
+                                  variant="outlined"
+                                  color="success"
+                                  onClick={() => handleUpdateComment(comment.comment_id)}
+                                  sx={{
+                                    textTransform: "none",
+                                  }}
+                                >
+                                  Edit
+                                </Button>
+                              </Box>
+                            ) : (
+                              <Box display="flex" justifyContent="flex-end">
+                                {comment.user_id === user.user_id && (
+                                  <IconButton
+                                    aria-label="delete"
+                                    size="small"
+                                    onClick={() => {
+                                      setEditable(index);
+                                    }}
+                                  >
+                                    <EditIcon fontSize="inherit" />
+                                  </IconButton>
+                                )}
                                 <IconButton
                                   aria-label="delete"
                                   size="small"
-                                  onClick={() => {
-                                    setEditable(index);
-                                  }}
+                                  onClick={() => setDeleteComment(comment)}
                                 >
-                                  <EditIcon fontSize="inherit" />
+                                  <DeleteIcon fontSize="inherit" />
                                 </IconButton>
-                              )}
-                              <IconButton
-                                aria-label="delete"
-                                size="small"
-                                onClick={() => setDeleteComment(comment)}
-                              >
-                                <DeleteIcon fontSize="inherit" />
-                              </IconButton>
-                            </Box>
-                          )}
-                        </Box>
-                      )}
+                              </Box>
+                            )}
+                          </Box>
+                        )}
+                      </Box>
                     </Box>
                   </Box>
-                </Box>
-              ))}
+                ))}
             </Box>
           </Box>
         </TabPanel>
@@ -646,13 +640,7 @@ export function AnalysisTopic(props) {
           currentActions={topicActions}
         />
       </Box>
-      <CommentDeleteModal
-        comment={deleteComment}
-        onClose={() => {
-          setDeleteComment(null);
-          handleReloadComments(targetTopic.topic_id);
-        }}
-      />
+      <CommentDeleteModal comment={deleteComment} onClose={() => setDeleteComment(null)} />
     </>
   );
 }

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -449,20 +449,32 @@ export const tcApi = createApi({
     }),
 
     /* Topic Comment */
+    getATeamTopicComment: builder.query({
+      query: ({ ateamId, topicId }) => `ateams/${ateamId}/topiccomment/${topicId}`,
+      providesTags: (result, error, arg) => [
+        { type: "ATeamTopicComment", id: `${arg.ateamId}:${arg.topicId}` },
+        { type: "ATeamTopicComment", id: `ALL:${arg.topicId}` },
+      ],
+    }),
     createATeamTopicComment: builder.mutation({
       query: ({ ateamId, topicId, data }) => ({
         url: `ateams/${ateamId}/topiccomment/${topicId}`,
         method: "POST",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [
+        { type: "ATeamTopicComment", id: `${arg.ateamId}:${arg.topicId}` },
+      ],
     }),
-
     updateATeamTopicComment: builder.mutation({
       query: ({ ateamId, topicId, commentId, data }) => ({
         url: `ateams/${ateamId}/topiccomment/${topicId}/${commentId}`,
         method: "PUT",
         body: data,
       }),
+      invalidatesTags: (result, error, arg) => [
+        { type: "ATeamTopicComment", id: `${arg.ateamId}:${arg.topicId}` },
+      ],
     }),
 
     deleteATeamTopicComment: builder.mutation({
@@ -470,6 +482,9 @@ export const tcApi = createApi({
         url: `ateams/${ateamId}/topiccomment/${topicId}/${commentId}`,
         method: "DELETE",
       }),
+      invalidatesTags: (result, error, arg) => [
+        { type: "ATeamTopicComment", id: `${arg.ateamId}:${arg.topicId}` },
+      ],
     }),
 
     /* Topics */
@@ -488,7 +503,6 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
     }),
-
     updateTopic: builder.mutation({
       query: ({ topicId, data }) => ({
         url: `topics/${topicId}`,
@@ -497,13 +511,15 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
     }),
-
     deleteTopic: builder.mutation({
       query: (topicId) => ({
         url: `topics/${topicId}`,
         method: "DELETE",
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "Threat", id: "ALL" }],
+      invalidatesTags: (result, error, topicId) => [
+        { type: "ATeamTopicComment", id: `ALL:${topicId}` },
+        { type: "Threat", id: "ALL" },
+      ],
     }),
 
     /* User */
@@ -582,14 +598,15 @@ export const {
   useGetPTeamTopicActionsQuery,
   useGetTopicActionsQuery,
   useDeleteATeamMemberMutation,
-  useDeleteATeamTopicCommentMutation,
+  useGetATeamTopicCommentQuery,
   useCreateATeamTopicCommentMutation,
+  useUpdateATeamTopicCommentMutation,
+  useDeleteATeamTopicCommentMutation,
   useCreateATeamWatchingRequestMutation,
   useApplyATeamWatchingRequestMutation,
   useRemoveWatchingPTeamMutation,
   useGetPTeamQuery,
   useCreatePTeamMutation,
-  useUpdateATeamTopicCommentMutation,
   useUpdatePTeamMutation,
   useUpdatePTeamAuthMutation,
   useUpdateTopicMutation,

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -36,18 +36,6 @@ export const getATeamRequested = async (tokenId) =>
 export const getATeamTopics = async (ateamId, params) =>
   axios.get(`/ateams/${ateamId}/topicstatus`, { params: params ?? {} });
 
-export const getATeamTopicComments = async (ateamId, topicId) =>
-  axios.get(`/ateams/${ateamId}/topiccomment/${topicId}`);
-
-export const createATeamTopicComment = async (ateamId, topicId, data) =>
-  axios.post(`/ateams/${ateamId}/topiccomment/${topicId}`, data);
-
-export const updateATeamTopicComment = async (ateamId, topicId, commentId, data) =>
-  axios.put(`/ateams/${ateamId}/topiccomment/${topicId}/${commentId}`, data);
-
-export const deleteATeamTopicComment = async (ateamId, topicId, commentId) =>
-  axios.delete(`/ateams/${ateamId}/topiccomment/${topicId}/${commentId}`);
-
 // topics
 export const getTopic = async (topicId) => axios.get(`/topics/${topicId}`);
 


### PR DESCRIPTION
## PR の目的

- getATeamTopicComment の RTKQ 化
  - 現状、ateam の topic edit modal にトピック削除機能が無いため、delete topic との cache tag 連携は動作未確認
    - pteam の topic edit modal にはトピック削除機能があるが、ateam, pteam を行き来すると深い階層のコンポーネントが入れ替わりキャッシュもほぼ刷新されてしまうため。
  - トピック本体の表示をコメント取得完了まで遅延するのは避けたかったため、error, isLoading の処理が他コンポーネントとは違っている。
- インデント変更に紛れて分かり難いですが、key に配列の index を指定していたのに気付いたので comment_id に修正しています。