### PR TITLE
fix a bug authorities is not a function

### DIFF
--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -162,9 +162,7 @@ export function Analysis() {
     navigate(location.pathname + "?" + params.toString());
   };
 
-  const isAdmin = (
-    authorities.find((x) => x.user_id === userMe.user_id)?.authorities ?? []
-  ).includes("admin");
+  const isAdmin = (authorities[userMe.user_id] ?? []).includes("admin");
   const pageMax = Math.ceil(pageInfo.num_topics / perPage);
   if (page > pageMax && pageMax > 0) setPage(pageMax);
 


### PR DESCRIPTION
## PR の目的

- Analysis で authorities.find is not a function となるバグを修正
