### PR TITLE
refine getPTeamServiceTagsSummaryQuery RTKQ

### DIFF
--- a/web/src/components/PTeamStatusMenu.jsx
+++ b/web/src/components/PTeamStatusMenu.jsx
@@ -9,7 +9,7 @@ import { MdOutlineTopic } from "react-icons/md";
 import { TopicModal } from "../components/TopicModal";
 
 export function PTeamStatusMenu(props) {
-  const { presetTagId, presetParentTagId, serviceId } = props;
+  const { presetTagId, presetParentTagId } = props;
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -71,7 +71,6 @@ export function PTeamStatusMenu(props) {
         onSetOpen={setModalOpen}
         presetTagId={presetTagId}
         presetParentTagId={presetParentTagId}
-        serviceId={serviceId}
       />
     </>
   );
@@ -80,5 +79,4 @@ export function PTeamStatusMenu(props) {
 PTeamStatusMenu.propTypes = {
   presetTagId: PropTypes.string,
   presetParentTagId: PropTypes.string,
-  serviceId: PropTypes.string,
 };

--- a/web/src/components/PTeamStatusSSVCCards.jsx
+++ b/web/src/components/PTeamStatusSSVCCards.jsx
@@ -15,10 +15,8 @@ import {
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
 
 import { useUpdatePTeamServiceMutation } from "../services/tcApi";
-import { getPTeamServiceTagsSummary } from "../slices/pteam";
 import {
   sortedSSVCPriorities,
   ssvcPriorityProps,
@@ -48,7 +46,6 @@ export function PTeamStatusSSVCCards(props) {
 
   const [updatePTeamService] = useUpdatePTeamServiceMutation();
   const { enqueueSnackbar } = useSnackbar();
-  const dispatch = useDispatch();
 
   const handleUpdatePTeamService = async (card) => {
     const data =
@@ -59,7 +56,6 @@ export function PTeamStatusSSVCCards(props) {
     await updatePTeamService({ pteamId, serviceId, data })
       .unwrap()
       .then(() => {
-        dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
         enqueueSnackbar("Update succeeded", { variant: "success" });
       })
       .catch((error) => {

--- a/web/src/components/PTeamTaggedTopics.jsx
+++ b/web/src/components/PTeamTaggedTopics.jsx
@@ -84,11 +84,7 @@ export function PTeamTaggedTopics(props) {
           />
         ))}
         <Box flexGrow={1} />
-        <PTeamStatusMenu
-          presetTagId={presetTagId}
-          presetParentTagId={presetParentTagId}
-          serviceId={service.service_id}
-        />
+        <PTeamStatusMenu presetTagId={presetTagId} presetParentTagId={presetParentTagId} />
       </Box>
       {paginationRow}
       <List sx={{ p: 0 }}>

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -181,7 +181,6 @@ export function TopicCard(props) {
           presetTagId={currentTagId}
           presetParentTagId={currentTagDict.parent_id}
           presetActions={pteamTopicActions}
-          serviceId={serviceId}
         />
       </Box>
       <Divider />

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -37,7 +37,7 @@ import {
   useDeleteActionMutation,
   useGetTagsQuery,
 } from "../services/tcApi";
-import { getPTeamServiceTagsSummary, getPTeamTagsSummary } from "../slices/pteam";
+import { getPTeamTagsSummary } from "../slices/pteam";
 import { fetchFlashsense } from "../utils/api";
 import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";
@@ -51,8 +51,7 @@ import { TopicTagSelector } from "./TopicTagSelector";
 const steps = ["Import Flashsense", "Create topic"];
 
 export function TopicModal(props) {
-  const { open, onSetOpen, presetTopic, presetTagId, presetParentTagId, presetActions, serviceId } =
-    props;
+  const { open, onSetOpen, presetTopic, presetTagId, presetParentTagId, presetActions } = props;
 
   const [errors, setErrors] = useState([]);
   const [activeStep, setActiveStep] = useState(0);
@@ -176,10 +175,7 @@ export function TopicModal(props) {
 
   const reloadTopicAfterAPI = async () => {
     // fix topic state
-    await Promise.all([
-      dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId })),
-      dispatch(getPTeamTagsSummary({ pteamId: pteamId })),
-    ]);
+    await Promise.all([dispatch(getPTeamTagsSummary({ pteamId: pteamId }))]);
   };
 
   const handleCreateTopic = async () => {
@@ -424,7 +420,6 @@ export function TopicModal(props) {
   };
 
   const handleDeleteTopic = () => {
-    dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
     dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
   };
 
@@ -783,5 +778,4 @@ TopicModal.propTypes = {
       }),
     }),
   ),
-  serviceId: PropTypes.string.isRequired,
 };

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -26,7 +26,7 @@ import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useCreateTicketStatusMutation } from "../services/tcApi";
-import { getPTeamServiceTagsSummary, getPTeamTagsSummary } from "../slices/pteam";
+import { getPTeamTagsSummary } from "../slices/pteam";
 import { topicStatusProps } from "../utils/const";
 import { errorToString } from "../utils/func";
 
@@ -63,7 +63,6 @@ export function TopicStatusSelector(props) {
   ];
 
   const dispatchRelatedSlices = () => {
-    dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
     dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
   };
 

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -151,7 +151,7 @@ export function Status() {
   const {
     currentData: serviceTagsSummary,
     error: serviceTagsSummaryError,
-    isFetching: serviceTagsSummaryFetching,
+    isFetching: serviceTagsSummaryIsFetching,
   } = useGetPTeamServiceTagsSummaryQuery(
     { pteamId, serviceId },
     { skip: skipByAuth || !pteamId || !serviceId },
@@ -193,8 +193,10 @@ export function Status() {
   if (pteamIsLoading) return <>Now loading PTeam...</>;
   if (serviceTagsSummaryError)
     return <>{`Cannot get serviceTagsSummary: ${errorToString(serviceTagsSummaryError)}`}</>;
-  if (serviceId && (!serviceTagsSummary || serviceTagsSummaryFetching))
-    return <>Now loading serviceTagsSummary...</>;
+  if (serviceId || pteam.services.length > 0) {
+    if (!serviceTagsSummary || serviceTagsSummaryIsFetching)
+      return <>Now loading serviceTagsSummary...</>;
+  }
 
   const service =
     isActiveAllServicesMode || !serviceId

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -39,8 +39,8 @@ import { PTeamServicesListModal } from "../components/PTeamServicesListModal";
 import { PTeamStatusCard } from "../components/PTeamStatusCard";
 import { SBOMDropArea } from "../components/SBOMDropArea";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
-import { useGetPTeamQuery } from "../services/tcApi";
-import { getPTeamServiceTagsSummary, getPTeamTagsSummary, setPTeamId } from "../slices/pteam";
+import { useGetPTeamQuery, useGetPTeamServiceTagsSummaryQuery } from "../services/tcApi";
+import { getPTeamTagsSummary, setPTeamId } from "../slices/pteam";
 import { noPTeamMessage, sortedSSVCPriorities, ssvcPriorityProps } from "../utils/const";
 import { errorToString } from "../utils/func";
 
@@ -122,10 +122,8 @@ export function Status() {
   const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
 
-  const serviceTagsSummaries = useSelector((state) => state.pteam.serviceTagsSummaries);
   const pteamTagsSummaries = useSelector((state) => state.pteam.pteamTagsSummaries);
 
-  const serviceTagsSummary = serviceTagsSummaries[serviceId];
   const pteamTagsSummary = pteamTagsSummaries[pteamId];
 
   const [expandService, setExpandService] = useState(false);
@@ -142,12 +140,22 @@ export function Status() {
     serviceIds: [],
   });
 
-  const skip = useSkipUntilAuthTokenIsReady() || !pteamId;
+  const skipByAuth = useSkipUntilAuthTokenIsReady();
+
   const {
     data: pteam,
     error: pteamError,
     isLoading: pteamIsLoading,
-  } = useGetPTeamQuery(pteamId, { skip });
+  } = useGetPTeamQuery(pteamId, { skip: skipByAuth || !pteamId });
+
+  const {
+    currentData: serviceTagsSummary,
+    error: serviceTagsSummaryError,
+    isFetching: serviceTagsSummaryFetching,
+  } = useGetPTeamServiceTagsSummaryQuery(
+    { pteamId, serviceId },
+    { skip: skipByAuth || !pteamId || !serviceId },
+  );
 
   useEffect(() => {
     if (!pteamId) return; // wait fixed by App
@@ -156,12 +164,6 @@ export function Status() {
       // for the case pteam switched. -- looks redundant but necessary, uhmm...
       dispatch(setPTeamId(pteamId));
       return;
-    }
-
-    if (isActiveAllServicesMode) {
-      if (pteamTagsSummary) return;
-    } else {
-      if (serviceTagsSummary) return; // Ready!
     }
 
     if (!serviceId) {
@@ -181,16 +183,18 @@ export function Status() {
 
     if (isActiveAllServicesMode) {
       dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
-    } else {
-      dispatch(getPTeamServiceTagsSummary({ pteamId: pteamId, serviceId: serviceId }));
     }
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [pteamId, pteam, pteamId, serviceId, isActiveAllServicesMode]);
 
-  if (skip) return <></>;
+  if (skipByAuth || !pteamId) return <></>;
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (serviceTagsSummaryError)
+    return <>{`Cannot get serviceTagsSummary: ${errorToString(serviceTagsSummaryError)}`}</>;
+  if (serviceId && (!serviceTagsSummary || serviceTagsSummaryFetching))
+    return <>Now loading serviceTagsSummary...</>;
 
   const service =
     isActiveAllServicesMode || !serviceId

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -366,6 +366,20 @@ export const tcApi = createApi({
       invalidatesTags: (result, error, arg) => [{ type: "Service", id: "ALL" }],
     }),
 
+    /* PTeam Service Tags Summary */
+    getPTeamServiceTagsSummary: builder.query({
+      query: ({ pteamId, serviceId }) => ({
+        url: `pteams/${pteamId}/services/${serviceId}/tags/summary`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "Ticket", id: "ALL" },
+        { type: "Threat", id: "ALL" },
+        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "Service", id: "ALL" },
+      ],
+    }),
+
     /* PTeam Service Tagged TopicId */
     getPTeamServiceTaggedTopicIds: builder.query({
       query: ({ pteamId, serviceId, tagId }) => ({
@@ -673,6 +687,7 @@ export const {
   useUploadSBOMFileMutation,
   useUpdatePTeamServiceMutation,
   useDeletePTeamServiceMutation,
+  useGetPTeamServiceTagsSummaryQuery,
   useGetPTeamServiceTaggedTopicIdsQuery,
   useGetPTeamServiceThumbnailQuery,
   useGetTicketsRelatedToServiceTopicTagQuery,

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -2,7 +2,6 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 import {
   getDependencies as apiGetDependencies,
-  getPTeamServiceTagsSummary as apiGetPTeamServiceTagsSummary,
   getPTeamTagsSummary as apiGetPTeamTagsSummary,
 } from "../utils/api";
 
@@ -13,16 +12,6 @@ export const getDependencies = createAsyncThunk(
       pteamId: data.pteamId,
       serviceId: data.serviceId,
       data: response.data,
-    })),
-);
-
-export const getPTeamServiceTagsSummary = createAsyncThunk(
-  "pteam/getPTeamServiceTagsSummary",
-  async (data) =>
-    await apiGetPTeamServiceTagsSummary(data.pteamId, data.serviceId).then((response) => ({
-      data: response.data,
-      pteamId: data.pteamId,
-      serviceId: data.serviceId,
     })),
 );
 
@@ -38,7 +27,6 @@ export const getPTeamTagsSummary = createAsyncThunk(
 const _initialState = {
   pteamId: undefined,
   serviceDependencies: {}, // dict[serviceId: list[dependency]]
-  serviceTagsSummaries: {},
   pteamTagsSummaries: {},
   serviceThumbnails: {}, // dict[serviceId: dataURL | noImageAvailableUrl(=NoThumbnail)]
 };
@@ -61,8 +49,6 @@ const pteamSlice = createSlice({
       ...state,
       /* Note: state.pteam.services should be fixed by dispatch(getPTeam(pteamId)) */
       serviceDependencies: { ...state.serviceDependencies, [action.payload]: undefined },
-      serviceTagsSummaries: { ...state.serviceTagsSummaries, [action.payload]: undefined },
-      tickets: { ...state.tickets, [action.payload]: undefined },
       serviceThumbnails: { ...state.serviceThumbnails, [action.payload]: undefined },
     }),
     storeServiceThumbnail: (state, action) => ({
@@ -86,13 +72,6 @@ const pteamSlice = createSlice({
         ...state,
         serviceDependencies: {
           ...state.serviceDependencies,
-          [action.payload.serviceId]: action.payload.data,
-        },
-      }))
-      .addCase(getPTeamServiceTagsSummary.fulfilled, (state, action) => ({
-        ...state,
-        serviceTagsSummaries: {
-          ...state.serviceTagsSummaries,
           [action.payload.serviceId]: action.payload.data,
         },
       }))

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -9,9 +9,6 @@ export const removeToken = () => {
 };
 
 // pteams
-export const getPTeamServiceTagsSummary = async (pteamId, serviceId) =>
-  axios.get(`/pteams/${pteamId}/services/${serviceId}/tags/summary`);
-
 export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
 
 export const getDependencies = async (pteamId, serviceId) =>


### PR DESCRIPTION
## PR の目的
- getPTeamServiceTagsSummaryをRTKQ化しました

## 経緯・意図・意思決定
- tcApi.js
   - invalidatesTagsとprovidesTagsの紐付けを行いました
- Status.jsx
   - useSelectorを使用して情報を取ってきていたところをuseGetTicketsRelatedToServiceTopicTagQueryを使用するようにしました。
   - チームを変更した際に、前チームのsummaryの内容が残り少し時間が経つと新しく選択したチームのsummaryに遷移する現象を抑止するために、data, LoadingではなくcurrentData, Fechingを使用しています。
   - 196~199行目について、tag登録がなくserviceがない状態の時も考慮して ` if (serviceId || pteam.services.length > 0)`を付け加えています
- 削除した部分
  - api.jsとpteam.jsでgetPTeamServiceTagsSummaryに関係している部分を削除しました
  - PTeamStatusSSVCCards.jsx, TopicModal.jsx, TopicStatusSelector.jsxにあったdispatchについて削除しました
  - PTeamStatusMenu.jsx, PTeamTaggedTopics.jsx, TopicCard.jsx, TopicModal.jsxについてdispatchがなくなっためserviceIdについても削除しました