### PR TITLE
replace get dependencies with rtkquery

### DIFF
--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -56,8 +56,6 @@ export function TopicCard(props) {
   const skipByServiceId = serviceId === undefined;
   const skipBytagId = tagId === undefined;
   const getDependenciesReady = !skipByAuth && pteamId && serviceId;
-  const ticketsDict = useSelector((state) => state.pteam.tickets);
-  const topics = useSelector((state) => state.topics.topics);
 
   const {
     data: serviceDependencies,
@@ -86,8 +84,6 @@ export function TopicCard(props) {
     { pteamId, serviceId, topicId, tagId },
     { skip: skipByAuth || skipByPTeamId || skipByTopicId || skipByServiceId || skipBytagId },
   );
-
-  const dispatch = useDispatch();
 
   const handleDetailOpen = () => setDetailOpen(!detailOpen);
 

--- a/web/src/components/TopicCard.jsx
+++ b/web/src/components/TopicCard.jsx
@@ -16,7 +16,6 @@ import {
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -107,8 +107,6 @@ export function Tag() {
     return <>{`Cannot get TaggedTopics: ${errorToString(taggedTopicsError)}`}</>;
   if (taggedTopicsIsLoading) return <>Now loading TaggedTopics...</>;
 
-  if (!currentTagDependencies) return <>Now loading...</>;
-
   const numSolved = taggedTopics.solved?.topic_ids?.length ?? 0;
   const numUnsolved = taggedTopics.unsolved?.topic_ids?.length ?? 0;
 

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -74,7 +74,7 @@ export function Tag() {
       return;
     }
 
-    if (!tagId || (!currentTagDependencies?.length > 0 && !serviceDependenciesIsLoading)) {
+    if (!tagId || (currentTagDependencies.length == 0 && !serviceDependenciesIsLoading)) {
       const msg = `${tagId ? "Invalid" : "Missing"} tagId`;
       enqueueSnackbar(msg, { variant: "error" });
       const params = new URLSearchParams();

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -74,7 +74,7 @@ export function Tag() {
       return;
     }
 
-    if (!tagId || (currentTagDependencies.length == 0 && !serviceDependenciesIsLoading)) {
+    if (!tagId || (currentTagDependencies.length === 0 && !serviceDependenciesIsLoading)) {
       const msg = `${tagId ? "Invalid" : "Missing"} tagId`;
       enqueueSnackbar(msg, { variant: "error" });
       const params = new URLSearchParams();

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -2,7 +2,7 @@ import { Box, Divider, Tab, Tabs, Typography, Chip } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 
 import { PTeamTaggedTopics } from "../components/PTeamTaggedTopics";
@@ -14,8 +14,8 @@ import {
   useGetPTeamQuery,
   useGetPTeamServiceTaggedTopicIdsQuery,
   useGetTagsQuery,
+  useGetDependenciesQuery,
 } from "../services/tcApi";
-import { getDependencies } from "../slices/pteam";
 import { a11yProps, errorToString } from "../utils/func.js";
 
 export function Tag() {
@@ -27,7 +27,6 @@ export function Tag() {
     error: allTagsError,
     isLoading: allTagsIsLoading,
   } = useGetTagsQuery(undefined, { skipByAuth });
-  const serviceDependencies = useSelector((state) => state.pteam.serviceDependencies);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -37,9 +36,15 @@ export function Tag() {
   const params = new URLSearchParams(useLocation().search);
   const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
-
+  const getDependenciesReady = !skipByAuth && pteamId && serviceId;
   const getPTeamReady = !skipByAuth && pteamId;
   const getTopicIdsReady = getPTeamReady && serviceId && tagId;
+
+  const {
+    data: serviceDependencies,
+    error: serviceDependenciesError,
+    isLoading: serviceDependenciesIsLoading,
+  } = useGetDependenciesQuery({ pteamId, serviceId }, { skip: !getDependenciesReady });
   const {
     data: pteam,
     error: pteamError,
@@ -54,8 +59,9 @@ export function Tag() {
     { skip: !getTopicIdsReady },
   );
 
-  const dependencies = serviceDependencies[serviceId];
-  const currentTagDependencies = dependencies?.filter((dependency) => dependency.tag_id === tagId);
+  const currentTagDependencies = (serviceDependencies ?? []).filter(
+    (dependency) => dependency.tag_id === tagId,
+  );
 
   useEffect(() => {
     if (!pteam) return; // wait getQuery
@@ -67,11 +73,8 @@ export function Tag() {
       navigate("/?" + params.toString()); // force jump to Status page
       return;
     }
-    if (dependencies === undefined) {
-      dispatch(getDependencies({ pteamId: pteamId, serviceId: serviceId }));
-      return;
-    }
-    if (!tagId || !currentTagDependencies?.length > 0) {
+
+    if (!tagId || (!currentTagDependencies?.length > 0 && !serviceDependenciesIsLoading)) {
       const msg = `${tagId ? "Invalid" : "Missing"} tagId`;
       enqueueSnackbar(msg, { variant: "error" });
       const params = new URLSearchParams();
@@ -81,12 +84,12 @@ export function Tag() {
     }
   }, [
     pteam,
-    dependencies,
     currentTagDependencies,
     taggedTopics,
     pteamId,
     serviceId,
     tagId,
+    serviceDependenciesIsLoading,
     dispatch,
     enqueueSnackbar,
     navigate,
@@ -97,6 +100,9 @@ export function Tag() {
   if (allTagsIsLoading) return <>Now loading allTags...</>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (serviceDependenciesError)
+    return <>{`Cannot get serviceDependencies: ${errorToString(serviceDependenciesError)}`}</>;
+  if (serviceDependenciesIsLoading) return <>Now loading serviceDependencies...</>;
   if (taggedTopicsError)
     return <>{`Cannot get TaggedTopics: ${errorToString(taggedTopicsError)}`}</>;
   if (taggedTopicsIsLoading) return <>Now loading TaggedTopics...</>;

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -225,6 +225,15 @@ export const tcApi = createApi({
       ],
     }),
 
+    /* Dependencies */
+    getDependencies: builder.query({
+      query: ({ pteamId, serviceId }) => ({
+        url: `pteams/${pteamId}/services/${serviceId}/dependencies`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [{ type: "Service", id: "ALL" }],
+    }),
+
     /* PTeam */
     getPTeam: builder.query({
       query: (pteamId) => `pteams/${pteamId}`,
@@ -671,6 +680,7 @@ export const {
   useCreateATeamWatchingRequestMutation,
   useApplyATeamWatchingRequestMutation,
   useRemoveWatchingPTeamMutation,
+  useGetDependenciesQuery,
   useGetPTeamQuery,
   useCreatePTeamMutation,
   useUpdatePTeamMutation,

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -1,19 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
-import {
-  getDependencies as apiGetDependencies,
-  getPTeamTagsSummary as apiGetPTeamTagsSummary,
-} from "../utils/api";
-
-export const getDependencies = createAsyncThunk(
-  "pteam/getDependencies",
-  async (data) =>
-    await apiGetDependencies(data.pteamId, data.serviceId).then((response) => ({
-      pteamId: data.pteamId,
-      serviceId: data.serviceId,
-      data: response.data,
-    })),
-);
+import { getPTeamTagsSummary as apiGetPTeamTagsSummary } from "../utils/api";
 
 export const getPTeamTagsSummary = createAsyncThunk(
   "pteam/getPTeamTagsSummary",
@@ -26,7 +13,6 @@ export const getPTeamTagsSummary = createAsyncThunk(
 
 const _initialState = {
   pteamId: undefined,
-  serviceDependencies: {}, // dict[serviceId: list[dependency]]
   pteamTagsSummaries: {},
   serviceThumbnails: {}, // dict[serviceId: dataURL | noImageAvailableUrl(=NoThumbnail)]
 };
@@ -48,7 +34,6 @@ const pteamSlice = createSlice({
     invalidateServiceId: (state, action) => ({
       ...state,
       /* Note: state.pteam.services should be fixed by dispatch(getPTeam(pteamId)) */
-      serviceDependencies: { ...state.serviceDependencies, [action.payload]: undefined },
       serviceThumbnails: { ...state.serviceThumbnails, [action.payload]: undefined },
     }),
     storeServiceThumbnail: (state, action) => ({
@@ -67,21 +52,13 @@ const pteamSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder
-      .addCase(getDependencies.fulfilled, (state, action) => ({
-        ...state,
-        serviceDependencies: {
-          ...state.serviceDependencies,
-          [action.payload.serviceId]: action.payload.data,
-        },
-      }))
-      .addCase(getPTeamTagsSummary.fulfilled, (state, action) => ({
-        ...state,
-        pteamTagsSummaries: {
-          ...state.pteamTagsSummaries,
-          [action.payload.pteamId]: action.payload.data,
-        },
-      }));
+    builder.addCase(getPTeamTagsSummary.fulfilled, (state, action) => ({
+      ...state,
+      pteamTagsSummaries: {
+        ...state.pteamTagsSummaries,
+        [action.payload.pteamId]: action.payload.data,
+      },
+    }));
   },
 });
 

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -11,9 +11,6 @@ export const removeToken = () => {
 // pteams
 export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
 
-export const getDependencies = async (pteamId, serviceId) =>
-  axios.get(`/pteams/${pteamId}/services/${serviceId}/dependencies`);
-
 // ateams
 export const getATeam = async (ateamId) => axios.get(`/ateams/${ateamId}`);
 


### PR DESCRIPTION
## PR の目的
getDependencies関連について、RTKQueryに置き換え
- 以前はAPIで取得したデータをserviceIDをkeyとするオブジェクトの形にして保存していたが、今回はDependencies関連の値を利用するときはRTKQueryで直接呼び出すため、該当部分は削除されている。

- tag.jsx 77行目 if (!tagId || (!currentTagDependencies?.length > 0 && !serviceDependenciesIsLoading)) {
 useEffectと変数宣言(currentTagDependencies)の位置関係を保持するためにcurrentTagDependenciesの変数宣言時に空配列を渡している関係でそのままではif文の中の処理が実行されてしまうため、 !serviceDependenciesIsLoadingを追加
