### PR TITLE
refine getPTeamTagsSummaryQuery using RTKQ

### DIFF
--- a/web/src/components/PTeamServiceDelete.jsx
+++ b/web/src/components/PTeamServiceDelete.jsx
@@ -18,7 +18,7 @@ import { useLocation, useNavigate } from "react-router";
 import styles from "../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useDeletePTeamServiceMutation, useGetPTeamQuery } from "../services/tcApi";
-import { invalidateServiceId, getPTeamTagsSummary } from "../slices/pteam";
+import { invalidateServiceId } from "../slices/pteam";
 import { errorToString } from "../utils/func";
 
 export function PTeamServiceDelete(props) {
@@ -63,7 +63,6 @@ export function PTeamServiceDelete(props) {
   const handleDeleteService = async () => {
     function onSuccess(success, deletingServiceId) {
       dispatch(invalidateServiceId(deletingServiceId));
-      dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
       enqueueSnackbar("Remove service succeeded", { variant: "success" });
     }
     function onError(error) {

--- a/web/src/components/ReportCompletedActions.jsx
+++ b/web/src/components/ReportCompletedActions.jsx
@@ -30,17 +30,7 @@ import { RecommendedStar } from "./RecommendedStar";
 import { UUIDTypography } from "./UUIDTypography";
 
 export function ReportCompletedActions(props) {
-  const {
-    pteamId,
-    serviceId,
-    ticketId,
-    topicId,
-    tagId,
-    topicActions,
-    onSucceeded,
-    onSetShow,
-    show,
-  } = props;
+  const { pteamId, serviceId, ticketId, topicId, tagId, topicActions, onSetShow, show } = props;
 
   const [note, setNote] = useState("");
   const [selectedAction, setSelectedAction] = useState([]);
@@ -97,7 +87,6 @@ export function ReportCompletedActions(props) {
       )
       .then((data) => {
         handleClose();
-        onSucceeded();
         setNote("");
         enqueueSnackbar("Set ticketstatus 'completed' succeeded", { variant: "success" });
       })
@@ -270,7 +259,6 @@ ReportCompletedActions.propTypes = {
   topicId: PropTypes.string.isRequired,
   tagId: PropTypes.string.isRequired,
   topicActions: PropTypes.array.isRequired,
-  onSucceeded: PropTypes.func.isRequired,
   onSetShow: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
 };

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -24,7 +24,6 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 import uuid from "react-native-uuid";
-import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
@@ -37,7 +36,6 @@ import {
   useDeleteActionMutation,
   useGetTagsQuery,
 } from "../services/tcApi";
-import { getPTeamTagsSummary } from "../slices/pteam";
 import { fetchFlashsense } from "../utils/api";
 import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";
@@ -90,8 +88,6 @@ export function TopicModal(props) {
   const [deleteAction] = useDeleteActionMutation();
   const [createTopic] = useCreateTopicMutation();
   const [updateTopic] = useUpdateTopicMutation();
-
-  const dispatch = useDispatch();
 
   useEffect(() => {
     setErrors([]);
@@ -173,11 +169,6 @@ export function TopicModal(props) {
     return true;
   };
 
-  const reloadTopicAfterAPI = async () => {
-    // fix topic state
-    await Promise.all([dispatch(getPTeamTagsSummary({ pteamId: pteamId }))]);
-  };
-
   const handleCreateTopic = async () => {
     if (!validateActionTags()) return;
     const data = {
@@ -197,7 +188,6 @@ export function TopicModal(props) {
       .unwrap()
       .then(async () => {
         enqueueSnackbar("Create topic succeeded", { variant: "success" });
-        reloadTopicAfterAPI();
         onSetOpen(false);
       })
       .catch((error) =>
@@ -340,7 +330,6 @@ export function TopicModal(props) {
       await updateActionPromise();
     }
 
-    reloadTopicAfterAPI();
     enqueueSnackbar("Update topic succeeded", { variant: "success" });
     onSetOpen(false);
   };
@@ -417,10 +406,6 @@ export function TopicModal(props) {
   const handleClose = () => {
     setActiveStep(presetTopic ? 1 : 0);
     onSetOpen(false);
-  };
-
-  const handleDeleteTopic = () => {
-    dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
   };
 
   function ActionGeneratorModal() {
@@ -734,7 +719,6 @@ export function TopicModal(props) {
                   <TopicDeleteModal
                     topicId={presetTopic.topic_id}
                     onSetOpenTopicModal={onSetOpen}
-                    onDelete={handleDeleteTopic}
                   />
                 </Box>
               </Box>

--- a/web/src/components/TopicStatusSelector.jsx
+++ b/web/src/components/TopicStatusSelector.jsx
@@ -22,11 +22,9 @@ import { isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useRef, useState } from "react";
-import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useCreateTicketStatusMutation } from "../services/tcApi";
-import { getPTeamTagsSummary } from "../slices/pteam";
 import { topicStatusProps } from "../utils/const";
 import { errorToString } from "../utils/func";
 
@@ -45,8 +43,6 @@ export function TopicStatusSelector(props) {
 
   const [createTicketStatus] = useCreateTicketStatusMutation();
 
-  const dispatch = useDispatch();
-
   const dateFormat = "yyyy/MM/dd HH:mm";
   const selectableItems = [
     {
@@ -62,10 +58,6 @@ export function TopicStatusSelector(props) {
     },
   ];
 
-  const dispatchRelatedSlices = () => {
-    dispatch(getPTeamTagsSummary({ pteamId: pteamId }));
-  };
-
   const modifyTicketStatus = async (selectedStatus) => {
     let requestParams = { topic_status: selectedStatus };
     if (selectedStatus === "scheduled") {
@@ -77,7 +69,6 @@ export function TopicStatusSelector(props) {
     await createTicketStatus({ pteamId, serviceId, ticketId, data: requestParams })
       .unwrap()
       .then(() => {
-        dispatchRelatedSlices();
         enqueueSnackbar("Change ticket status succeeded", { variant: "success" });
       })
       .catch((error) =>
@@ -105,8 +96,6 @@ export function TopicStatusSelector(props) {
     modifyTicketStatus("scheduled");
   };
 
-  const handleReportSucceeded = () => dispatchRelatedSlices();
-
   const handleClose = (event) => {
     if (anchorRef.current?.contains(event.target)) return;
     setOpen(false);
@@ -128,7 +117,6 @@ export function TopicStatusSelector(props) {
         topicId={topicId}
         tagId={tagId}
         topicActions={topicActions}
-        onSucceeded={handleReportSucceeded}
         onSetShow={setActionModalOpen}
         show={actionModalOpen}
       />

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -411,6 +411,20 @@ export const tcApi = createApi({
       }),
     }),
 
+    /* PTeam Tags Summary */
+    getPTeamTagsSummary: builder.query({
+      query: (pteamId) => ({
+        url: `pteams/${pteamId}/tags/summary`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "Ticket", id: "ALL" },
+        { type: "Threat", id: "ALL" },
+        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "Service", id: "ALL" },
+      ],
+    }),
+
     /* PTeam Ticket Related To Service TopicTag */
     getTicketsRelatedToServiceTopicTag: builder.query({
       query: ({ pteamId, serviceId, topicId, tagId }) => ({
@@ -700,6 +714,7 @@ export const {
   useGetPTeamServiceTagsSummaryQuery,
   useGetPTeamServiceTaggedTopicIdsQuery,
   useGetPTeamServiceThumbnailQuery,
+  useGetPTeamTagsSummaryQuery,
   useGetTicketsRelatedToServiceTopicTagQuery,
   useRemoveWatcherATeamMutation,
   useCreateTicketStatusMutation,

--- a/web/src/slices/pteam.js
+++ b/web/src/slices/pteam.js
@@ -1,19 +1,7 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-
-import { getPTeamTagsSummary as apiGetPTeamTagsSummary } from "../utils/api";
-
-export const getPTeamTagsSummary = createAsyncThunk(
-  "pteam/getPTeamTagsSummary",
-  async (data) =>
-    await apiGetPTeamTagsSummary(data.pteamId).then((response) => ({
-      data: response.data,
-      pteamId: data.pteamId,
-    })),
-);
+import { createSlice } from "@reduxjs/toolkit";
 
 const _initialState = {
   pteamId: undefined,
-  pteamTagsSummaries: {},
   serviceThumbnails: {}, // dict[serviceId: dataURL | noImageAvailableUrl(=NoThumbnail)]
 };
 
@@ -43,15 +31,6 @@ const pteamSlice = createSlice({
         ...action.payload,
       },
     }),
-  },
-  extraReducers: (builder) => {
-    builder.addCase(getPTeamTagsSummary.fulfilled, (state, action) => ({
-      ...state,
-      pteamTagsSummaries: {
-        ...state.pteamTagsSummaries,
-        [action.payload.pteamId]: action.payload.data,
-      },
-    }));
   },
 });
 

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -8,9 +8,6 @@ export const removeToken = () => {
   delete axios.defaults.headers.common["Authorization"];
 };
 
-// pteams
-export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
-
 // ateams
 export const getATeam = async (ateamId) => axios.get(`/ateams/${ateamId}`);
 


### PR DESCRIPTION
## PR の目的
- getPTeamTagsSummaryをRTKQ化しました

## 経緯・意図・意思決定
- tcApi.js
   - invalidatesTagsとprovidesTagsの紐付けを行いました
- Status.jsx
   - useSelectorを使用して情報を取ってきていたところをuseGetTicketsRelatedToServiceTopicTagQueryを使用するようにしました。
   - getPTeamServiceTagsSummaryの時と同様にdata, LoadingではなくcurrentData, Fechingを使用しています。
   - 195~198行目について、isActiveAllServicesModeがTureの時に`Now loading pteamTagsSummary...`が表示されるようにしています
- 削除した部分
  - api.jsとpteam.jsでgetPTeamTagsSummaryに関係している部分を削除しました
  - PTeamServiceDelete.jsx, TopicModal.jsx, TopicStatusSelector.jsxにあったdispatchについて削除しました
  - TopicStatusSelector.jsxにあったdispatchRelatedSlices()でdispatchする必要がなくなったため、ReportCompletedActions.jsx, TopicStatusSelector.jsxにあったonSucceededを削除しました
