### PR TITLE
get ateamId from URL params

### DIFF
--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -15,7 +15,7 @@ import { errorToString } from "../utils/func";
 import { CheckButton } from "./CheckButton";
 
 export function ATeamGeneralSetting(props) {
-  const { show } = props;
+  const { ateamId, show } = props;
   const [ateamName, setATeamName] = useState("");
   const [contactInfo, setContactInfo] = useState("");
   const [slackUrl, setSlackUrl] = useState("");
@@ -26,7 +26,6 @@ export function ATeamGeneralSetting(props) {
   const { enqueueSnackbar } = useSnackbar();
   const [updateATeam] = useUpdateATeamMutation();
 
-  const ateamId = useSelector((state) => state.ateam.ateamId);
   const ateam = useSelector((state) => state.ateam.ateam);
 
   const dispatch = useDispatch();
@@ -149,5 +148,6 @@ export function ATeamGeneralSetting(props) {
   );
 }
 ATeamGeneralSetting.propTypes = {
+  ateamId: PropTypes.string.isRequired,
   show: PropTypes.bool.isRequired,
 };

--- a/web/src/components/ATeamInviteModal.jsx
+++ b/web/src/components/ATeamInviteModal.jsx
@@ -19,7 +19,6 @@ import { addHours, isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 
 import styles from "../cssModule/button.module.css";
 import dialogStyle from "../cssModule/dialog.module.css";
@@ -29,9 +28,7 @@ import { errorToString } from "../utils/func";
 import { CopiedIcon } from "./CopiedIcon";
 
 export function ATeamInviteModal(props) {
-  const { text } = props;
-
-  const ateamId = useSelector((state) => state.ateam.ateamId);
+  const { ateamId, text } = props;
 
   const [open, setOpen] = useState(false);
   const [maxUses, setMaxUses] = useState(0);
@@ -167,5 +164,6 @@ export function ATeamInviteModal(props) {
 }
 
 ATeamInviteModal.propTypes = {
+  ateamId: PropTypes.string.isRequired,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 };

--- a/web/src/components/ATeamMember.jsx
+++ b/web/src/components/ATeamMember.jsx
@@ -29,7 +29,7 @@ export function ATeamMember(props) {
     <>
       <Box sx={{ width: "100%" }}>
         <Box display="flex" justifyContent="flex-end" mb={2}>
-          {ateamId && <ATeamInviteModal text="Add member" />}
+          {ateamId && <ATeamInviteModal ateamId={ateamId} text="Add member" />}
         </Box>
         <TableContainer component={Paper}>
           <Table sx={{ minWidth: 650 }} aria-label="memberTable">
@@ -76,6 +76,7 @@ export function ATeamMember(props) {
                       </TableCell>
                       <TableCell align="right">
                         <ATeamMemberMenu
+                          ateamId={ateamId}
                           userId={member.user_id}
                           userEmail={member.email}
                           isAdmin={isAdmin}

--- a/web/src/components/ATeamMemberMenu.jsx
+++ b/web/src/components/ATeamMemberMenu.jsx
@@ -15,14 +15,12 @@ import { useGetUserMeQuery } from "../services/tcApi";
 import { errorToString } from "../utils/func";
 
 export function ATeamMemberMenu(props) {
-  const { userId, userEmail, isAdmin } = props;
+  const { ateamId, userId, userEmail, isAdmin } = props;
 
   const [openAuth, setOpenAuth] = useState(false);
   const [openRemove, setOpenRemove] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
-
-  const ateamId = useSelector((state) => state.ateam.ateamId);
   const ateam = useSelector((state) => state.ateam.ateam);
 
   const skip = useSkipUntilAuthTokenIsReady();
@@ -102,6 +100,7 @@ export function ATeamMemberMenu(props) {
 }
 
 ATeamMemberMenu.propTypes = {
+  ateamId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
   userEmail: PropTypes.string.isRequired,
   isAdmin: PropTypes.bool.isRequired,

--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -33,7 +33,7 @@ import { errorToString } from "../utils/func";
 import { CheckButton } from "./CheckButton";
 
 export function ATeamNotificationSetting(props) {
-  const { show } = props;
+  const { ateamId, show } = props;
   const [edittingSlackUrl, setEdittingSlackUrl] = useState(false);
   const [slackUrl, setSlackUrl] = useState("");
   const [slackEnable, setSlackEnable] = useState(false);
@@ -50,7 +50,6 @@ export function ATeamNotificationSetting(props) {
   const [postCheckSlack] = useCheckSlackMutation();
   const [updateATeam] = useUpdateATeamMutation();
 
-  const ateamId = useSelector((state) => state.ateam.ateamId);
   const ateam = useSelector((state) => state.ateam.ateam);
 
   const dispatch = useDispatch();
@@ -266,5 +265,6 @@ export function ATeamNotificationSetting(props) {
   );
 }
 ATeamNotificationSetting.propTypes = {
+  ateamId: PropTypes.string,
   show: PropTypes.bool.isRequired,
 };

--- a/web/src/components/ATeamRequestModal.jsx
+++ b/web/src/components/ATeamRequestModal.jsx
@@ -19,7 +19,6 @@ import { addHours, isBefore } from "date-fns";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 
 import styles from "../cssModule/button.module.css";
 import dialogStyle from "../cssModule/dialog.module.css";
@@ -27,9 +26,7 @@ import { useCreateATeamWatchingRequestMutation } from "../services/tcApi";
 import { errorToString } from "../utils/func";
 
 export function ATeamRequestModal(props) {
-  const { text } = props;
-
-  const ateamId = useSelector((state) => state.ateam.ateamId);
+  const { ateamId, text } = props;
 
   const [open, setOpen] = useState(false);
   const [maxUses, setMaxUses] = useState(0);
@@ -161,5 +158,6 @@ export function ATeamRequestModal(props) {
 }
 
 ATeamRequestModal.propTypes = {
+  ateamId: PropTypes.string.isRequired,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 };

--- a/web/src/components/ATeamSettingsModal.jsx
+++ b/web/src/components/ATeamSettingsModal.jsx
@@ -49,10 +49,10 @@ export function ATeamSettingsModal(props) {
           </Tabs>
         </Box>
         <TabPanel index={0} value={tab}>
-          <ATeamGeneralSetting show={show} />
+          <ATeamGeneralSetting ateamId={ateamId} show={show} />
         </TabPanel>
         <TabPanel index={1} value={tab}>
-          <ATeamNotificationSetting show={show} />
+          <ATeamNotificationSetting ateamId={ateamId} show={show} />
         </TabPanel>
         <TabPanel index={2} value={tab}>
           <ATeamAuthEditor ateamId={ateamId} />

--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -24,7 +24,7 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 import uuid from "react-native-uuid";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
@@ -46,7 +46,7 @@ import { TopicTagSelector } from "./TopicTagSelector";
 const steps = ["Threat, Vulnerability, and Risk", "Dissemination", "Response planning"];
 
 export function ATeamTopicCreateModal(props) {
-  const { open, onSetOpen } = props;
+  const { ateamId, open, onSetOpen } = props;
 
   const [activeStep, setActiveStep] = useState(0);
   const [topicId, setTopicId] = useState(uuid.v4());
@@ -58,8 +58,6 @@ export function ATeamTopicCreateModal(props) {
   const [actionTagOptions, setActionTagOptions] = useState([]);
   const [editActionOpen, setEditActionOpen] = useState(false);
   const [editActionTarget] = useState({});
-
-  const ateamId = useSelector((state) => state.ateam.ateamId); // dispatched by parent
 
   const skip = useSkipUntilAuthTokenIsReady();
   const {
@@ -421,6 +419,7 @@ export function ATeamTopicCreateModal(props) {
 }
 
 ATeamTopicCreateModal.propTypes = {
+  ateamId: PropTypes.string.isRequired,
   open: PropTypes.bool.isRequired,
   onSetOpen: PropTypes.func.isRequired,
 };

--- a/web/src/components/ATeamTopicMenu.jsx
+++ b/web/src/components/ATeamTopicMenu.jsx
@@ -1,11 +1,13 @@
 import { Button, Box } from "@mui/material";
+import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import styles from "../cssModule/button.module.css";
 
 import { ATeamTopicCreateModal } from "./ATeamTopicCreateModal";
 
-export function ATeamTopicMenu() {
+export function ATeamTopicMenu(props) {
+  const { ateamId } = props;
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -20,8 +22,11 @@ export function ATeamTopicMenu() {
         >
           New Topic
         </Button>
-        <ATeamTopicCreateModal open={modalOpen} onSetOpen={setModalOpen} />
+        <ATeamTopicCreateModal ateamId={ateamId} open={modalOpen} onSetOpen={setModalOpen} />
       </Box>
     </>
   );
 }
+ATeamTopicMenu.propTypes = {
+  ateamId: PropTypes.string.isRequired,
+};

--- a/web/src/components/ATeamWatching.jsx
+++ b/web/src/components/ATeamWatching.jsx
@@ -74,7 +74,7 @@ export function ATeamWatching(props) {
     <>
       <Box sx={{ width: "100%" }}>
         <Box display="flex" justifyContent="flex-end" mb={2}>
-          <ATeamRequestModal text="New Watching Request" />
+          <ATeamRequestModal ateamId={ateam.ateam_id} text="New Watching Request" />
         </Box>
         <TableContainer component={Paper}>
           <Table sx={{ minWidth: 650 }} aria-label="monitorTable">

--- a/web/src/components/AppBar.jsx
+++ b/web/src/components/AppBar.jsx
@@ -35,7 +35,7 @@ const StyledAppBar = styled(MuiAppBar, {
 }));
 
 export function AppBar(props) {
-  const { pteamId } = props;
+  const { ateamId, pteamId } = props;
 
   const dispatch = useDispatch();
   const system = useSelector((state) => state.system);
@@ -68,7 +68,7 @@ export function AppBar(props) {
           </IconButton>
           <Divider orientation="vertical" flexItem sx={{ mr: 2 }} />
           <Box flexGrow={1} />
-          <TeamSelector pteamId={pteamId} />
+          <TeamSelector ateamId={ateamId} pteamId={pteamId} />
           <Button color="inherit" onClick={handleLogout}>
             Logout
           </Button>
@@ -79,5 +79,6 @@ export function AppBar(props) {
   );
 }
 AppBar.propTypes = {
-  pteamId: PropTypes.string.isRequired,
+  ateamId: PropTypes.string,
+  pteamId: PropTypes.string,
 };

--- a/web/src/components/TeamSelector.jsx
+++ b/web/src/components/TeamSelector.jsx
@@ -27,13 +27,12 @@ function textTrim(selector) {
 }
 
 export function TeamSelector(props) {
-  const { pteamId } = props;
+  const { ateamId, pteamId } = props;
 
   const dispatch = useDispatch();
   const location = useLocation();
   const navigate = useNavigate();
   const teamMode = useSelector((state) => state.system.teamMode);
-  const ateamId = useSelector((state) => state.ateam.ateamId);
 
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -191,5 +190,6 @@ export function TeamSelector(props) {
   );
 }
 TeamSelector.propTypes = {
-  pteamId: PropTypes.string.isRequired,
+  ateamId: PropTypes.string,
+  pteamId: PropTypes.string,
 };

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -1,6 +1,7 @@
 import { Avatar, Box, MenuItem, Tab, Tabs, TextField, Tooltip } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router";
 
 import { ATeamLabel } from "../components/ATeamLabel";
 import { ATeamMember } from "../components/ATeamMember";
@@ -20,7 +21,9 @@ export function ATeam() {
   const [filterMode, setFilterMode] = useState("ATeam");
   const [tabValue, setTabValue] = useState(0);
 
-  const ateamId = useSelector((state) => state.ateam.ateamId);
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const ateamId = params.get("ateamId");
   const ateam = useSelector((state) => state.ateam.ateam);
 
   const dispatch = useDispatch();

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -171,7 +171,7 @@ export function Analysis() {
       <>
         <ATeamLabel ateam={ateam} />
         <>No watching teams.</>
-        <ATeamTopicMenu />
+        <ATeamTopicMenu ateamId={ateamId} />
       </>
     );
   }
@@ -179,7 +179,7 @@ export function Analysis() {
     return (
       <>
         <ATeamLabel ateam={ateam} />
-        <ATeamTopicMenu />
+        <ATeamTopicMenu ateamId={ateamId} />
         <AnalysisNoThreatsMsg ateam={ateam} />
       </>
     );
@@ -221,7 +221,7 @@ export function Analysis() {
           ))}
         </Select>
         <Box flexGrow={1} />
-        <ATeamTopicMenu />
+        <ATeamTopicMenu ateamId={ateamId} />
       </Box>
       <Box
         display="flex"

--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -10,7 +10,6 @@ import { Drawer } from "../components/Drawer";
 import { Main } from "../components/Main";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useGetUserMeQuery, useTryLoginMutation } from "../services/tcApi";
-import { setATeamId } from "../slices/ateam";
 import { setAuthToken } from "../slices/auth";
 import { setTeamMode } from "../slices/system";
 import { setToken } from "../utils/api";
@@ -31,6 +30,7 @@ export function App() {
   const system = useSelector((state) => state.system);
   const location = useLocation();
   const navigate = useNavigate();
+  const [ateamId, setATeamId] = useState(undefined);
   const [pteamId, setPteamId] = useState(undefined);
 
   const {
@@ -69,7 +69,7 @@ export function App() {
     if (["/analysis", "/ateam"].includes(location.pathname)) {
       dispatch(setTeamMode("ateam"));
       if (!userMe.ateams.length > 0) {
-        dispatch(setATeamId(undefined));
+        setATeamId(undefined);
         return;
       }
       const ateamIdx = params.get("ateamId") || userMe.ateams[0].ateam_id;
@@ -86,7 +86,7 @@ export function App() {
         navigate(location.pathname + "?" + params.toString());
         return;
       }
-      dispatch(setATeamId(params.get("ateamId")));
+      setATeamId(params.get("ateamId"));
     } else if (
       ["/", "/pteam", "/pteam/watching_request"].includes(location.pathname) ||
       /\/tags\//.test(location.pathname)
@@ -120,7 +120,7 @@ export function App() {
   return (
     <>
       <Box flexGrow={1}>
-        <AppBar pteamId={pteamId} />
+        <AppBar ateamId={ateamId} pteamId={pteamId} />
       </Box>
       <Drawer />
       <Main open={system.drawerOpen}>

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -33,13 +33,6 @@ const ateamSlice = createSlice({
     clearATeam: (state, action) => ({
       ..._initialState,
     }),
-    setATeamId: (state, action) => ({
-      /*
-       * CAUTION: ateam slice is initialized on changing ateamId.
-       */
-      ...(action.payload && state.ateamId === action.payload ? state : _initialState),
-      ateamId: action.payload,
-    }),
   },
   extraReducers: (builder) => {
     builder
@@ -56,6 +49,6 @@ const ateamSlice = createSlice({
 
 const { actions, reducer } = ateamSlice;
 
-export const { clearATeam, setATeamId } = actions;
+export const { clearATeam } = actions;
 
 export default reducer;


### PR DESCRIPTION
## PR の目的
- ateam id をsliceからではなく、URLパラメータから取得する
  - pages：URLパラメータから取得
  - components：propsで呼び出し元から受け取る

- AppBar,TeamSelectorはateamId、pteamIdのどちらかがundefinedのため、PropTypesにisRequiredを付けない

## 経緯・意図・意思決定
テスト中に下記バグを発見したが、既存バグのため別途起票した。
[Tc][Bug]ATeamを選択してTopics、Accountのページでブラウザの更新をすると、PTeamにおけるTopics、Accountページに変わる
https://github.com/orgs/nttcom-ic/projects/1/views/9?pane=issue&itemId=86685928