### PR TITLE
Topic/replace api for query of ateams

### DIFF
--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -40,7 +40,7 @@ export function ATeamGeneralSetting(props) {
       setFlashsenseUrl(fsInfo.api_url);
     }
 
-    if (!ateam) fetchFsInfo();
+    fetchFsInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -4,7 +4,6 @@ import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useUpdateATeamMutation, useGetATeamQuery } from "../services/tcApi";

--- a/web/src/components/ATeamGeneralSetting.jsx
+++ b/web/src/components/ATeamGeneralSetting.jsx
@@ -26,6 +26,8 @@ export function ATeamGeneralSetting(props) {
   const { enqueueSnackbar } = useSnackbar();
   const [updateATeam] = useUpdateATeamMutation();
 
+  const skip = useSkipUntilAuthTokenIsReady();
+
   const {
     data: ateam,
     error: ateamError,

--- a/web/src/components/ATeamMemberMenu.jsx
+++ b/web/src/components/ATeamMemberMenu.jsx
@@ -6,7 +6,6 @@ import {
 import { Button, Dialog, DialogContent, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useSelector } from "react-redux";
 
 import { ATeamAuthEditor } from "../components/ATeamAuthEditor";
 import { ATeamMemberRemoveModal } from "../components/ATeamMemberRemoveModal";

--- a/web/src/components/ATeamMemberMenu.jsx
+++ b/web/src/components/ATeamMemberMenu.jsx
@@ -11,7 +11,7 @@ import { useSelector } from "react-redux";
 import { ATeamAuthEditor } from "../components/ATeamAuthEditor";
 import { ATeamMemberRemoveModal } from "../components/ATeamMemberRemoveModal";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
-import { useGetUserMeQuery } from "../services/tcApi";
+import { useGetUserMeQuery, useGetATeamQuery } from "../services/tcApi";
 import { errorToString } from "../utils/func";
 
 export function ATeamMemberMenu(props) {
@@ -23,7 +23,6 @@ export function ATeamMemberMenu(props) {
   const open = Boolean(anchorEl);
 
   const ateamId = useSelector((state) => state.ateam.ateamId);
-  const ateam = useSelector((state) => state.ateam.ateam);
 
   const skip = useSkipUntilAuthTokenIsReady();
   const {
@@ -31,6 +30,11 @@ export function ATeamMemberMenu(props) {
     error: userMeError,
     isLoading: userMeIsLoading,
   } = useGetUserMeQuery(undefined, { skip });
+  const {
+    data: ateam,
+    error: ateamError,
+    isLoading: ateamIsLoading,
+  } = useGetATeamQuery(ateamId, { skip });
 
   const handleClick = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -43,8 +47,11 @@ export function ATeamMemberMenu(props) {
     setOpenRemove(true);
   };
 
+  if (skip) return <></>;
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
+  if (ateamError) return <>{`Cannot get Ateam: ${errorToString(ateamError)}`}</>;
+  if (ateamIsLoading) return <>Now loading Ateam...</>;
   if (!ateamId || !ateam) return <></>;
 
   return (

--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -19,14 +19,15 @@ import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
+import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import {
   useCheckMailMutation,
   useCheckSlackMutation,
+  useGetATeamQuery,
   useUpdateATeamMutation,
 } from "../services/tcApi";
-import { getATeam } from "../slices/ateam";
 import { modalCommonButtonStyle } from "../utils/const";
 import { errorToString } from "../utils/func";
 
@@ -51,9 +52,13 @@ export function ATeamNotificationSetting(props) {
   const [updateATeam] = useUpdateATeamMutation();
 
   const ateamId = useSelector((state) => state.ateam.ateamId);
-  const ateam = useSelector((state) => state.ateam.ateam);
+  const skip = useSkipUntilAuthTokenIsReady();
 
-  const dispatch = useDispatch();
+  const {
+    data: ateam,
+    error: ateamError,
+    isLoading: ateamIsLoading,
+  } = useGetATeamQuery(ateamId, { skip });
 
   useEffect(() => {
     if (ateam) {
@@ -66,6 +71,10 @@ export function ATeamNotificationSetting(props) {
     setCheckSlack(false);
     setSlackMessage();
   }, [show, ateam]);
+
+  if (skip) return <></>;
+  if (ateamError) return <>{`Cannot get Ateam: ${errorToString(ateamError)}`}</>;
+  if (ateamIsLoading) return <>Now loading Ateam...</>;
 
   const connectSuccessMessage = () => {
     return (
@@ -93,7 +102,6 @@ export function ATeamNotificationSetting(props) {
     await updateATeam({ ateamId: ateamId, data: ateamInfo })
       .unwrap()
       .then(() => {
-        dispatch(getATeam(ateamId));
         enqueueSnackbar("update ateam info succeeded", { variant: "success" });
       })
       .catch((error) =>

--- a/web/src/components/ATeamNotificationSetting.jsx
+++ b/web/src/components/ATeamNotificationSetting.jsx
@@ -19,7 +19,6 @@ import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import {

--- a/web/src/components/ATeamWatchingMenu.jsx
+++ b/web/src/components/ATeamWatchingMenu.jsx
@@ -2,10 +2,8 @@ import { DoDisturbAlt as DoDisturbAltIcon, MoreVert as MoreVertIcon } from "@mui
 import { Button, Dialog, Menu, MenuItem } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import { useDispatch } from "react-redux";
 
 import { ATeamWatchingStop } from "../components/ATeamWatchingStop";
-import { getATeam } from "../slices/ateam";
 
 export function ATeamWatchingMenu(props) {
   const { ateam, watchingPteamId, watchingPteamName, isAdmin } = props;
@@ -13,8 +11,6 @@ export function ATeamWatchingMenu(props) {
   const [openRemove, setOpenRemove] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
-
-  const dispatch = useDispatch();
 
   const handleClick = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -67,7 +63,6 @@ export function ATeamWatchingMenu(props) {
           ateamId={ateam.ateam_id}
           ateamName={ateam.ateam_name}
           onClose={() => {
-            dispatch(getATeam(ateam.ateam_id)); // update ateam.pteams
             setOpenRemove(false);
           }}
         />

--- a/web/src/components/ATeamWatchingStop.jsx
+++ b/web/src/components/ATeamWatchingStop.jsx
@@ -11,11 +11,9 @@ import {
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
-import { useDispatch } from "react-redux";
 
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useRemoveWatchingPTeamMutation } from "../services/tcApi";
-import { getATeam } from "../slices/ateam";
 import { errorToString } from "../utils/func";
 
 export function ATeamWatchingStop(props) {
@@ -24,11 +22,8 @@ export function ATeamWatchingStop(props) {
   const { enqueueSnackbar } = useSnackbar();
   const [removeWatchingPTeam] = useRemoveWatchingPTeamMutation();
 
-  const dispatch = useDispatch();
-
   const handleRemove = async () => {
     function onSuccess(success) {
-      dispatch(getATeam(ateamId));
       enqueueSnackbar(`Stop watching ${watchingPteamName} succeeded`, {
         variant: "success",
       });

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -1,6 +1,6 @@
 import { Avatar, Box, MenuItem, Tab, Tabs, TextField, Tooltip } from "@mui/material";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import { ATeamLabel } from "../components/ATeamLabel";
 import { ATeamMember } from "../components/ATeamMember";
@@ -8,11 +8,11 @@ import { ATeamWatching } from "../components/ATeamWatching";
 import { TabPanel } from "../components/TabPanel";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import {
+  useGetATeamQuery,
   useGetATeamAuthQuery,
   useGetATeamMembersQuery,
   useGetUserMeQuery,
 } from "../services/tcApi";
-import { getATeam } from "../slices/ateam";
 import { noATeamMessage, experienceColors } from "../utils/const";
 import { a11yProps, errorToString } from "../utils/func.js";
 
@@ -21,9 +21,6 @@ export function ATeam() {
   const [tabValue, setTabValue] = useState(0);
 
   const ateamId = useSelector((state) => state.ateam.ateamId);
-  const ateam = useSelector((state) => state.ateam.ateam);
-
-  const dispatch = useDispatch();
 
   const filterModes = ["All", "ATeam"];
 
@@ -33,6 +30,11 @@ export function ATeam() {
     error: userMeError,
     isLoading: userMeIsLoading,
   } = useGetUserMeQuery(undefined, { skip });
+  const {
+    data: ateam,
+    error: ateamError,
+    isLoading: ateamIsLoading,
+  } = useGetATeamQuery(ateamId, { skip });
   const {
     data: authorities,
     error: authoritiesError,
@@ -46,8 +48,7 @@ export function ATeam() {
 
   useEffect(() => {
     if (!ateamId) return;
-    if (!ateam) dispatch(getATeam(ateamId));
-  }, [dispatch, ateamId, ateam]);
+  }, [ateamId, ateam]);
 
   const tabHandleChange = (event, newValue) => {
     setTabValue(newValue);
@@ -58,6 +59,8 @@ export function ATeam() {
 
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
+  if (ateamError) return <>{`Cannot get Ateam: ${errorToString(ateamError)}`}</>;
+  if (ateamIsLoading) return <>Now loading Ateam...</>;
   if (authoritiesError) return <>{`Cannot get ATeamAuth: ${errorToString(authoritiesError)}`}</>;
   if (authoritiesIsLoading) return <>Now loading ATeamAuth...</>;
   if (membersError) return <>{`Cannot get Members: ${errorToString(membersError)}`}</>;

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -1,6 +1,5 @@
 import { Avatar, Box, MenuItem, Tab, Tabs, TextField, Tooltip } from "@mui/material";
-import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { useState } from "react";
 import { useLocation } from "react-router";
 
 import { ATeamLabel } from "../components/ATeamLabel";
@@ -24,8 +23,6 @@ export function ATeam() {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const ateamId = params.get("ateamId");
-
-  const dispatch = useDispatch();
 
   const filterModes = ["All", "ATeam"];
 

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -51,10 +51,6 @@ export function ATeam() {
     isLoading: membersIsLoading,
   } = useGetATeamMembersQuery(ateamId, { skip });
 
-  useEffect(() => {
-    if (!ateamId) return;
-  }, [ateamId]);
-
   const tabHandleChange = (event, newValue) => {
     setTabValue(newValue);
   };

--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -48,7 +48,7 @@ export function ATeam() {
 
   useEffect(() => {
     if (!ateamId) return;
-  }, [ateamId, ateam]);
+  }, [ateamId]);
 
   const tabHandleChange = (event, newValue) => {
     setTabValue(newValue);

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -29,7 +29,6 @@ import { grey } from "@mui/material/colors";
 import { format } from "date-fns";
 import { useSnackbar } from "notistack";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
 import { ATeamLabel } from "../components/ATeamLabel";
@@ -37,15 +36,13 @@ import { ATeamTopicMenu } from "../components/ATeamTopicMenu";
 import { AnalysisNoThreatsMsg } from "../components/AnalysisNoThreatsMsg";
 import { AnalysisTopic } from "../components/AnalysisTopic";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
-import { useGetATeamAuthQuery, useGetUserMeQuery } from "../services/tcApi";
-import { getATeam } from "../slices/ateam";
+import { useGetATeamQuery, useGetATeamAuthQuery, useGetUserMeQuery } from "../services/tcApi";
 import { getATeamTopics } from "../utils/api";
 import { difficulty, difficultyColors, noATeamMessage } from "../utils/const";
 import { calcTimestampDiff, errorToString, utcStringToLocalDate } from "../utils/func";
 
 export function Analysis() {
   const { enqueueSnackbar } = useSnackbar();
-  const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
   const params = new URLSearchParams(location.search);
@@ -60,12 +57,15 @@ export function Analysis() {
     isLoading: userMeIsLoading,
   } = useGetUserMeQuery(undefined, { skip });
   const {
+    data: ateam,
+    error: ateamError,
+    isLoading: ateamIsLoading,
+  } = useGetATeamQuery(ateamId, { skip });
+  const {
     data: authorities,
     error: authoritiesError,
     isLoading: authoritiesIsLoading,
   } = useGetATeamAuthQuery(ateamId, { skip });
-
-  const ateam = useSelector((state) => state.ateam.ateam);
 
   const perPageItems = [10, 20, 50, 100];
   const sortKeyItems = [
@@ -132,12 +132,13 @@ export function Analysis() {
 
   useEffect(() => {
     if (skip || !ateamId) return;
-    if (!ateam) dispatch(getATeam(ateamId));
-  }, [dispatch, ateam, skip, ateamId]);
+  }, [ateam, skip, ateamId]);
 
   if (skip) return <></>;
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
+  if (ateamError) return <>{`Cannot get Ateam: ${errorToString(ateamError)}`}</>;
+  if (ateamIsLoading) return <>Now loading Ateam...</>;
   if (authoritiesError) return <>{`Cannot get ATeamAuth: ${errorToString(authoritiesError)}`}</>;
   if (authoritiesIsLoading) return <>Now loading ATeamAuth...</>;
 

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -130,10 +130,6 @@ export function Analysis() {
     fetchPageInfo();
   }, [skip, ateamId, ateam, page, perPage, sortKey, actualSearch, enqueueSnackbar]);
 
-  useEffect(() => {
-    if (skip || !ateamId) return;
-  }, [skip, ateamId]);
-
   if (skip) return <></>;
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -132,7 +132,7 @@ export function Analysis() {
 
   useEffect(() => {
     if (skip || !ateamId) return;
-  }, [ateam, skip, ateamId]);
+  }, [skip, ateamId]);
 
   if (skip) return <></>;
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;

--- a/web/src/pages/Analysis.jsx
+++ b/web/src/pages/Analysis.jsx
@@ -99,7 +99,6 @@ export function Analysis() {
   const [anchorEl, setAnchorEl] = useState();
 
   useEffect(() => {
-    /* Note: state.ateam.* are re-initialized when ateamId is changed. */
     if (skip || !ateamId || !ateam) return;
     async function fetchPageInfo() {
       const queryParams = {

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -91,6 +91,20 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [{ type: "ATeamAccount", id: "ALL" }],
     }),
+    getATeam: builder.query({
+      query: (ateamId) => ({
+        url: `/ateams/${ateamId}`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "Pteam", id: arg.pteamId },
+        { type: "AteamPteam", id: "ALL" },
+        { type: "AteamPteam", id: `${arg.ateamId}:${arg.pteamId}` },
+        { type: "Ateam", id: arg.ateamId },
+        { type: "AteamPteam", id: `${arg.ateamId}:${arg.pteamId}` },
+        { type: "Service", id: "ALL" },
+      ],
+    }),
     updateATeam: builder.mutation({
       query: ({ ateamId, data }) => ({
         url: `ateams/${ateamId}`,
@@ -363,6 +377,7 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [
         { type: "Service", id: arg.serviceId },
+        { type: "Service", id: "ALL" },
         { type: "Ticket", id: "ALL" },
       ],
     }),
@@ -451,7 +466,10 @@ export const tcApi = createApi({
           /* Note: Content-Type is fixed to multipart/form-data automatically. */
         };
       },
-      invalidatesTags: (result, error, arg) => [{ type: "Tag", id: "ALL" }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "Tag", id: "ALL" },
+        { type: "Service", id: "ALL" },
+      ],
     }),
 
     /* tag */
@@ -666,6 +684,7 @@ export const {
   useUpdateATeamAuthMutation,
   useCreateATeamInvitationMutation,
   useApplyATeamInvitationMutation,
+  useGetATeamQuery,
   useGetATeamInvitedQuery,
   useGetATeamMembersQuery,
   useGetATeamRequestedQuery,

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -96,12 +96,16 @@ export const tcApi = createApi({
         url: `/ateams/${ateamId}`,
         method: "GET",
       }),
-      providesTags: (result, error, arg) => [
-        { type: "Pteam", id: arg.pteamId },
-        { type: "AteamPteam", id: "ALL" },
-        { type: "AteamPteam", id: `${arg.ateamId}:${arg.pteamId}` },
-        { type: "Ateam", id: arg.ateamId },
-        { type: "AteamPteam", id: `${arg.ateamId}:${arg.pteamId}` },
+      providesTags: (result, error, ateamId) => [
+        ...(result?.pteams.reduce(
+          (ret, pteam) => [
+            ...ret,
+            { type: "PTeam", id: pteam.pteam_id },
+            { type: "ATeamPTeam", id: `${ateamId}:${pteam.pteam_id}` },
+          ],
+          [{ type: "ATeamPTeam", id: "ALL" }],
+        ) ?? []),
+        { type: "ATeam", id: ateamId },
         { type: "Service", id: "ALL" },
       ],
     }),

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -1,4 +1,4 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
 
 const _initialState = {
   ateamId: undefined,

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -1,15 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
-import { getATeam as apiGetATeam, getATeamTopics as apiGetATeamTopics } from "../utils/api";
-
-export const getATeam = createAsyncThunk(
-  "ateam/getATeam",
-  async (ateamId) =>
-    await apiGetATeam(ateamId).then((response) => ({
-      data: response.data,
-      ateamId: ateamId,
-    })),
-);
+import { getATeamTopics as apiGetATeamTopics } from "../utils/api";
 
 export const getATeamTopics = createAsyncThunk(
   "ateam/getATeamTopics",
@@ -42,15 +33,10 @@ const ateamSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder
-      .addCase(getATeam.fulfilled, (state, action) => ({
-        ...state,
-        ateam: action.payload.data,
-      }))
-      .addCase(getATeamTopics.fulfilled, (state, action) => ({
-        ...state,
-        ateamTopics: action.payload.data,
-      }));
+    builder.addCase(getATeamTopics.fulfilled, (state, action) => ({
+      ...state,
+      ateamTopics: action.payload.data,
+    }));
   },
 });
 

--- a/web/src/slices/ateam.js
+++ b/web/src/slices/ateam.js
@@ -13,7 +13,6 @@ export const getATeamTopics = createAsyncThunk(
 
 const _initialState = {
   ateamId: undefined,
-  ateam: undefined,
   ateamTopics: undefined,
 };
 

--- a/web/src/utils/api.js
+++ b/web/src/utils/api.js
@@ -11,9 +11,6 @@ export const removeToken = () => {
 // pteams
 export const getPTeamTagsSummary = async (pteamId) => axios.get(`/pteams/${pteamId}/tags/summary`);
 
-// ateams
-export const getATeam = async (ateamId) => axios.get(`/ateams/${ateamId}`);
-
 export const getATeamTopics = async (ateamId, params) =>
   axios.get(`/ateams/${ateamId}/topicstatus`, { params: params ?? {} });
 


### PR DESCRIPTION
## PR の目的
- /ateams/${ateamId}のRTKクエリAPI入替作業の実施

## 経緯・意図・意思決定
- 以下のファイルでuseGetATeamQueryフックを使ってAPIからデータを取得するコードの実装
   - web/src/components/ATeamGeneralSetting.jsx
   - web/src/components/ATeamMemberMenu.jsx
   - web/src/components/ATeamNotificationSetting.jsx
   - web/src/pages/ATeam.jsx
   - web/src/pages/Analysis.jsx

- 以下のファイルでdispatch(getATeam(ateamId));の処理を消去
   - web/src/components/ATeamWatchingStop.jsx
   - web/src/components/ATeamWatchingMenu.jsx
   - web/src/slices/ateam.js

- 以下のファイルでgetATeamのAPIのクエリを定義
   - web/src/services/tcApi.js

- 以下のファイルでgetATeamメソッドの削除
   - web/src/utils/api.js 