### PR TITLE
topic/fix team selector error

### DIFF
--- a/web/src/components/TeamSelector.jsx
+++ b/web/src/components/TeamSelector.jsx
@@ -74,7 +74,7 @@ export function TeamSelector(props) {
     setCurrentTeamName(userMe.pteams?.find((x) => x.pteam_id === teamId)?.pteam_name);
 
     if (teamMode === "pteam") {
-      if (tagId) {
+      if (tagId || location.pathname === "/ateam/join") {
         const newParams = new URLSearchParams();
         newParams.set("pteamId", teamId);
         navigate("/?" + newParams);


### PR DESCRIPTION
## PR の目的
- ATeamのadd memberから移動したリンク先のaccept画面において、右上のteam selectorからチームを変更した際に発生するエラーについて修正しました

## 経緯・意図・意思決定
- エラーが発生する原因
  - チームを切り替えた時にnavigateが正しくできておらず、存在しないURLを指定しているのが原因でした
  - 下記のURLを指定していました。仕様的にjoinの後にはtokenIdしか来ないはずですが、pteamIdが入るようになっていました。
  - http://localhost:3000/ateam/join?pteamId=<pteamId>
  - 
- 解決方法
  - location.pathname === "/ateam/join"の時を条件に含めるようにしました。

