### PR TITLE
set team state when common page

### DIFF
--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -110,6 +110,14 @@ export function App() {
         return;
       }
       setPteamId(pteamIdx);
+    } else if (["/topics", "/account"].includes(location.pathname)) {
+      if (params.get("ateamId")) {
+        dispatch(setTeamMode("ateam"));
+        setATeamId(params.get("ateamId"));
+      } else if (params.get("pteamId")) {
+        dispatch(setTeamMode("pteam"));
+        setPteamId(params.get("pteamId"));
+      }
     }
   }, [dispatch, enqueueSnackbar, navigate, location, userMe, userMeIsFetching, system.teamMode]);
 

--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -110,7 +110,7 @@ export function App() {
         return;
       }
       setPteamId(pteamIdx);
-    } else if (["/topics", "/account"].includes(location.pathname)) {
+    } else if (location.pathname.includes("/topics") || location.pathname === "/account") {
       if (params.get("ateamId")) {
         dispatch(setTeamMode("ateam"));
         setATeamId(params.get("ateamId"));


### PR DESCRIPTION
## PR の目的
- 下記バグを修正
  - [現象] 
    - ATeamを選択してTopics、Accountのページでブラウザの更新をすると、PTeamにおけるTopics、Accountページに変わる。Topicsで1件表示したページも含む。
URL上はateamIdが設定されているが、Drawer.jsxはPTeamの表示となる。
    - 関連する問題として、ATeamまたはPTeamを選択してTopics、Accountのページでブラウザの更新をすると、TeamSelectorにチーム名が表示されなくなる。
  - [原因]
    - App.jsxでTopics、Accountの場合にsetTeamModeをしておらず、AppBarに渡すateamId、pteamIdをセットしていない
  - [対策]
    - App.jsxでTopics、Accountの場合にsetTeamMode、AppBarに渡すateamId、pteamIdをセットする

