### PR TITLE
Fix CinC in ATeamTopicCreateModal, TopicEditModal,TopicModal

### DIFF
--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -1,5 +1,4 @@
 import {
-  AddBox as AddBoxIcon,
   Close as CloseIcon,
   SentimentSatisfiedAlt as SentimentSatisfiedAltIcon,
   SentimentVeryDissatisfied as SentimentVeryDissatisfiedIcon,
@@ -19,7 +18,7 @@ import {
   Typography,
   List,
 } from "@mui/material";
-import { blue, red, green } from "@mui/material/colors";
+import { red, green } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
@@ -37,9 +36,10 @@ import {
 } from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
+import { ActionGeneratorModal } from "./ActionGeneratorModal";
 import { ActionItem } from "./ActionItem";
 import { ThreatImpactChip } from "./ThreatImpactChip";
-import { TopicTagSelector } from "./TopicTagSelector";
+import { TopicTagSelectorModal } from "./TopicTagSelectorModal";
 
 const steps = ["Threat, Vulnerability, and Risk", "Dissemination", "Response planning"];
 
@@ -146,54 +146,6 @@ export function ATeamTopicCreateModal(props) {
     onSetOpen(false);
   };
 
-  function ActionGeneratorModal() {
-    const [generatorOpen, setGeneratorOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setGeneratorOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
-          <DialogContent>
-            <ActionGenerator
-              text="Add action"
-              tagIds={actionTagOptions}
-              onGenerate={(ret) => {
-                setActions([...actions, ret]);
-                setGeneratorOpen(false);
-              }}
-              onCancel={() => setGeneratorOpen(false)}
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  }
-
-  function TopicTagSelectorModal() {
-    const [tagOpen, setTagOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setTagOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={tagOpen} onClose={() => setTagOpen(false)}>
-          <DialogContent>
-            <TopicTagSelector
-              currentSelectedIds={tagIds}
-              onCancel={() => setTagOpen(false)}
-              onApply={(ary) => {
-                setTagIds(ary);
-                setActionTagOptions(createActionTagOptions(ary));
-                setTagOpen(false);
-              }}
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  }
-
   return (
     <>
       <Dialog
@@ -298,7 +250,12 @@ export function ATeamTopicCreateModal(props) {
                   <Typography variant="body2" sx={{ fontWeight: 600 }}>
                     Artifact Tag
                   </Typography>
-                  <TopicTagSelectorModal />
+                  <TopicTagSelectorModal
+                    tagIds={tagIds}
+                    setTagIds={setTagIds}
+                    setActionTagOptions={setActionTagOptions}
+                    createActionTagOptions={createActionTagOptions}
+                  />
                 </Box>
                 <TextField
                   size="small"
@@ -324,7 +281,11 @@ export function ATeamTopicCreateModal(props) {
                   <Typography variant="body2" sx={{ fontWeight: 600 }}>
                     Action
                   </Typography>
-                  <ActionGeneratorModal />
+                  <ActionGeneratorModal
+                    actionTagOptions={actionTagOptions}
+                    actions={actions}
+                    setActions={setActions}
+                  />
                 </Box>
                 <List
                   sx={{

--- a/web/src/components/ActionGeneratorModal.jsx
+++ b/web/src/components/ActionGeneratorModal.jsx
@@ -1,0 +1,38 @@
+import { AddBox as AddBoxIcon } from "@mui/icons-material";
+import { Dialog, DialogContent, IconButton } from "@mui/material";
+import { blue } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+
+import { ActionGenerator } from "./ActionGenerator";
+
+export function ActionGeneratorModal(props) {
+  const { actionTagOptions, actions, setActions } = props;
+  const [generatorOpen, setGeneratorOpen] = useState(false);
+  return (
+    <>
+      <IconButton onClick={() => setGeneratorOpen(true)} sx={{ color: blue[700] }}>
+        <AddBoxIcon />
+      </IconButton>
+      <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
+        <DialogContent>
+          <ActionGenerator
+            text="Add action"
+            tagIds={actionTagOptions}
+            onGenerate={(ret) => {
+              setActions([...actions, ret]);
+              setGeneratorOpen(false);
+            }}
+            onCancel={() => setGeneratorOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+ActionGeneratorModal.propTypes = {
+  actionTagOptions: PropTypes.array.isRequired,
+  actions: PropTypes.array.isRequired,
+  setActions: PropTypes.func.isRequired,
+};

--- a/web/src/components/AnalysisActionGeneratorModal.jsx
+++ b/web/src/components/AnalysisActionGeneratorModal.jsx
@@ -1,0 +1,36 @@
+import { AddBox as AddBoxIcon } from "@mui/icons-material";
+import { Dialog, IconButton } from "@mui/material";
+import { blue } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+
+import { AnalysisActionGenerator } from "./AnalysisActionGenerator";
+
+export function AnalysisActionGeneratorModal(props) {
+  const { actionTagOptions, actions, setActions } = props;
+  const [generatorOpen, setGeneratorOpen] = useState(false);
+  return (
+    <>
+      <IconButton onClick={() => setGeneratorOpen(true)} sx={{ color: blue[700] }}>
+        <AddBoxIcon />
+      </IconButton>
+      <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
+        <AnalysisActionGenerator
+          text="Add action"
+          tagIds={actionTagOptions}
+          onGenerate={(ret) => {
+            setActions([...actions, ret]);
+            setGeneratorOpen(false);
+          }}
+          onCancel={() => setGeneratorOpen(false)}
+        />
+      </Dialog>
+    </>
+  );
+}
+
+AnalysisActionGeneratorModal.propTypes = {
+  actionTagOptions: PropTypes.array.isRequired,
+  actions: PropTypes.array.isRequired,
+  setActions: PropTypes.func.isRequired,
+};

--- a/web/src/components/TopicEditModal.jsx
+++ b/web/src/components/TopicEditModal.jsx
@@ -1,5 +1,4 @@
 import {
-  AddBox as AddBoxIcon,
   Close as CloseIcon,
   Delete as DeleteIcon,
   SentimentSatisfiedAlt as SentimentSatisfiedAltIcon,
@@ -26,7 +25,7 @@ import {
   ToggleButton,
   Stack,
 } from "@mui/material";
-import { blue, green, red } from "@mui/material/colors";
+import { green, red } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
@@ -45,9 +44,9 @@ import {
 import { a11yProps, errorToString, setEquals, validateNotEmpty } from "../utils/func";
 
 import { ActionTypeIcon } from "./ActionTypeIcon";
-import { AnalysisActionGenerator } from "./AnalysisActionGenerator";
+import { AnalysisActionGeneratorModal } from "./AnalysisActionGeneratorModal";
 import { ThreatImpactChip } from "./ThreatImpactChip";
-import { TopicTagSelector } from "./TopicTagSelector";
+import { TopicTagSelectorModal } from "./TopicTagSelectorModal";
 
 export function TopicEditModal(props) {
   const { open, onSetOpen, currentTopic, currentActions } = props;
@@ -205,52 +204,6 @@ export function TopicEditModal(props) {
       !setEquals(new Set(tagIds), new Set(currentTopic.tags.map((tag) => tag.tag_id))) ||
       JSON.stringify(actions) !== JSON.stringify(currentActions));
 
-  function TopicTagSelectorModal() {
-    const [tagOpen, setTagOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setTagOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={tagOpen} onClose={() => setTagOpen(false)}>
-          <DialogContent>
-            <TopicTagSelector
-              currentSelectedIds={tagIds}
-              onCancel={() => setTagOpen(false)}
-              onApply={(newTagIds) => {
-                setTagIds(newTagIds);
-                setActionTagOptions(createActionTagOptions(newTagIds));
-                setTagOpen(false);
-              }}
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  }
-
-  function AnalysisActionGeneratorModal() {
-    const [generatorOpen, setGeneratorOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setGeneratorOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
-          <AnalysisActionGenerator
-            text="Add action"
-            tagIds={actionTagOptions}
-            onGenerate={(ret) => {
-              setActions([...actions, ret]);
-              setGeneratorOpen(false);
-            }}
-            onCancel={() => setGeneratorOpen(false)}
-          />
-        </Dialog>
-      </>
-    );
-  }
-
   return (
     <Dialog open={open === true} maxWidth="md" sx={{ maxHeight: "100vh" }}>
       <DialogTitle>
@@ -335,7 +288,12 @@ export function TopicEditModal(props) {
                 <Typography variant="body2" sx={{ fontWeight: 600 }}>
                   Artifact Tag
                 </Typography>
-                <TopicTagSelectorModal />
+                <TopicTagSelectorModal
+                  tagIds={tagIds}
+                  setTagIds={setTagIds}
+                  setActionTagOptions={setActionTagOptions}
+                  createActionTagOptions={createActionTagOptions}
+                />
               </Box>
               <List sx={{ ml: 1 }}>
                 {allTags
@@ -388,7 +346,11 @@ export function TopicEditModal(props) {
               <Typography variant="body2" sx={{ fontWeight: 600 }}>
                 Action
               </Typography>
-              <AnalysisActionGeneratorModal />
+              <AnalysisActionGeneratorModal
+                actionTagOptions={actionTagOptions}
+                actions={actions}
+                setActions={setActions}
+              />
             </Box>
             <List sx={{ ml: 1 }}>
               {actions.map((action) => (

--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -1,8 +1,4 @@
-import {
-  AddBox as AddBoxIcon,
-  Close as CloseIcon,
-  ContentPaste as ContentPasteIcon,
-} from "@mui/icons-material";
+import { Close as CloseIcon, ContentPaste as ContentPasteIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -19,7 +15,7 @@ import {
   Typography,
   List,
 } from "@mui/material";
-import { blue, grey } from "@mui/material/colors";
+import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
@@ -41,10 +37,11 @@ import { actionTypes } from "../utils/const";
 import { validateNotEmpty, validateUUID, setEquals, errorToString } from "../utils/func";
 
 import { ActionGenerator } from "./ActionGenerator";
+import { ActionGeneratorModal } from "./ActionGeneratorModal";
 import { ActionItem } from "./ActionItem";
 import { ThreatImpactChip } from "./ThreatImpactChip";
 import { TopicDeleteModal } from "./TopicDeleteModal";
-import { TopicTagSelector } from "./TopicTagSelector";
+import { TopicTagSelectorModal } from "./TopicTagSelectorModal";
 
 const steps = ["Import Flashsense", "Create topic"];
 
@@ -408,54 +405,6 @@ export function TopicModal(props) {
     onSetOpen(false);
   };
 
-  function ActionGeneratorModal() {
-    const [generatorOpen, setGeneratorOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setGeneratorOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={generatorOpen} onClose={() => setGeneratorOpen(false)}>
-          <DialogContent>
-            <ActionGenerator
-              text="Add action"
-              tagIds={actionTagOptions}
-              onGenerate={(ret) => {
-                setActions([...actions, ret]);
-                setGeneratorOpen(false);
-              }}
-              onCancel={() => setGeneratorOpen(false)}
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  }
-
-  function TopicTagSelectorModal(props) {
-    const [tagOpen, setTagOpen] = useState(false);
-    return (
-      <>
-        <IconButton onClick={() => setTagOpen(true)} sx={{ color: blue[700] }}>
-          <AddBoxIcon />
-        </IconButton>
-        <Dialog open={tagOpen} onClose={() => setTagOpen(false)}>
-          <DialogContent>
-            <TopicTagSelector
-              currentSelectedIds={tagIds}
-              onCancel={() => setTagOpen(false)}
-              onApply={(ary) => {
-                setTagIds(ary);
-                setActionTagOptions(createActionTagOptions(ary));
-                setTagOpen(false);
-              }}
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  }
-
   const updateErrors = (key, value, validator) => {
     if (validator(value)) setErrors(errors.filter((error) => error !== key));
     else if (errors.indexOf(key) < 0) setErrors([...errors, key]);
@@ -585,7 +534,11 @@ export function TopicModal(props) {
                 <Box mb={1}>
                   <Box display="flex" flexDirection="row" alignItems="center" mb={1}>
                     <Typography sx={{ fontWeight: 900 }}>Actions</Typography>
-                    <ActionGeneratorModal />
+                    <ActionGeneratorModal
+                      actionTagOptions={actionTagOptions}
+                      actions={actions}
+                      setActions={setActions}
+                    />
                   </Box>
                   {actions?.length > 0 || (
                     <Box
@@ -639,7 +592,12 @@ export function TopicModal(props) {
                   <Box mb={1}>
                     <Box display="flex" flexDirection="row" alignItems="center">
                       <Typography sx={{ fontWeight: 900 }}>Artifact Tags</Typography>
-                      <TopicTagSelectorModal />
+                      <TopicTagSelectorModal
+                        tagIds={tagIds}
+                        setTagIds={setTagIds}
+                        setActionTagOptions={setActionTagOptions}
+                        createActionTagOptions={createActionTagOptions}
+                      />
                     </Box>
                     <TextField
                       size="small"

--- a/web/src/components/TopicTagSelectorModal.jsx
+++ b/web/src/components/TopicTagSelectorModal.jsx
@@ -1,0 +1,40 @@
+import { AddBox as AddBoxIcon } from "@mui/icons-material";
+import { Dialog, DialogContent, IconButton } from "@mui/material";
+import { blue } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+
+import { TopicTagSelector } from "./TopicTagSelector";
+
+export function TopicTagSelectorModal(props) {
+  const { tagIds, setTagIds, setActionTagOptions, createActionTagOptions } = props;
+  const [tagOpen, setTagOpen] = useState(false);
+
+  return (
+    <>
+      <IconButton onClick={() => setTagOpen(true)} sx={{ color: blue[700] }}>
+        <AddBoxIcon />
+      </IconButton>
+      <Dialog open={tagOpen} onClose={() => setTagOpen(false)}>
+        <DialogContent>
+          <TopicTagSelector
+            currentSelectedIds={tagIds}
+            onCancel={() => setTagOpen(false)}
+            onApply={(ary) => {
+              setTagIds(ary);
+              setActionTagOptions(createActionTagOptions(ary));
+              setTagOpen(false);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+TopicTagSelectorModal.propTypes = {
+  tagIds: PropTypes.array.isRequired,
+  setTagIds: PropTypes.func.isRequired,
+  setActionTagOptions: PropTypes.func.isRequired,
+  createActionTagOptions: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## PR の目的
- ATeamTopicCreateModal, TopicEditModal,TopicModalのコンポーネント in コンポーネントの解消

## 経緯・意図・意思決定
- 関数コンポーネントの中で関数コンポーネントを定義すると、コンポーネントが再レンダリングされるたびに定義が走るので非常に重くなるという問題がある。
- ATeamTopicCreateModal, TopicEditModal,TopicModalに対して、ネスト構造になっていたコンポーネントの定義を外部に移動
- 各コンポーネント内で宣言されていたコンポーネントinコンポーネントの処理は共通の部分が多かったため、ファイル外で定義してexportして共有した。
  - web/src/components/ActionGeneratorModal.jsx
  - web/src/components/AnalysisActionGeneratorModal.jsx
  - web/src/components/TopicTagSelectorModal.jsx

## 参考文献
https://ja.react.dev/learn/your-first-component#nesting-and-organizing-components