### PR TITLE
bugfix/ATeam Edit Topic Modal

### DIFF
--- a/web/src/components/TopicEditModal.jsx
+++ b/web/src/components/TopicEditModal.jsx
@@ -101,7 +101,7 @@ export function TopicEditModal(props) {
       .map((tag) => tag.tag_id);
   };
 
-  const resetParams = async () => {
+  const resetParams = () => {
     // reset with currentTopic
     setTab(0);
     setTopicId(currentTopic.topic_id);
@@ -118,7 +118,10 @@ export function TopicEditModal(props) {
 
   const handleChangeTab = (_, newTab) => setTab(newTab);
 
-  const handleClose = () => onSetOpen(false);
+  const handleClose = () => {
+    resetParams();
+    onSetOpen(false);
+  };
 
   const handleUpdate = async () => {
     setUpdating(true);


### PR DESCRIPTION
## PR の目的
- ATeamのTopic編集ダイアログで項目変更して×で閉じて開きなおすと、変更した値が表示される問題について対処しました
- 他のダイアログについて同様な問題が起こらないか確認したところ、無かったです

## 経緯・意図・意思決定
- ダイアログを閉じるための×ボタンが押された際に、ダイアログにある項目をリセットするように修正しました。
- resetParams()にあったasyncが不要なため削除しました。
