### PR TITLE
bugfix/message when there is no team

### DIFF
--- a/web/src/pages/ATeam.jsx
+++ b/web/src/pages/ATeam.jsx
@@ -52,8 +52,8 @@ export function ATeam() {
     setTabValue(newValue);
   };
 
-  if (skip) return <></>;
   if (!ateamId) return <>{noATeamMessage}</>;
+  if (skip) return <></>;
 
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;

--- a/web/src/pages/PTeam.jsx
+++ b/web/src/pages/PTeam.jsx
@@ -46,8 +46,8 @@ export function PTeam() {
     isLoading: membersIsLoading,
   } = useGetPTeamMembersQuery(pteamId, { skip });
 
-  if (skip) return <></>;
   if (!pteamId) return <>{noPTeamMessage}</>;
+  if (skip) return <></>;
 
   if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -182,8 +182,8 @@ export function Status() {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [pteamId, pteam, pteamId, serviceId, isActiveAllServicesMode]);
 
-  if (skipByAuth || !pteamId) return <></>;
   if (!pteamId) return <>{noPTeamMessage}</>;
+  if (skipByAuth || !pteamId) return <></>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
   if (serviceTagsSummaryError)


### PR DESCRIPTION
## PR の目的
- 所属するチームがない時、ATeam、PTeam、Status画面が真っ白になる問題について対処しました。

## 経緯・意図・意思決定
- 原因
  - RTKQ化した際に、ateamIdとpteamIdがない時の処理より先にskipの処理を行っていることが原因でした
- 解決策
  - skipの処理よりも先にateamIdとpteamIdがない時の処理を行うように変更しました。

