### PR TITLE
topic/fixing page transitions

### DIFF
--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -65,7 +65,6 @@ export function App() {
     const locationReader = new LocationReader(location);
     if (locationReader.isAnalysisPage() || locationReader.isATeamPage()) {
       if (!userMe.ateams.length > 0) {
-        setATeamId(undefined);
         if (params.get("ateamId")) {
           navigate(location.pathname);
         }
@@ -92,7 +91,6 @@ export function App() {
       locationReader.isWatchingRequestPage()
     ) {
       if (!userMe.pteams.length > 0) {
-        setPteamId(undefined);
         if (params.get("pteamId")) {
           navigate(location.pathname);
         }

--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -68,6 +68,9 @@ export function App() {
       dispatch(setTeamMode("ateam"));
       if (!userMe.ateams.length > 0) {
         setATeamId(undefined);
+        if (params.get("ateamId")) {
+          navigate(location.pathname);
+        }
         return;
       }
       const ateamIdx = params.get("ateamId") || userMe.ateams[0].ateam_id;
@@ -91,6 +94,9 @@ export function App() {
     ) {
       if (!userMe.pteams.length > 0) {
         setPteamId(undefined);
+        if (params.get("pteamId")) {
+          navigate(location.pathname);
+        }
         return;
       }
       const pteamIdx = params.get("pteamId") || userMe.pteams[0].pteam_id;


### PR DESCRIPTION
## PR の目的
-  所属する最後のチームから抜けた後、遷移先ページが正しく表示されない問題について対処しました
- チームを抜けた後、URLにアクセス許可がないateamId, pteamIdを指定していることで画面にエラーメッセージが表示されていました

## 経緯・意図・意思決定
- 原因
  - 所属する最後のチームから抜けた後に、ユーザに紐づくチームが1つもないのにateamId, pteamIdがURLに入っていることが原因でした
- 解決策
  -  チームを抜けた後、ユーザに紐づくチームが0かつURLにateamId, pteamIdが入っていた場合、ateamId, pteamIdを取り除くように修正しました