### PR TITLE
topic/fixed timing of when useGetPTeamTagsSummaryQuery is fetched

### DIFF
--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -151,7 +151,7 @@ export function Status() {
     isFetching: serviceTagsSummaryIsFetching,
   } = useGetPTeamServiceTagsSummaryQuery(
     { pteamId, serviceId },
-    { skip: skipByAuth || !pteamId || !serviceId },
+    { skip: skipByAuth || !pteamId || !serviceId || isActiveAllServicesMode },
   );
 
   const {
@@ -188,16 +188,24 @@ export function Status() {
   if (skipByAuth || !pteamId) return <></>;
   if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
-  if (serviceTagsSummaryError)
-    return <>{`Cannot get serviceTagsSummary: ${errorToString(serviceTagsSummaryError)}`}</>;
-  if (serviceId || pteam.services.length > 0) {
-    if (!serviceTagsSummary || serviceTagsSummaryIsFetching)
+
+  if (isActiveAllServicesMode) {
+    if (pteamTagsSummaryError)
+      return <>{`Cannot get pteamTagsSummary: ${errorToString(pteamTagsSummaryError)}`}</>;
+
+    if (!pteamTagsSummary || pteamTagsSummaryIsFetching)
+      return <>Now loading pteamTagsSummary...</>;
+  } else {
+    if (serviceTagsSummaryError)
+      return <>{`Cannot get serviceTagsSummary: ${errorToString(serviceTagsSummaryError)}`}</>;
+
+    if (
+      (serviceId || pteam.services.length > 0) &&
+      (!serviceTagsSummary || serviceTagsSummaryIsFetching)
+    ) {
       return <>Now loading serviceTagsSummary...</>;
+    }
   }
-  if (pteamTagsSummaryError)
-    return <>{`Cannot get pteamTagsSummary: ${errorToString(pteamTagsSummaryError)}`}</>;
-  if (isActiveAllServicesMode && (!pteamTagsSummary || pteamTagsSummaryIsFetching))
-    return <>Now loading pteamTagsSummary...</>;
 
   const service =
     isActiveAllServicesMode || !serviceId

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -158,7 +158,9 @@ export function Status() {
     currentData: pteamTagsSummary,
     error: pteamTagsSummaryError,
     isFetching: pteamTagsSummaryIsFetching,
-  } = useGetPTeamTagsSummaryQuery(pteamId, { skip: skipByAuth || !pteamId });
+  } = useGetPTeamTagsSummaryQuery(pteamId, {
+    skip: skipByAuth || !pteamId || !isActiveAllServicesMode,
+  });
 
   useEffect(() => {
     if (!pteamId) return; // wait fixed by App


### PR DESCRIPTION
## PR の目的
- useGetPTeamTagsSummaryQueryがフェッチされるタイミングを修正しました。

## 経緯・意図・意思決定
- 変更前
  - Status画面の初期表示時、[ALL Services]がOFF、ON関係なくuseGetPTeamTagsSummaryQueryとuseGetPTeamServiceTagsSummaryQuery両方がフェッチされる
- 変更後
  - Status画面で[ALL Services]がOFFの時useGetPTeamServiceTagsSummaryQuery、ONの時useGetPTeamTagsSummaryQueryをそれそれフェッチするように変更
 - useGetPTeamTagsSummaryQueryのスキップ条件にisActiveAllServicesModeを追加しました
 - エラーとローディングを表示するためのif文ではisActiveAllServicesModeがTrueの時とFalseの時で処理を分けるようにしました