### PR TITLE
topic/change authority api post to put

### DIFF
--- a/api/app/routers/ateams.py
+++ b/api/app/routers/ateams.py
@@ -254,7 +254,7 @@ def update_ateam(
     return ret
 
 
-@router.post("/{ateam_id}/authority", response_model=list[schemas.ATeamAuthResponse])
+@router.put("/{ateam_id}/authority", response_model=list[schemas.ATeamAuthResponse])
 def update_ateam_auth(
     ateam_id: UUID,
     requests: list[schemas.ATeamAuthRequest],

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -825,7 +825,7 @@ def create_pteam(
     return pteam
 
 
-@router.post("/{pteam_id}/authority", response_model=list[schemas.PTeamAuthResponse])
+@router.put("/{pteam_id}/authority", response_model=list[schemas.PTeamAuthResponse])
 def update_pteam_auth(
     pteam_id: UUID,
     requests: list[schemas.PTeamAuthRequest],

--- a/api/app/tests/medium/routers/test_ateams.py
+++ b/api/app/tests/medium/routers/test_ateams.py
@@ -264,19 +264,17 @@ def test_update_ateam_auth(testdb):
 
     # without header
     with pytest.raises(HTTPError, match=r"401: Unauthorized"):
-        assert_200(client.post(f"/ateams/{ateam1.ateam_id}/authority", json=request))
+        assert_200(client.put(f"/ateams/{ateam1.ateam_id}/authority", json=request))
 
     # without admin
     with pytest.raises(HTTPError, match=r"403: Forbidden: You do not have authority"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
         )
 
     # by master
     data = assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
     assert len(data) == len(request)
     assert data[0]["user_id"] == str(user2.user_id)
@@ -300,7 +298,7 @@ def test_update_ateam_auth(testdb):
         }
     ]
     data = assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
     )
     assert len(data) == len(request)
     assert data[0]["user_id"] == str(user2.user_id)
@@ -324,9 +322,7 @@ def test_update_ateam_auth(testdb):
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Not an ateam member"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
 
 
@@ -372,7 +368,7 @@ def test_update_ateam_auth__pseudo_uuid(testdb):
         {"user_id": str(NOT_MEMBER_UUID), "authorities": request_auth},
     ]
     data = assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
     assert len(data) == 2
     assert {x["user_id"] for x in data} == set(map(str, {MEMBER_UUID, NOT_MEMBER_UUID}))
@@ -402,18 +398,14 @@ def test_update_ateam_auth__pseudo_uuid(testdb):
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Cannot give ADMIN to pseudo account"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
     request = [
         {"user_id": str(NOT_MEMBER_UUID), "authorities": [models.ATeamAuthEnum.ADMIN]},
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Cannot give ADMIN to pseudo account"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
 
     # system account
@@ -422,9 +414,7 @@ def test_update_ateam_auth__pseudo_uuid(testdb):
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Invalid user id"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
 
 
@@ -438,9 +428,7 @@ def test_update_ateam_auth__remove_admin__last():
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Removing last ADMIN is not allowed"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
 
 
@@ -457,7 +445,7 @@ def test_update_ateam_auth__remove_admin__not_last():
     ]
     # removing (no more last) admin
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
     # removing last admin
     request = [
@@ -465,9 +453,7 @@ def test_update_ateam_auth__remove_admin__not_last():
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Removing last ADMIN is not allowed"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
         )
 
 
@@ -484,7 +470,7 @@ def test_update_ateam_auth__remove_admin__swap():
     ]
     #  removing (no more last) admin
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
 
     # swap admin
@@ -493,7 +479,7 @@ def test_update_ateam_auth__remove_admin__swap():
         {"user_id": str(user2.user_id), "authorities": []},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER2), json=request)
     )
 
     # comeback admin
@@ -501,7 +487,7 @@ def test_update_ateam_auth__remove_admin__swap():
         {"user_id": str(user2.user_id), "authorities": [models.ATeamAuthEnum.ADMIN]},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
 
     # remove all admin at once
@@ -511,9 +497,7 @@ def test_update_ateam_auth__remove_admin__swap():
     ]
     with pytest.raises(HTTPError, match=r"400: Bad Request: Removing last ADMIN is not allowed"):
         assert_200(
-            client.post(
-                f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request
-            )
+            client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
         )
 
 
@@ -537,7 +521,7 @@ def test_ateam_auth_effects__individual():
         {"user_id": str(user2.user_id), "authorities": [models.ATeamAuthEnum.INVITE]},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
 
     # try again
@@ -560,7 +544,7 @@ def test_ateam_auth_effects__pseudo_member():
         {"user_id": str(MEMBER_UUID), "authorities": [models.ATeamAuthEnum.INVITE]},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
 
     # try again
@@ -583,7 +567,7 @@ def test_ateam_auth_effects__pseudo_not_member():
         {"user_id": str(NOT_MEMBER_UUID), "authorities": [models.ATeamAuthEnum.INVITE]},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
 
     # try again
@@ -641,7 +625,7 @@ def test_create_invitation__without_authority():
         {"user_id": str(user2.user_id), "authorities": [models.ATeamAuthEnum.INVITE]},
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
     invitation = invite_to_ateam(USER2, ateam1.ateam_id)
     assert invitation.invitation_id != UUID(int=0)
@@ -658,7 +642,7 @@ def test_create_invitation__without_authority():
         },
     ]
     assert_200(
-        client.post(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
+        client.put(f"/ateams/{ateam1.ateam_id}/authority", headers=headers(USER1), json=request)
     )
     invitation = invite_to_ateam(USER2, ateam1.ateam_id, authes=[models.ATeamAuthEnum.INVITE])
     assert invitation.invitation_id != UUID(int=0)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -542,7 +542,7 @@ def test_update_pteam_auth(testdb):
             "authorities": request_auth,
         }
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -582,7 +582,7 @@ def test_update_pteam_auth__without_auth(testdb):
             "authorities": None,
         }
     ]
-    response = client.post(f"/pteams/{pteam1.pteam_id}/authority", json=request)  # no headers
+    response = client.put(f"/pteams/{pteam1.pteam_id}/authority", json=request)  # no headers
     assert response.status_code == 401
     assert response.reason_phrase == "Unauthorized"
 
@@ -604,7 +604,7 @@ def test_update_pteam_auth__without_authority():
             "authorities": request_auth,
         }
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -621,7 +621,7 @@ def test_update_pteam_auth__without_authority():
             "authorities": request_auth,
         }
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 403
@@ -670,7 +670,7 @@ def test_update_pteam_auth__pseudo_uuid(testdb):
         {"user_id": str(MEMBER_UUID), "authorities": member_auth},
         {"user_id": str(NOT_MEMBER_UUID), "authorities": not_member_auth},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -725,7 +725,7 @@ def test_update_pteam_auth__not_member(testdb):
             "authorities": request_auth,
         }
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 400
@@ -777,7 +777,7 @@ def test_update_pteam_auth__pseudo(testdb):
         {"user_id": str(MEMBER_UUID), "authorities": member_auth},
         {"user_id": str(NOT_MEMBER_UUID), "authorities": not_member_auth},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -809,7 +809,7 @@ def test_update_pteam_auth__pseudo_admin():
     create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)
 
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(MEMBER_UUID), "authorities": ["admin"]}],
@@ -817,7 +817,7 @@ def test_update_pteam_auth__pseudo_admin():
     assert response.status_code == 400
     assert response.reason_phrase == "Bad Request"
 
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(NOT_MEMBER_UUID), "authorities": ["admin"]}],
@@ -834,7 +834,7 @@ def test_update_pteam_auth__remove_admin__last():
     request = [
         {"user_id": str(user1.user_id), "authorities": []},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 400
@@ -854,7 +854,7 @@ def test_update_pteam_auth__remove_admin__another():
     request = [
         {"user_id": str(user1.user_id), "authorities": []},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -866,7 +866,7 @@ def test_update_pteam_auth__remove_admin__another():
     request = [
         {"user_id": str(user1.user_id), "authorities": ["admin"]},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER2), json=request
     )
     assert response.status_code == 200
@@ -876,7 +876,7 @@ def test_update_pteam_auth__remove_admin__another():
         {"user_id": str(user1.user_id), "authorities": []},
         {"user_id": str(user2.user_id), "authorities": []},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 400
@@ -895,7 +895,7 @@ def test_update_pteam_auth__swap_admin():
         {"user_id": str(user1.user_id), "authorities": []},  # retire ADMIN
         {"user_id": str(user2.user_id), "authorities": ["admin"]},  # be ADMIN
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -924,7 +924,7 @@ def test_get_pteam_auth():
         {"user_id": str(MEMBER_UUID), "authorities": member_auth},
         {"user_id": str(NOT_MEMBER_UUID), "authorities": not_member_auth},
     ]
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority", headers=headers(USER1), json=request
     )
     assert response.status_code == 200
@@ -985,7 +985,7 @@ def test_pteam_auth_effects__indivudual():
         invite_to_pteam(USER2, pteam1.pteam_id)
 
     # give INVITE
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(user2.user_id), "authorities": ["invite"]}],
@@ -1008,7 +1008,7 @@ def test_pteam_auth_effects__pseudo_member():
         invite_to_pteam(USER2, pteam1.pteam_id)
 
     # give INVITE to MEMBER
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(MEMBER_UUID), "authorities": ["invite"]}],
@@ -1031,7 +1031,7 @@ def test_pteam_auth_effects__pseudo_not_member():
         invite_to_pteam(USER2, pteam1.pteam_id)
 
     # give INVITE to NOT_MEMBER. it is also applied to members.
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(NOT_MEMBER_UUID), "authorities": ["invite"]}],
@@ -1085,7 +1085,7 @@ def test_create_invitation__without_authorities():
     assert response.reason_phrase == "Forbidden"
 
     # give INVITE
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(user2.user_id), "authorities": ["invite"]}],
@@ -1118,7 +1118,7 @@ def test_create_invitation__without_authorities():
     assert response.reason_phrase == "Bad Request"
 
     # give INVITE & ADMIN
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(user2.user_id), "authorities": ["invite", "admin"]}],
@@ -1301,7 +1301,7 @@ def test_delete_invitation__by_another():
     assert response.status_code == 403
 
     # delete by pteam member with INVITE
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(user3.user_id), "authorities": ["invite"]}],
@@ -1567,7 +1567,7 @@ def test_delete_member__not_last_admin():
     accept_pteam_invitation(USER2, invitation.invitation_id)
 
     # make the other member ADMIN
-    response = client.post(
+    response = client.put(
         f"/pteams/{pteam1.pteam_id}/authority",
         headers=headers(USER1),
         json=[{"user_id": str(user2.user_id), "authorities": ["admin"]}],

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -136,7 +136,7 @@ export const tcApi = createApi({
     updateATeamAuth: builder.mutation({
       query: ({ ateamId, data }) => ({
         url: `ateams/${ateamId}/authority`,
-        method: "POST",
+        method: "PUT",
         body: data,
       }),
       invalidatesTags: (result, error, arg) => [{ type: "ATeamAuthority", id: arg.ateamId }],
@@ -314,7 +314,7 @@ export const tcApi = createApi({
     updatePTeamAuth: builder.mutation({
       query: ({ pteamId, data }) => ({
         url: `pteams/${pteamId}/authority`,
-        method: "POST",
+        method: "PUT",
         body: data,
       }),
       invalidatesTags: (result, error, arg) => [{ type: "PTeamAuthority", id: arg.pteamId }],


### PR DESCRIPTION
## PR の目的
- update authority のメソッドをPOSTから PUT に修正しました

## 経緯・意図・意思決定
- ATeam, PTeamどちらともPOSTから PUT に変更しました
- api, test, ui内にあったupdate authority関する部分を変更しました
