### PR TITLE
add button to delete topic

### DIFF
--- a/web/src/components/AnalysisTopic.jsx
+++ b/web/src/components/AnalysisTopic.jsx
@@ -34,6 +34,7 @@ import React, { useEffect, useState } from "react";
 
 import { AnalysisActionTypeIcon } from "../components/AnalysisActionTypeIcon";
 import { CommentDeleteModal } from "../components/CommentDeleteModal";
+import { DeleteTopicIcon } from "../components/DeleteTopicIcon";
 import { TabPanel } from "../components/TabPanel";
 import { ThreatImpactChip } from "../components/ThreatImpactChip";
 import { TopicEditModal } from "../components/TopicEditModal";
@@ -210,6 +211,7 @@ export function AnalysisTopic(props) {
               <IconButton onClick={() => setTopicModalOpen(true)}>
                 <EditIcon />
               </IconButton>
+              <DeleteTopicIcon topicId={topic.topic_id} />
             </Box>
           </Box>
           <UUIDTypography sx={{ marginLeft: "95px" }}>{topic.topic_id}</UUIDTypography>

--- a/web/src/components/DeleteTopicIcon.jsx
+++ b/web/src/components/DeleteTopicIcon.jsx
@@ -1,0 +1,96 @@
+import { Delete as DeleteIcon, Close as CloseIcon } from "@mui/icons-material";
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { grey } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+
+import dialogStyle from "../cssModule/dialog.module.css";
+
+import { TopicDeleteModal } from "./TopicDeleteModal";
+
+export function DeleteTopicIcon(props) {
+  const { topicId } = props;
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleModalClose = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <Tooltip title="Delete this topic">
+        <IconButton onClick={() => setModalOpen(true)}>
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+      <Dialog
+        open={modalOpen}
+        onClose={handleModalClose}
+        maxWidth="md"
+        fullWidth
+        sx={{ maxHeight: "100vh" }}
+      >
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="row"
+          sx={{ backgroundColor: grey[200] }}
+        >
+          <Typography
+            fontWeight="bold"
+            flexGrow={1}
+            className={dialogStyle.dialog_title}
+            sx={{ marginLeft: 2 }}
+          >
+            DANGER ZONE
+          </Typography>
+          <IconButton onClick={handleModalClose} sx={{ color: grey[500] }}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        <DialogTitle sx={{ backgroundColor: grey[200] }}>
+          <Box
+            alignItems="center"
+            display="flex"
+            flexDirection="row"
+            sx={{ bgcolor: "common.white" }}
+          >
+            <Typography
+              fontWeight="bold"
+              flexGrow={1}
+              className={dialogStyle.dialog_title}
+              sx={{ marginLeft: 2 }}
+            >
+              Delete this topic
+            </Typography>
+          </Box>
+          <Box
+            alignItems="center"
+            display="flex"
+            flexDirection="row"
+            sx={{ bgcolor: "common.white" }}
+          >
+            <Typography flexGrow={1} className={dialogStyle.dialog_title} sx={{ marginLeft: 2 }}>
+              Once you delete a topic, there is no going back. Please to certain.
+            </Typography>
+            <DialogContent sx={{ marginLeft: 10 }}>
+              <TopicDeleteModal topicId={topicId} onSetOpenTopicModal={setModalOpen} />
+            </DialogContent>
+          </Box>
+        </DialogTitle>
+      </Dialog>
+    </>
+  );
+}
+DeleteTopicIcon.propTypes = {
+  topicId: PropTypes.string.isRequired,
+};

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -219,6 +219,7 @@ export const tcApi = createApi({
         { type: "Service", id: "ALL" },
         { type: "Threat", id: "ALL" },
         { type: "Ticket", id: "ALL" },
+        { type: "CurrentTicketStatus", id: "ALL" },
       ],
     }),
 

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -219,7 +219,7 @@ export const tcApi = createApi({
         { type: "Service", id: "ALL" },
         { type: "Threat", id: "ALL" },
         { type: "Ticket", id: "ALL" },
-        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "TicketStatus", id: "ALL" },
       ],
     }),
 

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -517,9 +517,7 @@ export const tcApi = createApi({
         method: "GET",
       }),
       providesTags: (result, error, arg) => [
-        ...(result
-          ? result.map((ticket) => ({ type: "TicketStatus", id: ticket.ticket_id }))
-          : []),
+        ...(result ? result.map((ticket) => ({ type: "TicketStatus", id: ticket.ticket_id })) : []),
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
         { type: "Service", id: "ALL" },

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -212,6 +212,14 @@ export const tcApi = createApi({
         url: `/ateams/${ateamId}/topicstatus`,
         params: params ?? {},
       }),
+      providesTags: (result, error, arg) => [
+        { type: "ATeamPTeam", id: `${arg.ateamId}:ALL` },
+        { type: "ATeamPTeam", id: "ALL" },
+        { type: "PTeam", id: "ALL" },
+        { type: "Service", id: "ALL" },
+        { type: "Threat", id: "ALL" },
+        { type: "Ticket", id: "ALL" },
+      ],
     }),
 
     /* ATeam Watching Request */
@@ -248,6 +256,7 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [
         { type: "ATeamPTeam", id: `${arg.ateamId}:${arg.pteamId}` },
+        { type: "ATeamPTeam", id: `${arg.ateamId}:ALL` },
       ],
     }),
 
@@ -460,6 +469,7 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (result, error, arg) => [
         { type: "ATeamPTeam", id: `${arg.ateamId}:${arg.pteamId}` },
+        { type: "ATeamPTeam", id: `${arg.ateamId}:ALL` },
       ],
     }),
 

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -421,7 +421,7 @@ export const tcApi = createApi({
       providesTags: (result, error, arg) => [
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
-        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "TicketStatus", id: "ALL" },
         { type: "Service", id: "ALL" },
       ],
     }),
@@ -435,7 +435,7 @@ export const tcApi = createApi({
       providesTags: (result, error, arg) => [
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
-        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "TicketStatus", id: "ALL" },
         { type: "Service", id: "ALL" },
       ],
     }),
@@ -457,7 +457,7 @@ export const tcApi = createApi({
       providesTags: (result, error, arg) => [
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
-        { type: "CurrentTicketStatus", id: "ALL" },
+        { type: "TicketStatus", id: "ALL" },
         { type: "Service", id: "ALL" },
       ],
     }),
@@ -518,7 +518,7 @@ export const tcApi = createApi({
       }),
       providesTags: (result, error, arg) => [
         ...(result
-          ? result.map((ticket) => ({ type: "CurrentTicketStatus", id: ticket.ticket_id }))
+          ? result.map((ticket) => ({ type: "TicketStatus", id: ticket.ticket_id }))
           : []),
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
@@ -534,8 +534,8 @@ export const tcApi = createApi({
         body: data,
       }),
       invalidatesTags: (result, error, arg) => [
-        { type: "CurrentTicketStatus", id: "ALL" },
-        { type: "CurrentTicketStatus", id: arg.ticketId },
+        { type: "TicketStatus", id: "ALL" },
+        { type: "TicketStatus", id: arg.ticketId },
       ],
     }),
 


### PR DESCRIPTION
## PR の目的
- Ateamに選択中のtopicを削除する機能を実装
   - web/src/components/DeleteTopicIcon.jsxを作成
      - DeleteTopicIcon.jsx内でTopicDeleteModalを呼び出して、削除機能を実装
   - web/src/components/AnalysisTopic.jsx上でDeleteTopicIcon.jsxをimportして実装
      - 現在選択しているtopicのeditbuttonの横にtopic削除buttonを追加
- get /ateams/${ateamId}/topicstatus (getATeamTopics) APIにおいて、RTKクエリのキャッシュtagを設定していなかったが、設定するよう変更
   - Analysisページでトピック削除時に、トピックリストのキャッシュがクリアされず、削除したトピックを選択したままとなり、1件のトピックフェッチがエラーとなった。そのため、getATeamTopicsにキャッシュタグをつける。

## 経緯・意図・意思決定
- Ateamに選択中のtopicを削除する機能がなかったため
