### PR TITLE
bugfix/fix tag selection display in ateam

### DIFF
--- a/web/src/components/ATeamTopicCreateModal.jsx
+++ b/web/src/components/ATeamTopicCreateModal.jsx
@@ -84,8 +84,7 @@ export function ATeamTopicCreateModal(props) {
   const validateTopicParams = () => validateUUID(topicId) && validateNotEmpty(title);
 
   const createActionTagOptions = (tagIdList) => {
-    // TODO
-    return [];
+    return [...new Set([...tagIdList])];
   };
 
   const validateActionTags = () => {


### PR DESCRIPTION
## PR の目的
- Analysis画面の[New Topic]で表示される画面からActionを作る際、アクションを適用するタグの選択が表示されない問題を修正しました
- 2番目のDisseminationのArtifact Tagで選択されたTagがActionを作る際に表示されるように修正しました

## 経緯・意図・意思決定
- 原因
  - ActionGeneratorのtagIdsに渡している値であるactionTagOptionsが空の状態になっていました。
  - actionTagOptionsに値を入れる過程でcreateActionTagOptionsを使用する必要があるのですが、空のリストを返すだけになっていました
- 解決策
  - createActionTagOptionsに処理を追加しました
  - pteam側の処理と同じになるように処理を追加しました
  - 参考箇所はTopicModal.jsxです
https://github.com/nttcom/threatconnectome/blob/f914c187497c93d30354b4eb64704476400090f1/web/src/components/TopicModal.jsx#L115
