### PR TITLE
fix invalid id navigation

### DIFF
--- a/web/src/pages/App.jsx
+++ b/web/src/pages/App.jsx
@@ -97,14 +97,6 @@ export function App() {
         return;
       }
       const pteamIdx = params.get("pteamId") || userMe.pteams[0].pteam_id;
-      if (!userMe.pteams.find((pteam) => pteam.pteam_id === pteamIdx)) {
-        enqueueSnackbar(`Wrong pteamId. Force switching to '${userMe.pteams[0].pteam_name}'.`, {
-          variant: "error",
-        });
-        params.set("pteamId", userMe.pteams[0].pteam_id);
-        navigate(location.pathname + "?" + params.toString());
-        return;
-      }
       if (params.get("pteamId") !== pteamIdx) {
         params.set("pteamId", pteamIdx);
         navigate(location.pathname + "?" + params.toString());

--- a/web/src/pages/Status.jsx
+++ b/web/src/pages/Status.jsx
@@ -174,11 +174,6 @@ export function Status() {
       newParams.set("serviceId", pteam.services[0].service_id);
       navigate(location.pathname + "?" + newParams.toString());
       return;
-    } else if (!pteam.services.find((service) => service.service_id === serviceId)) {
-      const newParams = new URLSearchParams();
-      newParams.set("pteamId", pteamId);
-      navigate("/?" + newParams.toString());
-      return;
     }
 
     /* eslint-disable-next-line react-hooks/exhaustive-deps */

--- a/web/src/pages/Tag.jsx
+++ b/web/src/pages/Tag.jsx
@@ -1,9 +1,7 @@
 import { Box, Divider, Tab, Tabs, Typography, Chip } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import { useSnackbar } from "notistack";
-import React, { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
-import { useNavigate, useParams, useLocation } from "react-router-dom";
+import React, { useState } from "react";
+import { useParams, useLocation } from "react-router-dom";
 
 import { PTeamTaggedTopics } from "../components/PTeamTaggedTopics";
 import { TabPanel } from "../components/TabPanel";
@@ -27,10 +25,6 @@ export function Tag() {
     error: allTagsError,
     isLoading: allTagsIsLoading,
   } = useGetTagsQuery(undefined, { skipByAuth });
-
-  const dispatch = useDispatch();
-  const navigate = useNavigate();
-  const { enqueueSnackbar } = useSnackbar();
 
   const { tagId } = useParams();
   const params = new URLSearchParams(useLocation().search);
@@ -62,38 +56,6 @@ export function Tag() {
   const currentTagDependencies = (serviceDependencies ?? []).filter(
     (dependency) => dependency.tag_id === tagId,
   );
-
-  useEffect(() => {
-    if (!pteam) return; // wait getQuery
-    if (!serviceId || !pteam.services.find((service) => service.service_id === serviceId)) {
-      const msg = `${serviceId ? "Invalid" : "Missing"} serviceId`;
-      enqueueSnackbar(msg, { variant: "error" });
-      const params = new URLSearchParams();
-      params.set("pteamId", pteamId);
-      navigate("/?" + params.toString()); // force jump to Status page
-      return;
-    }
-
-    if (!tagId || (currentTagDependencies.length === 0 && !serviceDependenciesIsLoading)) {
-      const msg = `${tagId ? "Invalid" : "Missing"} tagId`;
-      enqueueSnackbar(msg, { variant: "error" });
-      const params = new URLSearchParams();
-      params.set("pteamId", pteamId);
-      navigate("/?" + params.toString()); // force jump to Status page
-      return;
-    }
-  }, [
-    pteam,
-    currentTagDependencies,
-    taggedTopics,
-    pteamId,
-    serviceId,
-    tagId,
-    serviceDependenciesIsLoading,
-    dispatch,
-    enqueueSnackbar,
-    navigate,
-  ]);
 
   if (!getTopicIdsReady) return <></>;
   if (allTagsError) return <>{`Cannot get allTags: ${errorToString(allTagsError)}`}</>;


### PR DESCRIPTION
## PR の目的
- 存在しないIDを指定した際の自動遷移を廃止

## 経緯・意図・意思決定
(1)ページ：Status、Tag、PTeam
　ケース：指定したpteamIdに所属していない
　修正前：メッセージを表示して、自分が所属する1件目のPTeamに遷移
　修正後：エラーメッセージを表示し、遷移しない

サンプル(status画面のURLに含まれるpteamidを変更)

<img width="1509" alt="スクリーンショット 2024-11-21 17 11 39" src="https://github.com/user-attachments/assets/ab9535be-2166-41f3-b385-e6f539133b1b">

(3)
　ページ：Status
　ケース：指定したserviceIdが指定したpreamIdに所属していない
　修正前：メッセージなく、serviceId無しに遷移し、その先で下記挙動
　　PTeamにServiceが無い場合、SBOM投入ページを表示
　　PTeamにServiceがある場合、1件目のServiceのページに遷移
　修正後：エラーメッセージを表示し、遷移しない

サンプル(serviceのあるPTeamで、status画面のURLに含まれるserviceidを変更)

<img width="1512" alt="スクリーンショット 2024-11-21 17 15 56" src="https://github.com/user-attachments/assets/7e002ca7-e024-4009-a201-fde6afdc1c4d">


(4)
　ページ：Tag
　ケース：指定したtagId、serviceIdが存在しない
　修正前：メッセージを表示してStatus画面に遷移する
　修正後：エラーメッセージを表示し、遷移しない

サンプル(tag画面のURLに含まれるtagidを変更)

<img width="1512" alt="スクリーンショット 2024-11-21 17 28 08" src="https://github.com/user-attachments/assets/ffd9aef7-e7d9-49e1-9263-e0cf8a089e0b">




