### PR TITLE
docker multistage build to build web

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -31,7 +31,7 @@ services:
     restart: always
     volumes:
       - ./api/app:/app:ro
-      - ./api/app/alembic:/app/alembic:rw  # for 'alembic revision --autogenerate'
+      - ./api/app/alembic:/app/alembic:rw # for 'alembic revision --autogenerate'
       - ./key:/key:ro
   db:
     image: postgres:14
@@ -71,11 +71,9 @@ services:
       - ./traefik:/etc/traefik
       - /var/run/docker.sock:/var/run/docker.sock
   web:
-    image: nginx:stable
-    command:
-      - /usr/sbin/nginx
-      - -g
-      - daemon off;
+    build:
+      context: ./web
+      dockerfile: ../web.dockerfile
     labels:
       - traefik.http.routers.web.entrypoints=http
       - traefik.http.routers.web.priority=1
@@ -83,7 +81,6 @@ services:
     restart: always
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
-      - ./web/build:/usr/share/nginx/html
   firebase:
     build: ./firebase
     ports:

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -1,0 +1,26 @@
+# Stage 1: Build the JavaScript code
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json, and install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the application code
+COPY ./ .
+
+# Build the application
+RUN npm run build
+
+# Stage 2: Serve the static files with Nginx
+FROM nginx:stable
+
+# Copy the built files from the previous stage
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## PR の目的
docker multistage buildを利用し、ホストマシン上でwebをビルドする作業を不要とする

## 経緯・意図・意思決定
nodeコンテナで `npm run build` を実行し、その成果物をnginxコンテナに格納する仕様

`COPY package*.json ./; npm ci` を本体ファイルのコピーと分けて実行し、パッケージの変化がない限りパッケージインストールが行われないようにしている 

## 参考文献
multistage buildについて
https://matsuand.github.io/docs.docker.jp.onthefly/develop/develop-images/multistage-build/