### PR TITLE
topic/fix-warning-in-TopicModal

### DIFF
--- a/web/src/components/TopicModal.jsx
+++ b/web/src/components/TopicModal.jsx
@@ -413,7 +413,7 @@ export function TopicModal(props) {
                     setActions={setActions}
                   />
                 </Box>
-                {actions?.length > 0 || (
+                {actions?.length > 0 ? null : (
                   <Box
                     display="flex"
                     flexDirection="row"


### PR DESCRIPTION
## PR の目的
- TopicModal.jsxを開いた時にコンソールに出力される警告について対応しました。PTeamのTopic作成、編集は削除予定ですが、今後もし元に戻した時に備えて修正しました。
- 警告内容
  - Warning: Failed prop type: Invalid prop children supplied to ForwardRef(Box), expected a ReactNode.

## 経緯・意図・意思決定
- 原因
  - Boxコンポーネントに渡されたchildrenプロパティが期待されるReactNodeではなことが警告の内容でした
  - actions?.length > 0がfalseの時にchilderanプロパティに渡される要素が無効であることが原因のようでした

- 解決策
　-  || ではなく、三項演算子を使用してactions?.length > 0がtrueの時、何も表示せず、falseの時<Box>コンポーネントを表示するようにしました。