### PR TITLE
get dependency api

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -60,6 +60,29 @@ def missing_pteam_admin(db: Session, pteam: models.PTeam) -> bool:
     )
 
 
+def search_threats(
+    db: Session,
+    service_id: UUID | str | None,
+    dependency_id: UUID | str | None,
+    topic_id: UUID | str | None,
+) -> Sequence[models.Threat]:
+    select_stmt = select(models.Threat)
+    if service_id:
+        select_stmt = select_stmt.join(
+            models.Dependency,
+            and_(
+                models.Dependency.dependency_id == models.Threat.dependency_id,
+                models.Dependency.service_id == str(service_id),
+            ),
+        )
+    if dependency_id:
+        select_stmt = select_stmt.where(models.Threat.dependency_id == str(dependency_id))
+    if topic_id:
+        select_stmt = select_stmt.where(models.Threat.topic_id == str(topic_id))
+
+    return db.scalars(select_stmt).all()
+
+
 def search_topics_internal(
     db: Session,
     offset: int = 0,

--- a/api/app/detector/vulnerability_detector.py
+++ b/api/app/detector/vulnerability_detector.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
-from app import models, persistence
+from app import command, models, persistence
 from app.business.ticket_business import create_ticket_internal
 from app.detector.version import (
     PackageFamily,
@@ -56,7 +56,7 @@ def fix_threats_for_topic(db: Session, topic: models.Topic) -> list[str]:
         except ValueError:
             dependency_version = None
 
-        tmp_threats = persistence.search_threats(db, dependency.dependency_id, topic.topic_id)
+        tmp_threats = command.search_threats(db, None, dependency.dependency_id, topic.topic_id)
         current_threat = tmp_threats[0] if tmp_threats else None
 
         if dependency_version:
@@ -145,7 +145,7 @@ def fix_threats_for_dependency(db: Session, dependency: models.Dependency):
 
     # check and fix for each topics related to the dependency
     for topic_id in [topic.topic_id for topic in tag.topics]:
-        tmp_threats = persistence.search_threats(db, dependency.dependency_id, topic_id)
+        tmp_threats = command.search_threats(db, None, dependency.dependency_id, topic_id)
         current_threat = tmp_threats[0] if tmp_threats else None
 
         if dependency_version:

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -269,20 +269,6 @@ def get_threat_by_id(db: Session, threat_id: UUID | str) -> models.Threat | None
     ).one_or_none()
 
 
-def search_threats(
-    db: Session,
-    dependency_id: UUID | str | None,
-    topic_id: UUID | str | None,
-) -> Sequence[models.Threat]:
-    select_stmt = select(models.Threat)
-    if dependency_id:
-        select_stmt = select_stmt.where(models.Threat.dependency_id == str(dependency_id))
-    if topic_id:
-        select_stmt = select_stmt.where(models.Threat.topic_id == str(topic_id))
-
-    return db.scalars(select_stmt).all()
-
-
 ### Ticket
 
 

--- a/api/app/routers/threat.py
+++ b/api/app/routers/threat.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from app import persistence, schemas
+from app import command, persistence, schemas
 from app.database import get_db
 
 router = APIRouter(prefix="/threats", tags=["threats"])
@@ -11,19 +11,20 @@ router = APIRouter(prefix="/threats", tags=["threats"])
 
 @router.get("", response_model=list[schemas.ThreatResponse])
 def get_threats(
+    service_id: UUID | None = Query(None),
     dependency_id: UUID | None = Query(None),
     topic_id: UUID | None = Query(None),
     db: Session = Depends(get_db),
 ):
     """
-    Get all threats sorted by service_id.
+    Get all threats.
 
     Query Params:
-    - **tag_id** (Optional) filter by specified tag_id. Default is None.
     - **service_id** (Optional) filter by specified service_id. Default is None.
+    - **dependency_id** (Optional) filter by specified service_id. Default is None.
     - **topic_id** (Optional) filter by specified topic_id. Default is None.
     """
-    threats = persistence.search_threats(db, dependency_id, topic_id)
+    threats = command.search_threats(db, service_id, dependency_id, topic_id)
     return threats
 
 

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -369,7 +369,7 @@ def update_topic(
     ):
 
         threats: list[models.Threat] = []
-        threats.extend(persistence.search_threats(db, None, topic.topic_id))
+        threats.extend(command.search_threats(db, None, None, topic.topic_id))
 
         now = datetime.now()
         for threat in threats:

--- a/api/app/tests/common/threat_utils.py
+++ b/api/app/tests/common/threat_utils.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models, persistence, schemas
+from app import command, models, persistence, schemas
 from app.main import app
 from app.tests.medium.utils import (
     create_pteam,
@@ -90,8 +90,8 @@ def create_threat(
     )
 
     if dependency:
-        threats = persistence.search_threats(
-            testdb, str(dependency.dependency_id), str(responsed_topic.topic_id)
+        threats = command.search_threats(
+            testdb, None, str(dependency.dependency_id), str(responsed_topic.topic_id)
         )
 
         assert threats

--- a/api/app/tests/common/ticket_utils.py
+++ b/api/app/tests/common/ticket_utils.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models, persistence
+from app import command, models, persistence
 from app.main import app
 from app.tests.medium.utils import (
     create_pteam,
@@ -57,8 +57,8 @@ def create_ticket(testdb: Session, user: dict, pteam: dict, topic: dict):
     )
 
     if dependency:
-        threats = persistence.search_threats(
-            testdb, str(dependency.dependency_id), str(responsed_topic.topic_id)
+        threats = command.search_threats(
+            testdb, None, str(dependency.dependency_id), str(responsed_topic.topic_id)
         )
 
         assert threats

--- a/api/app/tests/medium/test_alert.py
+++ b/api/app/tests/medium/test_alert.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
-from app import models, persistence, schemas
+from app import command, models, schemas
 from app.constants import DEFAULT_ALERT_SSVC_PRIORITY, SYSTEM_EMAIL
 from app.main import app
 from app.notification.alert import create_mail_alert_for_new_topic
@@ -86,7 +86,7 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(testdb, 
     # topic1: parent_tag1
     send_email = mocker.patch("app.notification.alert.send_email")  # reset
     topic1 = create_topic(USER1, _gen_topic_params([parent_tag1]))
-    threats1 = persistence.search_threats(testdb, None, topic1.topic_id)
+    threats1 = command.search_threats(testdb, None, None, topic1.topic_id)
     ssvc_priority1 = ssvc_calculator.calculate_ssvc_priority_by_threat(threats1[0])
     assert ssvc_priority1
     exp_to_email = pteam0.alert_mail.address
@@ -116,7 +116,7 @@ def test_alert_by_mail_if_vulnerabilities_are_found_when_creating_topic(testdb, 
     assert_200(client.put(f"/pteams/{pteam0.pteam_id}", headers=headers(USER1), json=request))
     send_email = mocker.patch("app.notification.alert.send_email")  # reset
     topic3 = create_topic(USER1, _gen_topic_params([parent_tag1]))
-    threats2 = persistence.search_threats(testdb, None, topic3.topic_id)
+    threats2 = command.search_threats(testdb, None, None, topic3.topic_id)
     ssvc_priority2 = ssvc_calculator.calculate_ssvc_priority_by_threat(threats2[0])
     assert ssvc_priority2
     exp_to_email = pteam0.alert_mail.address

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1547,6 +1547,83 @@ def test_delete_service_thumbnail():
     assert get_response.status_code == 404
 
 
+def test_get_dependency(testdb):
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
+    pteam_id = ticket_response["pteam_id"]
+    service_id = ticket_response["service_id"]
+
+    dependencies_response = client.get(
+        f"/pteams/{pteam_id}/services/{service_id}/dependencies", headers=headers(USER1)
+    )
+    dependency1 = dependencies_response.json()[0]
+    dependency_id = dependency1["dependency_id"]
+
+    dependency_response = client.get(
+        f"/pteams/{pteam_id}/services/{service_id}/dependencies/{dependency_id}",
+        headers=headers(USER1),
+    )
+    assert dependency_response.status_code == 200
+    data = dependency_response.json()
+    assert data["dependency_id"] == dependency1["dependency_id"]
+    assert data["service_id"] == dependency1["service_id"]
+    assert data["tag_id"] == dependency1["tag_id"]
+    assert data["version"] == dependency1["version"]
+    assert data["target"] == dependency1["target"]
+
+
+def test_get_dependency_with_wrong_pteam_id(testdb):
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
+    pteam_id = ticket_response["pteam_id"]
+    service_id = ticket_response["service_id"]
+
+    dependencies_response = client.get(
+        f"/pteams/{pteam_id}/services/{service_id}/dependencies", headers=headers(USER1)
+    )
+    dependency1 = dependencies_response.json()[0]
+    dependency_id = dependency1["dependency_id"]
+
+    wrong_pteam_id = str(uuid4())
+    dependency_response = client.get(
+        f"/pteams/{wrong_pteam_id}/services/{service_id}/dependencies/{dependency_id}",
+        headers=headers(USER1),
+    )
+    assert dependency_response.status_code == 404
+    assert dependency_response.json() == {"detail": "No such pteam"}
+
+
+def test_get_dependency_with_wrong_service_id(testdb):
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
+    pteam_id = ticket_response["pteam_id"]
+    service_id = ticket_response["service_id"]
+
+    dependencies_response = client.get(
+        f"/pteams/{pteam_id}/services/{service_id}/dependencies", headers=headers(USER1)
+    )
+    dependency1 = dependencies_response.json()[0]
+    dependency_id = dependency1["dependency_id"]
+
+    wrong_service_id = str(uuid4())
+    dependency_response = client.get(
+        f"/pteams/{pteam_id}/services/{wrong_service_id}/dependencies/{dependency_id}",
+        headers=headers(USER1),
+    )
+    assert dependency_response.status_code == 404
+    assert dependency_response.json() == {"detail": "No such service"}
+
+
+def test_get_dependency_with_wrong_dependency_id(testdb):
+    ticket_response = ticket_utils.create_ticket(testdb, USER1, PTEAM1, TOPIC1)
+    pteam_id = ticket_response["pteam_id"]
+    service_id = ticket_response["service_id"]
+    wrong_dependency_id = str(uuid4())
+    dependency_response = client.get(
+        f"/pteams/{pteam_id}/services/{service_id}/dependencies/{wrong_dependency_id}",
+        headers=headers(USER1),
+    )
+    assert dependency_response.status_code == 404
+    assert dependency_response.json() == {"detail": "No such dependency"}
+
+
 def test_delete_member__not_last_admin():
     user1 = create_user(USER1)
     pteam1 = create_pteam(USER1, PTEAM1)


### PR DESCRIPTION
## PR の目的
- APIの修正、追加を実施
  - [Get /threats]のクエリパラメータにservice_idを追加する
  - Dependency取得APIを新設する
　[Get /pteams/{pteam_id}/services/{service_id}/dependencies/{dependency_id}]

## 経緯・意図・意思決定
各ThreatにSafetyImpactを設定する際、外部ツールに「サービスの説明、Tag名、Topicの情報」を渡して算出したSafetyImpactを設定する、という運用を想定している。
そのため、必要な情報を取得できるようAPIを拡張する。

