### PR TITLE
add-cvss_v3_score-to-trivydb2tc-and-fix-calculate_topic_content_finge…

### DIFF
--- a/api/app/business/topic_business.py
+++ b/api/app/business/topic_business.py
@@ -21,13 +21,13 @@ def get_sorted_topics(topics: Sequence[models.Topic]) -> Sequence[models.Topic]:
 def calculate_topic_content_fingerprint(
     title: str,
     abstract: str,
-    threat_impact: int,
+    cvss_v3_score: float | None,
     tag_names: Sequence[str],
 ) -> str:
     data = {
         "title": title,
         "abstract": abstract,
-        "threat_impact": threat_impact,
+        "cvss_v3_score": cvss_v3_score,
         "tag_names": sorted(set(tag_names)),
     }
     return md5(json.dumps(data, sort_keys=True).encode()).hexdigest()

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -894,20 +894,20 @@ class TestTopicContentFingerprint:
         content_fingerprint1b = topic1b.content_fingerprint
         assert content_fingerprint1b == content_fingerprint1
 
-    def test_updated_on_threat_impact_changed(self):
+    def test_updated_on_cvss_v3_score_changed(self):
         topic1 = create_topic(USER1, TOPIC1)
         content_fingerprint1 = topic1.content_fingerprint
         assert len(content_fingerprint1) > 0
 
-        # update threat_impact
-        new_threat_impact = (topic1.threat_impact + 1) % 4 + 1
-        topic1a = self._update_topic(topic1.topic_id, {"threat_impact": new_threat_impact})
+        # update cvss_v3_score
+        new_cvss_v3_score = 9.0
+        topic1a = self._update_topic(topic1.topic_id, {"cvss_v3_score": new_cvss_v3_score})
         content_fingerprint1a = topic1a.content_fingerprint
         assert len(content_fingerprint1a) > 0
         assert content_fingerprint1a != content_fingerprint1
 
-        # revert threat_impact update
-        topic1b = self._update_topic(topic1.topic_id, {"threat_impact": TOPIC1["threat_impact"]})
+        # revert cvss_v3_score update
+        topic1b = self._update_topic(topic1.topic_id, {"cvss_v3_score": TOPIC1["cvss_v3_score"]})
         content_fingerprint1b = topic1b.content_fingerprint
         assert content_fingerprint1b == content_fingerprint1
 

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -433,9 +433,9 @@ def calculate_topic_content_fingerprint(topic: dict) -> str:
         else topic["tags"]
     )
     data = {
-        "title": topic["title"].strip(),
-        "abstract": topic["abstract"].strip(),
-        "threat_impact": topic["threat_impact"],
+        "title": topic["title"],
+        "abstract": topic["abstract"],
+        "cvss_v3_score": topic["cvss_v3_score"],
         "tag_names": sorted(set(tag_names)),
     }
     return md5(json.dumps(data, sort_keys=True).encode()).hexdigest()
@@ -534,10 +534,21 @@ def main() -> None:
                 else:
                     abstract = "There is no description."
                 severity = vuln_details["Severity"]
+
+                if (
+                    "CVSS" in vuln_details
+                    and "nvd" in vuln_details["CVSS"]
+                    and "V3Score" in vuln_details["CVSS"]["nvd"]
+                ):
+                    cvss_v3_score = float(vuln_details["CVSS"]["nvd"]["V3Score"])
+                else:
+                    cvss_v3_score = None
+
             else:
                 title = vuln_id
                 abstract = "This Vuln is not yet published."
                 severity = "UNKNOWN"
+                cvss_v3_score = None
             if vuln_content["tags"]:
                 tags = list(vuln_content["tags"])
             misp_tags = [vuln_id]
@@ -565,6 +576,7 @@ def main() -> None:
                 "tags": tags,
                 "misp_tags": misp_tags,
                 "actions": actions,
+                "cvss_v3_score": cvss_v3_score,
             }
 
     tc_client = ThreatconnectomeClient(


### PR DESCRIPTION
## PR の目的
以下2点について行いました
- trivyDBからCVSSv3データを取得し、CVSSv3データをthreatconnectomeに送れるようにtrivydb2tc.pyを変更しました
- calculate_topic_content_fingerprintの計算内容を変更しました

## 経緯・意図・意思決定
CVSSv3データ
-  trivyDBからnvdのCVSSv3データを取得するようにしました
- nvdのスコアがなく他の発行団体のスコアがあった場合、スコアは無しとしています

calculate_topic_content_fingerprint
- calculate_topic_content_fingerprintでthreat_impactを用いて計算していたところをcvss_v3_scoreを使用するように変更しました
- scriptとthreatconnectome両方とも、title、abstractのstripを廃止しました


