### PR TITLE
add alembic upgrade head process to the demo setup script

### DIFF
--- a/set_up_demo_environment/set_up.sh
+++ b/set_up_demo_environment/set_up.sh
@@ -7,6 +7,7 @@ sudo cp ./accounts.json ../firebase/data/auth_export/accounts.json
 docker compose -f ../docker-compose-local.yml up --build -d
 docker compose -f ../docker-compose-local.yml cp demo_data db:/
 docker compose -f ../docker-compose-local.yml exec -T db pg_restore --clean --if-exists -U postgres -d postgres demo_data
+sudo docker compose -f docker-compose-local.yml exec api sh -c "cd app && alembic upgrade head"
 cd ../web
 npm ci && npm run build
 docker compose -f ../docker-compose-local.yml restart

--- a/set_up_demo_environment/set_up.sh
+++ b/set_up_demo_environment/set_up.sh
@@ -7,7 +7,7 @@ sudo cp ./accounts.json ../firebase/data/auth_export/accounts.json
 docker compose -f ../docker-compose-local.yml up --build -d
 docker compose -f ../docker-compose-local.yml cp demo_data db:/
 docker compose -f ../docker-compose-local.yml exec -T db pg_restore --clean --if-exists -U postgres -d postgres demo_data
-sudo docker compose -f docker-compose-local.yml exec api sh -c "cd app && alembic upgrade head"
+docker compose -f ../docker-compose-local.yml exec api sh -c "cd app && alembic upgrade head"
 cd ../web
 npm ci && npm run build
 docker compose -f ../docker-compose-local.yml restart


### PR DESCRIPTION
## PR の目的
- デモセットアップスクリプトにおいてpg_restore実行後の部分にalembic upgrade head 処理を追加

## 経緯・意図・意思決定
- デモ用のデータをDBに挿入するためにpg_restoreを使用しているため、データベースのスキーマが元に戻ってしまうから
   - alembic upgrade head を実行する必要がある
      - バックアップを復元した後に、DBのスキーマを最新の状態に更新するため