### PR TITLE
get safetyImpact from threat in UI

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -305,6 +305,18 @@ export const tcApi = createApi({
       invalidatesTags: (result, error, arg) => [{ type: "Tag", id: "ALL" }],
     }),
 
+    /* Threat */
+    getThreat: builder.query({
+      query: (threatId) => ({
+        url: `threats/${threatId}`,
+        method: "GET",
+      }),
+      providesTags: (result, error, arg) => [
+        { type: "Threat", id: "ALL" },
+        { type: "Service", id: "ALL" },
+      ],
+    }),
+
     /* Ticket */
     getTickets: builder.query({
       query: ({ pteamId, serviceId, topicId, tagId }) => ({
@@ -482,6 +494,7 @@ export const {
   useUploadSBOMFileMutation,
   useGetTagsQuery,
   useCreateTagMutation,
+  useGetThreatQuery,
   useGetTicketsQuery,
   useUpdateTicketStatusMutation,
   useGetTopicQuery,


### PR DESCRIPTION
## PR の目的
- Tagページのチケット欄のSafety impactを、Threatに設定があればThreatを見て、なければServiceを見るよう変更
  - Tagページにおいて、getThreat API呼び出しを追加

## 経緯・意図・意思決定
getThreat でerror、isLoadiongの場合の表示は、チケット一覧の各行単位で表示する。
正常ケースと同様アコーディオン形式だが、クリックしても何も開かない状態とする。

![image](https://github.com/user-attachments/assets/a6a8c2b1-986d-4aa7-9601-14664edde3a4)

