### PR TITLE
fix inline comments in .env.for_demo

### DIFF
--- a/.env.for_demo
+++ b/.env.for_demo
@@ -4,7 +4,10 @@ DB_PASSWORD=your_secret_password
 DB_HOST=db
 DB_PORT=5432
 DB_SCHEMA=postgres
-FIREBASE_API_KEY=firebase-emulator-api-key  # any string is ok for emulator
-FIREBASE_CRED=/key/fake_firebase_credentials.json  # generate in demo_setup.sh
-FIREBASE_AUTH_EMULATOR_HOST=localhost:9099  # override in docker-compose-demo.yml
+# firebase api key: any string is ok for emulator
+FIREBASE_API_KEY=firebase-emulator-api-key
+# fake_firebase_credentilas.json will be generated in demo_setup.sh
+FIREBASE_CRED=/key/fake_firebase_credentials.json
+# firebase auth emulator host should be overridden in docker-compose-demo.yml
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
 SYSTEM_EMAIL=

--- a/web/.env.for_demo
+++ b/web/.env.for_demo
@@ -1,6 +1,7 @@
 PUBLIC_URL=
 REACT_APP_API_BASE_URL=http://localhost/api
-REACT_APP_FIREBASE_API_KEY=firebase-emulator-api-key  # any string is ok for emulator
+# firebase api key: any string is ok for emulator
+REACT_APP_FIREBASE_API_KEY=firebase-emulator-api-key
 REACT_APP_FIREBASE_APP_ID=
 REACT_APP_FIREBASE_AUTH_DOMAIN=
 REACT_APP_FIREBASE_MEASUREMENT_ID=


### PR DESCRIPTION
## PR の目的

- .env ファイルのインラインコメントを排除
  - .env ファイル的にはインラインコメントは可だが、docker-compose.yml の env_file として参照された場合にコメントと見なされず、意図しない結果をもたらすため
