### PR TITLE
topic/change color in borderLeft of TopicManagementTableRow

### DIFF
--- a/web/src/pages/TopicDetail/TopicDetailPage.jsx
+++ b/web/src/pages/TopicDetail/TopicDetailPage.jsx
@@ -15,14 +15,14 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { amber, green, grey, orange, red, yellow } from "@mui/material/colors";
+import { green, grey, yellow } from "@mui/material/colors";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetTopicActionsQuery, useGetTopicQuery } from "../../services/tcApi";
-import { errorToString } from "../../utils/func";
+import { errorToString, cvssProps } from "../../utils/func";
 
 import { TopicSSVCCards } from "./TopicSSVCCards";
 
@@ -68,28 +68,15 @@ export function TopicDetail() {
     return <>{`Cannot get topicActions: ${errorToString(topicActionsError)}`}</>;
   if (topicActionsIsLoading) return <>Now loading topicActions...</>;
 
-  const CVSSScore =
+  const cvssScore =
     topic.cvss_v3_score === undefined || topic.cvss_v3_score === null ? "N/A" : topic.cvss_v3_score;
-  let CVSSBgcolor;
-  let threatCardBgcolor;
-  if (CVSSScore === "N/A" || CVSSScore === 0.0) {
-    CVSSBgcolor = grey[600];
-    threatCardBgcolor = grey[100];
-  } else if (CVSSScore < 7.0) {
-    CVSSBgcolor = amber[600];
-    threatCardBgcolor = amber[100];
-  } else if (CVSSScore < 9.0) {
-    CVSSBgcolor = orange[600];
-    threatCardBgcolor = orange[100];
-  } else {
-    CVSSBgcolor = red[600];
-    threatCardBgcolor = red[100];
-  }
+
+  const cvss = cvssProps(cvssScore);
 
   return (
     <>
       <Box>
-        <Card variant="outlined" sx={{ margin: 1, backgroundColor: threatCardBgcolor }}>
+        <Card variant="outlined" sx={{ margin: 1, backgroundColor: cvss.threatCardBgcolor }}>
           <Box sx={{ margin: 3 }}>
             <Box alignItems="center" display="flex" flexDirection="row">
               <Avatar
@@ -98,11 +85,11 @@ export function TopicDetail() {
                   height: 60,
                   width: 60,
                   fontWeight: "bold",
-                  backgroundColor: CVSSBgcolor,
+                  backgroundColor: cvss.cvssBgcolor,
                 }}
                 variant="rounded"
               >
-                {CVSSScore === "N/A" ? CVSSScore : CVSSScore.toFixed(1)}
+                {cvssScore === "N/A" ? cvssScore : cvssScore.toFixed(1)}
               </Avatar>
               <Typography variant="h5">{topic.title}</Typography>
             </Box>

--- a/web/src/pages/TopicManagement/TopicManagementPage.jsx
+++ b/web/src/pages/TopicManagement/TopicManagementPage.jsx
@@ -37,8 +37,7 @@ import {
   useGetTopicQuery,
   useSearchTopicsQuery,
 } from "../../services/tcApi";
-import { difficulty, difficultyColors } from "../../utils/const";
-import { errorToString } from "../../utils/func";
+import { errorToString, cvssProps } from "../../utils/func";
 
 import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "./TopicSearchModal";
@@ -82,6 +81,11 @@ function TopicManagementTableRow(props) {
       </TableRow>
     );
 
+  const cvssScore =
+    topic.cvss_v3_score === undefined || topic.cvss_v3_score === null ? "N/A" : topic.cvss_v3_score;
+
+  const cvss = cvssProps(cvssScore);
+
   return (
     <TableRow
       key={topic.topic_id}
@@ -90,7 +94,7 @@ function TopicManagementTableRow(props) {
         cursor: "pointer",
         "&:last-child td, &:last-child th": { border: 0 },
         "&:hover": { bgcolor: grey[100] },
-        borderLeft: `solid 5px ${difficultyColors[difficulty[topic.threat_impact - 1]]}`,
+        borderLeft: `solid 5px ${cvss.cvssBgcolor}`,
       }}
       onClick={() => navigate(`/topics/${topic.topic_id}?${params.toString()}`)}
     >

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -39,8 +39,6 @@ export const actionTypeChipColors = {
 };
 export const actionTypes = Object.keys(actionTypeChipColors);
 
-export const difficulty = ["high", "middle", "low"];
-
 export const difficultyColors = {
   low: amber[500],
   middle: yellow[700],

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -1,3 +1,4 @@
+import { amber, grey, orange, red } from "@mui/material/colors";
 import { addMinutes, format } from "date-fns";
 
 export const a11yProps = (index) => ({
@@ -118,4 +119,24 @@ export const compareSSVCPriority = (prio1, prio2) => {
   if (int1 === int2) return 0;
   else if (int1 < int2) return -1;
   else return 1;
+};
+
+export const cvssProps = (cvssScore) => {
+  let cvssBgcolor;
+  let threatCardBgcolor;
+  if (cvssScore === "N/A" || cvssScore === 0.0) {
+    cvssBgcolor = grey[600];
+    threatCardBgcolor = grey[100];
+  } else if (cvssScore < 7.0) {
+    cvssBgcolor = amber[600];
+    threatCardBgcolor = amber[100];
+  } else if (cvssScore < 9.0) {
+    cvssBgcolor = orange[600];
+    threatCardBgcolor = orange[100];
+  } else {
+    cvssBgcolor = red[600];
+    threatCardBgcolor = red[100];
+  }
+
+  return { cvssBgcolor, threatCardBgcolor };
 };


### PR DESCRIPTION
## PR の目的
- Topic画面にあるテーブルのborderLeftの色をcvss仕様に変更しました
変更後の色
![image](https://github.com/user-attachments/assets/cbd901ec-5f1f-4d8b-a268-1ca9772be4bc)

## 経緯・意図・意思決定
- TopicDetailPage.jsx
  - cvssScoreを使った色の識別に関する機能をfunc.jsに移しました
- TopicManagement.jsx
  - テーブルのborderLeftの色をcvss仕様に変更しました
- func.js
  - cvssScoreを使った色の識別に関する機能を作成しました
- const.js
  - difficultyを使用する部分が無くなったため、削除しました 



