### PR TITLE
Topic/add error condition in collect threats data.py

### DIFF
--- a/scripts/collect_threats_data.py
+++ b/scripts/collect_threats_data.py
@@ -162,7 +162,7 @@ def get_threats_data(tc_client: ThreatconnectomeClient, service_id: str) -> list
     threats = tc_client.get_threats(params)
 
     if len(threats) == 0:
-        sys.exit("ERROR: The threats data associated with service_id is empty")
+        sys.exit("The threats data associated with service_id is empty")
 
     return threats
 

--- a/scripts/collect_threats_data.py
+++ b/scripts/collect_threats_data.py
@@ -151,6 +151,9 @@ def get_pteam_and_service_data(
             )
             break
 
+    if "service_name" not in pteam_and_service_data:
+        sys.exit("ERROR: The pairing of pteam_id and service_id is incorrect")
+
     return pteam_and_service_data
 
 

--- a/scripts/collect_threats_data.py
+++ b/scripts/collect_threats_data.py
@@ -160,6 +160,10 @@ def get_pteam_and_service_data(
 def get_threats_data(tc_client: ThreatconnectomeClient, service_id: str) -> list:
     params = {"service_id": service_id}
     threats = tc_client.get_threats(params)
+
+    if len(threats) == 0:
+        sys.exit("ERROR: The threats data associated with service_id is empty")
+
     return threats
 
 


### PR DESCRIPTION
## PR の目的
- collect_threats_data.pyにエラー条件を追加しました

## 経緯・意図・意思決定
- def get_pteam_and_service_data()
  - pteam_idに紐づくservice_idと入力されたservice_idが一致しなかった時、エラーになるようにしました
- def get_threats_data()
  - get_threatsをしてresponseが空だった場合、エラーになるようにしました
