### PR TITLE
change topic search condition

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -95,7 +95,8 @@ def search_topics_internal(
     offset: int = 0,
     limit: int = 10,
     sort_key: schemas.TopicSortKey = schemas.TopicSortKey.CVSS_V3_SCORE_DESC,
-    cvss_v3_scores: list[float] | None = None,
+    min_cvss_v3_score: float | None = None,
+    max_cvss_v3_score: float | None = None,
     title_words: list[str | None] | None = None,
     abstract_words: list[str | None] | None = None,
     tag_ids: list[str | None] | None = None,
@@ -110,10 +111,15 @@ def search_topics_internal(
     cve_ids: list[str | None] | None = None,
 ) -> dict:
     # search conditions
-    search_by_cvss_v3_scores_stmt = (
+    search_by_min_cvss_v3_scores_stmt = (
         true()
-        if cvss_v3_scores is None  # do not filter by cvss_v3_score
-        else models.Topic.cvss_v3_score.in_(cvss_v3_scores)
+        if min_cvss_v3_score is None  # do not filter by min_cvss_v3_score
+        else models.Topic.cvss_v3_score >= min_cvss_v3_score
+    )
+    search_by_max_cvss_v3_scores_stmt = (
+        true()
+        if max_cvss_v3_score is None  # do not filter by max_cvss_v3_score
+        else models.Topic.cvss_v3_score <= max_cvss_v3_score
     )
     search_by_tag_ids_stmt = (
         true()
@@ -211,7 +217,8 @@ def search_topics_internal(
     )
 
     search_conditions = [
-        search_by_cvss_v3_scores_stmt,
+        search_by_min_cvss_v3_scores_stmt,
+        search_by_max_cvss_v3_scores_stmt,
         search_by_tag_ids_stmt,
         search_by_misp_tag_ids_stmt,
         search_by_topic_ids_stmt,

--- a/api/app/routers/topics.py
+++ b/api/app/routers/topics.py
@@ -53,7 +53,8 @@ def search_topics(
     offset: int = Query(0, ge=0),
     limit: int = Query(10, ge=1, le=100),  # 10 is default in web/src/pages/TopicManagement.jsx
     sort_key: schemas.TopicSortKey = Query(schemas.TopicSortKey.CVSS_V3_SCORE_DESC),
-    cvss_v3_scores: list[float] | None = Query(None),
+    min_cvss_v3_score: float | None = Query(None),
+    max_cvss_v3_score: float | None = Query(None),
     topic_ids: list[str] | None = Query(None),
     title_words: list[str] | None = Query(None),
     abstract_words: list[str] | None = Query(None),
@@ -72,7 +73,8 @@ def search_topics(
     """
     Search topics by following parameters with sort and pagination.
 
-    - cvss_v3_scores
+    - min_cvss_v3_score
+    - max_cvss_v3_score
     - title_words
     - abstract_words
     - tag_names
@@ -152,15 +154,6 @@ def search_topics(
                 continue
             fixed_abstract_words.add(abstract_word)
 
-    fixed_cvss_v3_scores: set[float] = set()
-    if cvss_v3_scores is not None:
-        for cvss_v3_score in cvss_v3_scores:
-            try:
-                float_val = float(cvss_v3_score)
-                if float_val <= 10.0 and float_val >= 0:
-                    fixed_cvss_v3_scores.add(float_val)
-            except ValueError:
-                pass
     fixed_cve_ids: set[str | None] = set()
     if cve_ids is not None:
         for cve_id in cve_ids:
@@ -177,7 +170,8 @@ def search_topics(
         offset=offset,
         limit=limit,
         sort_key=sort_key,
-        cvss_v3_scores=None if cvss_v3_scores is None else list(fixed_cvss_v3_scores),
+        min_cvss_v3_score=min_cvss_v3_score,
+        max_cvss_v3_score=max_cvss_v3_score,
         title_words=None if title_words is None else list(fixed_title_words),
         abstract_words=None if abstract_words is None else list(fixed_abstract_words),
         tag_ids=None if tag_names is None else list(fixed_tag_ids),

--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -1050,22 +1050,27 @@ class TestSearchTopics:
             }
 
         @pytest.mark.parametrize(
-            "search_words, expected",
+            "min_cvss_v3_score, max_cvss_v3_score, expected",
             [
-                (None, {1, 2, 3, 4}),
-                ([-0.1], set()),  # wrong params are just ignored
-                ([10], {1}),
-                ([8], {2}),
-                ([3], {3}),
-                ([10.1], set()),  # wrong params are just ignored
-                (["xxx"], "422: Unprocessable Entity:"),  # not integer
-                ([10, 8], {1, 2}),
-                ([""], "422: Unprocessable Entity:"),  # reserved keyword does not make sense
-                ([10, 5], {1}),  # wrong params are just ignored
+                (None, None, {1, 2, 3, 4}),
+                (0, 10, {1, 2, 3}),
+                (-1, 11, {1, 2, 3}),
+                (10, 0, set()),  # wrong params are just ignored
+                (10, None, {1}),
+                (None, 3, {3}),
+                (8, 8, {2}),
+                (8, 10, {1, 2}),
+                (["xxx"], None, "422: Unprocessable Entity:"),  # not float
+                (None, ["xxx"], "422: Unprocessable Entity:"),  # not float
+                ("", None, "422: Unprocessable Entity:"),  # reserved keyword does not make sense
             ],
         )
-        def test_search_by_cvss_v3_score(self, search_words, expected):
-            search_params = {} if search_words is None else {"cvss_v3_scores": search_words}
+        def test_search_by_cvss_v3_score(self, min_cvss_v3_score, max_cvss_v3_score, expected):
+            search_params = {}
+            if min_cvss_v3_score is not None:
+                search_params["min_cvss_v3_score"] = min_cvss_v3_score
+            if max_cvss_v3_score is not None:
+                search_params["max_cvss_v3_score"] = max_cvss_v3_score
             self.try_search_topics(USER1, self.topics, search_params, expected)
 
     class TestSearchByTitle(Common_):


### PR DESCRIPTION
## PR の目的
- [Get /topics/search]APIのクエリパラメタを変更にmax_cvss_v3_score、min_cvss_v3_scoreを追加
  - cvss_v3_scoresを削除
  - max_cvss_v3_score、min_cvss_v3_scoreを追加
    - max_cvss_v3_score、min_cvss_v3_scoreは省略可能。どちらか片方のみの指定も可能
    - max_cvss_v3_scoreを指定した場合、cvss_v3_scoreが指定値以下のレコードを取得。未設定は取得しない
    - min_cvss_v3_scoreを指定した場合、cvss_v3_scoreが指定値以上のレコードを取得。未設定は取得しない

## 経緯・意図・意思決定
[Get /topics/search] APIの検索条件にcvss_v3_scores: list[float]を追加したが、float型0～10のcvss_v3_scoreに対して条件範囲を指定できないのは使い勝手が悪い。
そのため、範囲指定できるよう仕様改善する。
