### PR TITLE
delete threat_impact from cveid test

### DIFF
--- a/api/app/tests/medium/routers/test_topics.py
+++ b/api/app/tests/medium/routers/test_topics.py
@@ -388,7 +388,6 @@ def test_update_topic__invalid_cve_format():
     request = {
         "title": "topic one dash",
         "abstract": "abstract one dash",
-        "threat_impact": 2,
         "tags": [tag1.tag_name],
         "misp_tags": ["tlp:white"],
         "exploitation": "public_poc",


### PR DESCRIPTION
## PR の目的
- cve_idのテストからthreat_impactを削除する

## 経緯・意図・意思決定
threat_impactの削除と平行して実施したcve_idのテストにおいて、threat_impactが残っていた。