### PR TITLE
change to set CVE_ID in trivydb2tc.py

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -568,6 +568,7 @@ def main() -> None:
             ]
 
             CVE_PATTERN = r"^CVE-\d{4}-\d{4,}$"
+            cve_id = vuln_id if re.match(CVE_PATTERN, vuln_id) else None
             topics[topic_id] = {
                 "title": title,
                 "abstract": abstract,
@@ -575,7 +576,7 @@ def main() -> None:
                 "misp_tags": misp_tags,
                 "actions": actions,
                 "cvss_v3_score": cvss_v3_score,
-                "cve_id": vuln_id if re.match(CVE_PATTERN, vuln_id) else None,
+                "cve_id": cve_id,
             }
 
     tc_client = ThreatconnectomeClient(


### PR DESCRIPTION
## PR の目的
- trivydb2tc.pyのtopicsにCVE_IDを設定するように変更（動作検証済み）
   - CVE_PATTERNとフォーマットが一致しない場合はNoneを登録

## 経緯・意図・意思決定
- misp_tagに含まれる値において、CVE_IDを直接Topicに含めたいため
