### PR TITLE
Topic/UI error boundary

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^18.2.0",
         "react-cookie": "^7.2.1",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^5.0.0",
         "react-icons": "^5.0.1",
         "react-infinite-scroller": "^1.2.6",
         "react-native-uuid": "^2.0.1",
@@ -18374,6 +18375,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-error-overlay": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-cookie": "^7.2.1",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^5.0.0",
     "react-icons": "^5.0.1",
     "react-infinite-scroller": "^1.2.6",
     "react-native-uuid": "^2.0.1",

--- a/web/src/components/TcError.js
+++ b/web/src/components/TcError.js
@@ -1,6 +1,5 @@
 export class TcError extends Error {
   constructor(message, customProps) {
-    console.log(message, customProps);
     super(message);
     this.api = customProps.api;
   }

--- a/web/src/components/TcError.js
+++ b/web/src/components/TcError.js
@@ -1,0 +1,7 @@
+export class TcError extends Error {
+  constructor(message, customProps) {
+    console.log(message, customProps);
+    super(message);
+    this.api = customProps.api;
+  }
+}

--- a/web/src/pages/App/AppFallback.jsx
+++ b/web/src/pages/App/AppFallback.jsx
@@ -1,0 +1,18 @@
+import { Box, Typography } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { TcError } from "../../components/TcError";
+
+export function AppFallback({ error }) {
+  console.log(error);
+  return (
+    <Box>
+      <Typography>Error occurred: {error.message}</Typography>
+      {error instanceof TcError && <Typography>called API: {error.api || "unknown"}</Typography>}
+    </Box>
+  );
+}
+AppFallback.propTypes = {
+  error: PropTypes.object.isRequired,
+};

--- a/web/src/pages/App/AppFallback.jsx
+++ b/web/src/pages/App/AppFallback.jsx
@@ -2,14 +2,14 @@ import { Box, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { TcError } from "../../components/TcError";
+import { APIError } from "../../utils/APIError";
 
 export function AppFallback({ error }) {
   console.log(error);
   return (
     <Box>
       <Typography>Error occurred: {error.message}</Typography>
-      {error instanceof TcError && <Typography>called API: {error.api || "unknown"}</Typography>}
+      {error instanceof APIError && <Typography>called API: {error.api || "unknown"}</Typography>}
     </Box>
   );
 }

--- a/web/src/pages/App/AppPage.jsx
+++ b/web/src/pages/App/AppPage.jsx
@@ -2,6 +2,7 @@ import { Box } from "@mui/material";
 import { useSnackbar } from "notistack";
 import React, { useEffect } from "react";
 import { useCookies } from "react-cookie";
+import { ErrorBoundary } from "react-error-boundary";
 import { useDispatch, useSelector } from "react-redux";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
@@ -14,6 +15,7 @@ import { errorToString } from "../../utils/func";
 import { authCookieName } from "../Login/LoginPage";
 
 import { AppBar } from "./AppBar";
+import { AppFallback } from "./AppFallback";
 import { Drawer } from "./Drawer";
 import { Main } from "./Main";
 
@@ -96,7 +98,9 @@ export function App() {
       <Main open={system.drawerOpen}>
         <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" m={1}>
           <Box display="flex" flexDirection="column" flexGrow={1} maxWidth={mainMaxWidth}>
-            <Outlet />
+            <ErrorBoundary FallbackComponent={AppFallback}>
+              <Outlet />
+            </ErrorBoundary>
           </Box>
         </Box>
       </Main>

--- a/web/src/pages/Status/PTeamStatusCardFallback.jsx
+++ b/web/src/pages/Status/PTeamStatusCardFallback.jsx
@@ -3,7 +3,7 @@ import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { TcError } from "../../components/TcError";
+import { APIError } from "../../utils/APIError";
 
 export function PTeamStatusCardFallback({ error }) {
   console.log(error);
@@ -18,7 +18,7 @@ export function PTeamStatusCardFallback({ error }) {
       <TableCell colSpan={1000}>
         <Box>
           <Typography>Error occurred at PTeamStatusCard: {error.message}</Typography>
-          {error instanceof TcError && (
+          {error instanceof APIError && (
             <Typography>called API: {error.api || "unknown"}</Typography>
           )}
         </Box>

--- a/web/src/pages/Status/PTeamStatusCardFallback.jsx
+++ b/web/src/pages/Status/PTeamStatusCardFallback.jsx
@@ -6,7 +6,7 @@ import React from "react";
 import { TcError } from "../../components/TcError";
 
 export function PTeamStatusCardFallback({ error }) {
-  //console.log(error);
+  console.log(error);
   return (
     <TableRow
       sx={{

--- a/web/src/pages/Status/PTeamStatusCardFallback.jsx
+++ b/web/src/pages/Status/PTeamStatusCardFallback.jsx
@@ -1,0 +1,31 @@
+import { Box, TableCell, TableRow, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React from "react";
+
+import { TcError } from "../../components/TcError";
+
+export function PTeamStatusCardFallback({ error }) {
+  //console.log(error);
+  return (
+    <TableRow
+      sx={{
+        cursor: "pointer",
+        "&:last-child td, &:last-child th": { border: 0 },
+        "&:hover": { bgcolor: grey[100] },
+      }}
+    >
+      <TableCell colSpan={1000}>
+        <Box>
+          <Typography>Error occurred at PTeamStatusCard: {error.message}</Typography>
+          {error instanceof TcError && (
+            <Typography>called API: {error.api || "unknown"}</Typography>
+          )}
+        </Box>
+      </TableCell>
+    </TableRow>
+  );
+}
+PTeamStatusCardFallback.propTypes = {
+  error: PropTypes.object.isRequired,
+};

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -27,6 +27,7 @@ import {
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { useLocation, useNavigate } from "react-router";
 
 import { Android12Switch } from "../../components/Android12Switch";
@@ -45,6 +46,7 @@ import { PTeamServiceDetails } from "./PTeamServiceDetails";
 import { PTeamServiceTabs } from "./PTeamServiceTabs";
 import { PTeamServicesListModal } from "./PTeamServicesListModal";
 import { PTeamStatusCard } from "./PTeamStatusCard";
+import { PTeamStatusCardFallback } from "./PTeamStatusCardFallback";
 import { SBOMDropArea } from "./SBOMDropArea";
 
 const ssvcPriorityCountMax = 99999;
@@ -481,26 +483,30 @@ export function Status() {
               {isActiveAllServicesMode ? (
                 <>
                   {targetTags.map((tag) => (
-                    <PTeamStatusCard
-                      key={tag.tag_id}
-                      onHandleClick={() =>
-                        handleNavigateServiceList(tag.tag_id, tag.tag_name, tag.service_ids)
-                      }
-                      pteam={pteam}
-                      tag={tag}
-                      serviceIds={tag.service_ids}
-                    />
+                    <ErrorBoundary key={tag.tag_id} FallbackComponent={PTeamStatusCardFallback}>
+                      <PTeamStatusCard
+                        key={tag.tag_id}
+                        onHandleClick={() =>
+                          handleNavigateServiceList(tag.tag_id, tag.tag_name, tag.service_ids)
+                        }
+                        pteam={pteam}
+                        tag={tag}
+                        serviceIds={tag.service_ids}
+                      />
+                    </ErrorBoundary>
                   ))}
                 </>
               ) : (
                 <>
                   {targetTags.map((tag) => (
-                    <PTeamStatusCard
-                      key={tag.tag_id}
-                      onHandleClick={() => handleNavigateTag(tag.tag_id)}
-                      pteam={pteam}
-                      tag={tag}
-                    />
+                    <ErrorBoundary key={tag.tag_id} FallbackComponent={PTeamStatusCardFallback}>
+                      <PTeamStatusCard
+                        key={tag.tag_id}
+                        onHandleClick={() => handleNavigateTag(tag.tag_id)}
+                        pteam={pteam}
+                        tag={tag}
+                      />
+                    </ErrorBoundary>
                   ))}
                 </>
               )}

--- a/web/src/pages/Tag/TopicCard.jsx
+++ b/web/src/pages/Tag/TopicCard.jsx
@@ -17,6 +17,7 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
+import { TcError } from "../../components/TcError";
 import { UUIDTypography } from "../../components/UUIDTypography";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import {
@@ -85,17 +86,19 @@ export function TopicCard(props) {
 
   if (skipByAuth || skipByPTeamId || skipByTopicId || skipByServiceId || skipBytagId) return <></>;
   if (pteamTopicActionsError)
-    return <>{`Cannot get topicActions: ${errorToString(pteamTopicActionsError)}`}</>;
+    throw new TcError(errorToString(pteamTopicActionsError), { api: "getPTeamTopicActions" });
   if (pteamTopicActionsIsLoading) return <>Now loading topicActions...</>;
   if (ticketsRelatedToServiceTopicTagError)
-    return <>{`Cannot get tcikets: ${errorToString(ticketsRelatedToServiceTopicTagError)}`}</>;
+    throw new TcError(errorToString(ticketsRelatedToServiceTopicTagError), {
+      api: "getTicketsRelatedToServiceTopicTag",
+    });
   if (ticketsRelatedToServiceTopicTagIsLoading) return <>Now loading tickets...</>;
-  if (topicError) return <>{`Cannot get Topic: ${errorToString(topicError)}`}</>;
+  if (topicError) throw new TcError(errorToString(topicError), { api: "getTopic" });
   if (topicIsLoading) return <>Now loading Topic...</>;
-  if (allTagsError) return <>{`Cannot get allTags: ${errorToString(allTagsError)}`}</>;
+  if (allTagsError) throw new TcError(errorToString(allTagsError), { api: "getAllTags" });
   if (allTagsIsLoading) return <>Now loading allTags...</>;
   if (serviceDependenciesError)
-    return <>{`Cannot get serviceDependencies: ${errorToString(serviceDependenciesError)}`}</>;
+    throw new TcError(errorToString(serviceDependenciesError), { api: "getServiceDependencies" });
   if (serviceDependenciesIsLoading) return <>Now loading serviceDependencies...</>;
   if (!pteamId || !serviceId || !members || !tagId) {
     return <>Now Loading...</>;

--- a/web/src/pages/Tag/TopicCard.jsx
+++ b/web/src/pages/Tag/TopicCard.jsx
@@ -17,7 +17,6 @@ import PropTypes from "prop-types";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
-import { TcError } from "../../components/TcError";
 import { UUIDTypography } from "../../components/UUIDTypography";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import {
@@ -27,6 +26,7 @@ import {
   useGetTopicQuery,
   useGetDependenciesQuery,
 } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { dateTimeFormat, errorToString } from "../../utils/func";
 import { parseVulnerableVersions, versionMatch } from "../../utils/versions";
 
@@ -86,19 +86,19 @@ export function TopicCard(props) {
 
   if (skipByAuth || skipByPTeamId || skipByTopicId || skipByServiceId || skipBytagId) return <></>;
   if (pteamTopicActionsError)
-    throw new TcError(errorToString(pteamTopicActionsError), { api: "getPTeamTopicActions" });
+    throw new APIError(errorToString(pteamTopicActionsError), { api: "getPTeamTopicActions" });
   if (pteamTopicActionsIsLoading) return <>Now loading topicActions...</>;
   if (ticketsRelatedToServiceTopicTagError)
-    throw new TcError(errorToString(ticketsRelatedToServiceTopicTagError), {
+    throw new APIError(errorToString(ticketsRelatedToServiceTopicTagError), {
       api: "getTicketsRelatedToServiceTopicTag",
     });
   if (ticketsRelatedToServiceTopicTagIsLoading) return <>Now loading tickets...</>;
-  if (topicError) throw new TcError(errorToString(topicError), { api: "getTopic" });
+  if (topicError) throw new APIError(errorToString(topicError), { api: "getTopic" });
   if (topicIsLoading) return <>Now loading Topic...</>;
-  if (allTagsError) throw new TcError(errorToString(allTagsError), { api: "getAllTags" });
+  if (allTagsError) throw new APIError(errorToString(allTagsError), { api: "getAllTags" });
   if (allTagsIsLoading) return <>Now loading allTags...</>;
   if (serviceDependenciesError)
-    throw new TcError(errorToString(serviceDependenciesError), { api: "getServiceDependencies" });
+    throw new APIError(errorToString(serviceDependenciesError), { api: "getServiceDependencies" });
   if (serviceDependenciesIsLoading) return <>Now loading serviceDependencies...</>;
   if (!pteamId || !serviceId || !members || !tagId) {
     return <>Now Loading...</>;

--- a/web/src/utils/APIError.js
+++ b/web/src/utils/APIError.js
@@ -1,4 +1,4 @@
-export class TcError extends Error {
+export class APIError extends Error {
   constructor(message, customProps) {
     super(message);
     this.api = customProps.api;


### PR DESCRIPTION
## PR の目的

- ErrorBoundary を利用したエラー処理の実装（使用しているのは、まだ極一部のみ）
  - パッケージ react-error-boundary を追加

- 動作確認用の無理やりエラーを発生させるパッチ （PR には含まない）
[force_error.patch](https://github.com/user-attachments/files/18235079/force_error.patch)
  - Status ページ
    - tagId 末尾が a-f の場合は通常例外 `Error("some unexpected error!")`
    - tagId 末尾が 0-4 の場合は拡張例外 `APIError("404: No such pteam", {api: "getPTeamServiceTagSummary"}`
  - Tag ページ
    - topicId 末尾が a-f の場合、tagId を 000...000 に強制上書き（no such tag を誘発）
 
- PTeamStatusCardFallback が動作した場合
  - リスト表示を破損しないように、リストアイテムに合わせたコンポーネント形式で出力
  - 受け取った例外のクラスに応じて表示を切り替え（コード上の明示的な例外 or 意図しない例外）
![{F14C87BD-D508-439C-A6EC-4D367D7B4FD6}](https://github.com/user-attachments/assets/a5f5d59f-5431-4c11-b3d3-a6e37b7e35a5)
 
- AppFallback が動作した場合
  - Drawer と TeamSelector は通常表示
  - ただし、現状ではブラウザをリロードしないと Drawer 等は動作しない（エラー表示が消えない）
![{9FA2A674-7313-4E41-B622-35A5A264D7A0}](https://github.com/user-attachments/assets/fe802aa5-d6da-4e29-9237-8041a9a9e514)

- エラー発生時に収集・表示すべき内容については要検討
- APIError.js の置き場所も調整の余地あり
