### PR TITLE
output purl by collect_threats_data

### DIFF
--- a/scripts/collect_threats_data.py
+++ b/scripts/collect_threats_data.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import sys
+import urllib.parse
 from functools import partial
 from time import sleep
 from typing import Callable
@@ -168,10 +169,6 @@ def get_threats_data(tc_client: ThreatconnectomeClient, service_id: str) -> list
     return threats
 
 
-def encode_purl_type(type: str) -> str:
-    return type.replace("@", "%40")
-
-
 def generate_purl(tag_name: str, tag_version: str) -> str:
 
     # tag_name syntax
@@ -182,9 +179,12 @@ def generate_purl(tag_name: str, tag_version: str) -> str:
         return ""
     pkg_name = splited_tag_name[0]
     pkg_info = splited_tag_name[1]
-    type = encode_purl_type(pkg_info)
+    # The type must NOT be percent-encoded
+    type = pkg_info
+    name = urllib.parse.quote(pkg_name)
+    version = urllib.parse.quote(tag_version)
 
-    return f"pkg:{type}/{pkg_name}@{tag_version}"
+    return f"pkg:{type}/{name}@{version}"
 
 
 def add_tag_data_to_threat(


### PR DESCRIPTION
## PR の目的
- collect_threats_data.py　が追加でpurlを出力する
  - 出力箇所は"threats"の値(配列)の各要素の先頭"purl"
- purlの構築方法
  - purlの要素「scheme:type/namespace/name@version?qualifiers#subpath」
    - scheme: 固定値 "pkg"
    - type: Tagテーブルtag_nameの{pkg_info} ※1 ※2
    - namespace: 常に省略 ※3
    - name: Tagテーブルtag_nameの{pkg_name} ※1
    - version: Dependencyテーブルversion列
    - qualifiers: 常に省略
    - subpath: 常に省略
  - ※1 Tagテーブルtag_name列が持つ情報
"{pkg_name}:{pkg_info}:{pkg_mgr}"
  - ※2 エンコード
name、versionはパーセントエンコードする。(例)「@」→「%40」
typeはパーセントエンコードしない
  - ※3 namespaceの省略について
npmのpurl  `pkg:npm/%40babel/helper-module-import`
において、scope (= @babel の部分) をnamespaceとして扱うことが規定されている。
これに対するtag_nameは `@babel/helper-module-imports:npm:npm`
であり、{pkg_name}は `@babel/helper-module-imports`、と「/」を含む。
よって、{pkg_name}をpurlのnameに指定し、namespaceを省略することで、結果的にnamespace/name という構造になる。

## 経緯・意図・意思決定
- purlのtypeに指定できる文言は決まっている ※3
  - trivydb2tc.pyでtrivydbから情報取得する際、lang_familiesによって文言変換するケースがあるが、これによりtypeに指定できない文言になっていないか、確認必要
    - 確認した結果、問題なし

## 参考文献
- purlの要素
  - scheme:type/namespace/name@version?qualifiers#subpath
https://github.com/package-url/purl-spec
- ※3 purlのtypeに指定できる文言
https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst