### PR TITLE
Add exception handling for when the processing of resp.json() fails in _resp_to_msg.

### DIFF
--- a/scripts/collect_threats_data.py
+++ b/scripts/collect_threats_data.py
@@ -71,8 +71,11 @@ class ThreatconnectomeClient:
         _func = partial(func, *args, **{k: v for k, v in kwargs.items() if k != "headers"})
 
         def _resp_to_msg(resp: requests.Response) -> str:
-            data = resp.json()
-            return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            try:
+                data = resp.json()
+                return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            except ValueError:
+                return f"{resp.status_code}: {resp.reason}: {resp.text}"
 
         while True:
             try:

--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -230,8 +230,11 @@ class ThreatconnectomeClient:
         _func = partial(func, *args, **{k: v for k, v in kwargs.items() if k != "headers"})
 
         def _resp_to_msg(resp: requests.Response) -> str:
-            data = resp.json()
-            return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            try:
+                data = resp.json()
+                return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            except ValueError:
+                return f"{resp.status_code}: {resp.reason}: {resp.text}"
 
         while True:
             try:

--- a/scripts/vulnrichment2tc.py
+++ b/scripts/vulnrichment2tc.py
@@ -72,8 +72,11 @@ class ThreatconnectomeClient:
         _func = partial(func, *args, **{k: v for k, v in kwargs.items() if k != "headers"})
 
         def _resp_to_msg(resp: requests.Response) -> str:
-            data = resp.json()
-            return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            try:
+                data = resp.json()
+                return f"{resp.status_code}: {resp.reason}: {data.get('detail')}"
+            except ValueError:
+                return f"{resp.status_code}: {resp.reason}: {resp.text}"
 
         while True:
             try:


### PR DESCRIPTION
## PR の目的
- scripts/trivydb2tc.pyの_resp_to_msg関数におけるresp.json()の例外発生時の処理を追加（検証済み）
   - ValueErrorが発生した際にresp.textでエラー情報を出力するように修正
- scripts/vulnrichment2tc.py、collect_threats_data.pyにおいて、上記trivydb2tc.pyと同様に修正

## 経緯・意図・意思決定
- trivydb2tcにおいて、get_topicsでresp.json()で例外発生
   - リトライ3回失敗した際にエラーメッセージを出力しようとした結果、レスポンスがjson形式でなかったため
- 修正していないスクリプトでも同様のコードがありそうだが、今回は重要なスクリプトに絞って対応した