### PR TITLE
bugfix/spelling mistake in PTeamMember

### DIFF
--- a/web/src/pages/PTeam/PTeamAuthEditor.jsx
+++ b/web/src/pages/PTeam/PTeamAuthEditor.jsx
@@ -45,7 +45,7 @@ export function PTeamAuthEditor(props) {
 
     const data = { is_admin: checked };
 
-    await updatePTeamMember({ pteamId, memberUserId, data })
+    await updatePTeamMember({ pteamId, userId: memberUserId, data })
       .unwrap()
       .then((success) => onSuccess(success))
       .catch((error) => onError(error));

--- a/web/src/pages/PTeam/PTeamMember.jsx
+++ b/web/src/pages/PTeam/PTeamMember.jsx
@@ -76,7 +76,7 @@ export function PTeamMember(props) {
                       <TableCell align="right">
                         <PTeamMemberMenu
                           pteamId={pteamId}
-                          membaerUserId={member.user_id}
+                          memberUserId={member.user_id}
                           userEmail={member.email}
                           isCurrentMemberAdmin={checkAdmin(member, pteamId)}
                         />

--- a/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
+++ b/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
@@ -31,7 +31,7 @@ export function PTeamMemberRemoveModal(props) {
     function onError(error) {
       enqueueSnackbar(`Remove member failed: ${errorToString(error)}`, { variant: "error" });
     }
-    await deletePTeamMember({ pteamId, memberUserId })
+    await deletePTeamMember({ pteamId, userId: memberUserId })
       .unwrap()
       .then((success) => onSuccess(success))
       .catch((error) => onError(error));


### PR DESCRIPTION
## PR の目的
- PTeamMember.jsxにあるmemberUserIdのスペルを間違えていたため修正しました
- userIdをmemberUserIdに名前を変更したことに伴い、分割代入の部分を修正しました

## 経緯・意図・意思決定
- スペルを間違えていたため、下位のコンポーネントに値を正しく渡すことができていませんでした。
- updatePTeamMember, deletePTeamMemberに渡す値を分割代入するように修正しました

