### PR TITLE
topic/change PTeam to Team

### DIFF
--- a/api/app/notification/alert.py
+++ b/api/app/notification/alert.py
@@ -72,7 +72,7 @@ def create_mail_alert_for_new_topic(
             f"Title: {topic_title}",
             f"SSVC Priority: {ssvc_priority_label}",
             "",
-            f"PTeam: {pteam_name}",
+            f"Team: {pteam_name}",
             f"Services: {', '.join(services)}",
             f"Artifact: {tag_name}",
             "",

--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -37,7 +37,7 @@ export function PTeamGeneralSetting(props) {
     <Box>
       <Box mb={4}>
         <Typography sx={{ fontWeight: 900 }} mb={1}>
-          PTeam name
+          Team name
         </Typography>
         <TextField
           size="small"

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -35,8 +35,8 @@ export function PTeamSettingsModal(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
 
   const handleClose = () => onSetShow(false);
 
@@ -47,7 +47,7 @@ export function PTeamSettingsModal(props) {
       <DialogTitle>
         <Box alignItems="center" display="flex" flexDirection="row">
           <Typography flexGrow={1} className={dialogStyle.dialog_title}>
-            PTeam settings
+            Team settings
           </Typography>
           <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
             <CloseIcon />

--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
@@ -48,9 +48,9 @@ export function AcceptPTeamInvitation() {
 
   return (
     <>
-      <Typography variant="h6">Do you accept the invitation to the pteam below?</Typography>
-      <Typography>PTeam Name: {detail.pteam_name}</Typography>
-      <Typography>PTeam ID: {detail.pteam_id}</Typography>
+      <Typography variant="h6">Do you accept the invitation to the team below?</Typography>
+      <Typography>Team Name: {detail.pteam_name}</Typography>
+      <Typography>Team ID: {detail.pteam_id}</Typography>
       <Typography>
         Invitation created by {detail.email} ({detail.user_id})
       </Typography>

--- a/web/src/pages/Account/AccountPage.jsx
+++ b/web/src/pages/Account/AccountPage.jsx
@@ -109,7 +109,7 @@ export function Account() {
         </Box>
         <Box alignItems="center" display="flex" flexDirection="row" my={1}>
           <Box display="flex" flexDirection="row" width="30%">
-            <Typography>PTeam:</Typography>
+            <Typography>Team:</Typography>
           </Box>
           <Box display="flex" flexDirection="column" width="70%">
             {userMe.pteam_roles?.length >= 1 ? (

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -101,7 +101,7 @@ export function Drawer() {
             <StyledListItemIcon>
               <GroupsIcon />
             </StyledListItemIcon>
-            <ListItemText>PTeam</ListItemText>
+            <ListItemText>Team</ListItemText>
           </StyledListItemButton>
         </>
         {/* Topics */}

--- a/web/src/pages/App/PTeamCreateModal.jsx
+++ b/web/src/pages/App/PTeamCreateModal.jsx
@@ -64,7 +64,7 @@ export function PTeamCreateModal(props) {
       <Dialog fullWidth open={open} onClose={() => onSetOpen(false)}>
         <DialogTitle>
           <Box display="flex" flexDirection="row">
-            <Typography className={dialogStyle.dialog_title}>Create PTeam</Typography>
+            <Typography className={dialogStyle.dialog_title}>Create Team</Typography>
             <Box flexGrow={1} />
             <IconButton onClick={() => onSetOpen(false)}>
               <CloseIcon />
@@ -74,7 +74,7 @@ export function PTeamCreateModal(props) {
         <DialogContent>
           <Box display="flex" flexDirection="column">
             <TextField
-              label="PTeam name"
+              label="Team name"
               onChange={(event) => setPTeamName(event.target.value)}
               required
               error={!pteamName}

--- a/web/src/pages/App/TeamSelector.jsx
+++ b/web/src/pages/App/TeamSelector.jsx
@@ -1,5 +1,5 @@
 import { Add as AddIcon, KeyboardArrowDown as KeyboardArrowDownIcon } from "@mui/icons-material";
-import { Box, Button, ListSubheader, Menu, MenuItem } from "@mui/material";
+import { Box, Button, Menu, MenuItem } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import React, { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -93,7 +93,6 @@ export function TeamSelector() {
           open={open}
           onClose={handleClose}
         >
-          <ListSubheader sx={{ color: drawerParams.hoverColor }}>Product Team</ListSubheader>
           {userMe?.pteam_roles &&
             [...userMe.pteam_roles]
               .sort((a, b) => a.pteam.pteam_name.localeCompare(b.pteam.pteam_name)) // alphabetically
@@ -108,7 +107,7 @@ export function TeamSelector() {
               ))}
           <MenuItem onClick={() => setOpenPTeamCreationModal(true)}>
             <AddIcon fontSize="small" />
-            Create PTeam
+            Create Team
           </MenuItem>
         </Menu>
         <PTeamCreateModal

--- a/web/src/pages/PTeam/PTeamMemberMenu.jsx
+++ b/web/src/pages/PTeam/PTeamMemberMenu.jsx
@@ -37,8 +37,8 @@ export function PTeamMemberMenu(props) {
   if (skip) return <></>;
   if (userMeError) return <>{`Cannot get userInfo: ${errorToString(userMeError)}`}</>;
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
 
   const handleClick = (event) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
@@ -80,7 +80,7 @@ export function PTeamMemberMenu(props) {
         {(isCurrentUserAdmin || memberUserId === userMe.user_id) && (
           <MenuItem onClick={handleRemoveMember}>
             <PersonOffIcon sx={{ mr: 1 }} />
-            Remove from PTeam
+            Remove from Team
           </MenuItem>
         )}
       </Menu>

--- a/web/src/pages/PTeam/PTeamPage.jsx
+++ b/web/src/pages/PTeam/PTeamPage.jsx
@@ -29,7 +29,7 @@ export function PTeam() {
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (skip) return <></>;
 
-  if (membersError) return <>{`Cannot get PTeam: ${errorToString(membersError)}`}</>;
+  if (membersError) return <>{`Cannot get Team: ${errorToString(membersError)}`}</>;
   if (membersIsLoading) return <>Now loading Members...</>;
 
   const filterModes = ["All", "PTeam"];

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -39,8 +39,8 @@ export function PTeamServiceDelete(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
 
   const services = pteam.services;
 

--- a/web/src/pages/Status/PTeamServicesListModal.jsx
+++ b/web/src/pages/Status/PTeamServicesListModal.jsx
@@ -91,8 +91,8 @@ export function PTeamServicesListModal(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
 
   const targetServices = pteam.services
     .filter((service) => serviceIds.includes(service.service_id))

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -185,8 +185,8 @@ export function Status() {
 
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (skipByAuth || !pteamId) return <></>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
 
   if (isActiveAllServicesMode) {
     if (pteamTagsSummaryError)

--- a/web/src/pages/Tag/TagPage.jsx
+++ b/web/src/pages/Tag/TagPage.jsx
@@ -63,8 +63,8 @@ export function Tag() {
   if (!getTopicIdsReady) return <></>;
   if (allTagsError) return <>{`Cannot get allTags: ${errorToString(allTagsError)}`}</>;
   if (allTagsIsLoading) return <>Now loading allTags...</>;
-  if (pteamError) return <>{`Cannot get PTeam: ${errorToString(pteamError)}`}</>;
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
+  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamIsLoading) return <>Now loading Team...</>;
   if (serviceDependenciesError)
     return <>{`Cannot get serviceDependencies: ${errorToString(serviceDependenciesError)}`}</>;
   if (serviceDependenciesIsLoading) return <>Now loading serviceDependencies...</>;


### PR DESCRIPTION
## PR の目的
- UI上で PTeam と表記されている部分を Team に変更しました

## 経緯・意図・意思決定
### 変更箇所
- 左のメニューバーにあるPTeam
- Team Selectorの Product Team の表記を削除
- PTeam settingsをTeam settingsに変更
- PTeam settingsのGENERALにあるPTeam Name
- CreatePTeamModalにあるPTeam
- AcceptPTeamInvitationPage.jxsにあるPTeam
- AccountページにあるPTeam
- PTeamMemberMenu.jsxにあるRemove from PTeam
- エラー文にあるPTeam
  - PTeamSettingsModal.jsx
  - PTeamMemberMenu.jsx
  - PTeamServiceDelete.jsx
  - PTeamServicesListModal.jsx
  - Status.jsx
  - Tag.jsx
  - PTeam.jsx 
- slack、メールのメッセージの修正
  - メールへの通知部分でPTeamを使用していたので、Teamに変更しました(api/app/notification/alert.py)
  - slackへの通知でPTeamの文言は使用していませんでした
- PTeam画面のフィルター内にあるPTeamについては別PRで削除予定