### PR TITLE
Topic/search for topics using cvss

### DIFF
--- a/web/src/pages/TopicDetail/TopicDetailPage.jsx
+++ b/web/src/pages/TopicDetail/TopicDetailPage.jsx
@@ -23,7 +23,7 @@ import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetTopicActionsQuery, useGetTopicQuery } from "../../services/tcApi";
 import { cvssProps } from "../../utils/const";
-import { errorToString, cvssSeverityRating } from "../../utils/func";
+import { errorToString, cvssConvertToName } from "../../utils/func";
 
 import { TopicSSVCCards } from "./TopicSSVCCards";
 
@@ -72,7 +72,7 @@ export function TopicDetail() {
   const cvssScore =
     topic.cvss_v3_score === undefined || topic.cvss_v3_score === null ? "N/A" : topic.cvss_v3_score;
 
-  const cvss = cvssSeverityRating(cvssScore);
+  const cvss = cvssConvertToName(cvssScore);
 
   return (
     <>

--- a/web/src/pages/TopicManagement/TopicManagementPage.jsx
+++ b/web/src/pages/TopicManagement/TopicManagementPage.jsx
@@ -38,7 +38,7 @@ import {
   useSearchTopicsQuery,
 } from "../../services/tcApi";
 import { cvssProps } from "../../utils/const";
-import { errorToString, cvssSeverityRating } from "../../utils/func";
+import { errorToString, cvssConvertToName } from "../../utils/func";
 
 import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 import { TopicSearchModal } from "./TopicSearchModal";
@@ -85,7 +85,7 @@ function TopicManagementTableRow(props) {
   const cvssScore =
     topic.cvss_v3_score === undefined || topic.cvss_v3_score === null ? "N/A" : topic.cvss_v3_score;
 
-  const cvss = cvssSeverityRating(cvssScore);
+  const cvss = cvssConvertToName(cvssScore);
 
   return (
     <TableRow
@@ -174,6 +174,11 @@ export function TopicManagement() {
     if (params?.creatorIds?.length > 0) query.creator_ids = params.creatorIds.split(delimiter);
     if (params?.updatedAfter) query.updated_after = params.updatedAfter;
     if (params?.updatedBefore) query.updated_before = params.updatedBefore;
+    if (params?.minCvssV3Score || params?.minCvssV3Score === 0)
+      query.min_cvss_v3_score = params.minCvssV3Score;
+    if (params?.maxCvssV3Score || params?.maxCvssV3Score === 0)
+      query.max_cvss_v3_score = params.maxCvssV3Score;
+
     return query;
   };
 

--- a/web/src/pages/TopicManagement/TopicSearchModal.jsx
+++ b/web/src/pages/TopicManagement/TopicSearchModal.jsx
@@ -129,7 +129,6 @@ export function TopicSearchModal(props) {
 
   const isValidCvssScore = (cvssScore) => {
     const regex = /^\d+(\.\d{1})?$/; // Regular expression to allow only numbers to one decimal place
-    console.log(0 <= cvssScore && cvssScore <= 10);
     return (regex.test(cvssScore) && 0 <= cvssScore && cvssScore <= 10) || cvssScore === "";
   };
 

--- a/web/src/pages/TopicManagement/TopicSearchModal.jsx
+++ b/web/src/pages/TopicManagement/TopicSearchModal.jsx
@@ -26,7 +26,7 @@ import React, { useState } from "react";
 
 import { Android12Switch } from "../../components/Android12Switch";
 import dialogStyle from "../../cssModule/dialog.module.css";
-import { cvssNames } from "../../utils/const";
+import { cvssRatings } from "../../utils/const";
 import { cvssConvertToScore } from "../../utils/func";
 
 export function TopicSearchModal(props) {
@@ -45,6 +45,7 @@ export function TopicSearchModal(props) {
   const [maxCvssScore, setMaxCvssScore] = useState("");
 
   const now = new Date();
+  const cvssRatingsKeys = Object.keys(cvssRatings);
 
   const advancedChange = (event) => {
     setAdModeChange(event.target.checked);
@@ -118,21 +119,21 @@ export function TopicSearchModal(props) {
 
   const handleMinCvssScore = (event) => {
     setCvssName("");
-    const inputValue = event.target.value;
-    const regex = /^\d*\.?\d{0,1}$/; // Regular expression to allow only numbers to one decimal place
-    if (regex.test(inputValue) && 0 <= inputValue && inputValue <= 10) {
-      setMinCvssScore(inputValue);
-    }
+    setMinCvssScore(event.target.value);
   };
 
   const handleMaxCvssScore = (event) => {
     setCvssName("");
-    const inputValue = event.target.value;
-    const regex = /^\d*\.?\d{0,1}$/; // Regular expression to allow only numbers to one decimal place
-    if (regex.test(inputValue) && 0 <= inputValue && inputValue <= 10) {
-      setMaxCvssScore(inputValue);
-    }
+    setMaxCvssScore(event.target.value);
   };
+
+  const isValidCvssScore = (cvssScore) => {
+    const regex = /^\d+(\.\d{1})?$/; // Regular expression to allow only numbers to one decimal place
+    console.log(0 <= cvssScore && cvssScore <= 10);
+    return (regex.test(cvssScore) && 0 <= cvssScore && cvssScore <= 10) || cvssScore === "";
+  };
+
+  const isValidUserInput = isValidCvssScore(minCvssScore) && isValidCvssScore(maxCvssScore);
 
   const titleForm = (
     <Grid container sx={{ margin: 1.5, width: "100%" }}>
@@ -182,9 +183,9 @@ export function TopicSearchModal(props) {
           sx={{ width: "95%" }}
           fullWidth
         >
-          {cvssNames.map((cvssName) => (
-            <ToggleButton key={cvssName} value={cvssName}>
-              {cvssName}
+          {cvssRatingsKeys.map((cvssRatingKey) => (
+            <ToggleButton key={cvssRatingKey} value={cvssRatingKey}>
+              {cvssRatingKey}
             </ToggleButton>
           ))}
         </ToggleButtonGroup>
@@ -342,7 +343,11 @@ export function TopicSearchModal(props) {
         </DialogContent>
         <DialogActions className={dialogStyle.action_area}>
           <Box display="flex">
-            <Button className={dialogStyle.submit_btn} onClick={handleSearch}>
+            <Button
+              className={dialogStyle.submit_btn}
+              onClick={handleSearch}
+              disabled={!isValidUserInput}
+            >
               Search
             </Button>
           </Box>

--- a/web/src/pages/TopicManagement/TopicSearchModal.jsx
+++ b/web/src/pages/TopicManagement/TopicSearchModal.jsx
@@ -6,9 +6,12 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   FormControlLabel,
   IconButton,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
   Grid,
   FormControl,
@@ -23,6 +26,8 @@ import React, { useState } from "react";
 
 import { Android12Switch } from "../../components/Android12Switch";
 import dialogStyle from "../../cssModule/dialog.module.css";
+import { cvssNames } from "../../utils/const";
+import { cvssConvertToScore } from "../../utils/func";
 
 export function TopicSearchModal(props) {
   const { show, onSearch, onCancel } = props;
@@ -35,6 +40,9 @@ export function TopicSearchModal(props) {
   const [updatedBefore, setUpdatedBefore] = useState(null); // Date object
   const [adModeChange, setAdModeChange] = useState(false);
   const [dateFormList, setDateFormList] = useState("");
+  const [cvssName, setCvssName] = useState("");
+  const [minCvssScore, setMinCvssScore] = useState("");
+  const [maxCvssScore, setMaxCvssScore] = useState("");
 
   const now = new Date();
 
@@ -56,6 +64,8 @@ export function TopicSearchModal(props) {
       creatorIds: creatorIds,
       updatedAfter: updatedAfter?.toISOString(),
       updatedBefore: updatedBefore?.toISOString(),
+      minCvssV3Score: minCvssScore,
+      maxCvssV3Score: maxCvssScore,
     };
     onSearch(params);
     clearAllParams();
@@ -67,6 +77,9 @@ export function TopicSearchModal(props) {
     setUpdatedAfter(null);
     setUpdatedBefore(null);
     setDateFormList("");
+    setCvssName("");
+    setMinCvssScore("");
+    setMaxCvssScore("");
   };
 
   const clearAllParams = () => {
@@ -94,6 +107,31 @@ export function TopicSearchModal(props) {
         break;
     }
     setDateFormList(event.target.value);
+  };
+
+  const handleCvssName = (event, newCvssName) => {
+    setCvssName(newCvssName);
+    const score = cvssConvertToScore(newCvssName);
+    setMinCvssScore(score[0]);
+    setMaxCvssScore(score[1]);
+  };
+
+  const handleMinCvssScore = (event) => {
+    setCvssName("");
+    const inputValue = event.target.value;
+    const regex = /^\d*\.?\d{0,1}$/; // Regular expression to allow only numbers to one decimal place
+    if (regex.test(inputValue) && 0 <= inputValue && inputValue <= 10) {
+      setMinCvssScore(inputValue);
+    }
+  };
+
+  const handleMaxCvssScore = (event) => {
+    setCvssName("");
+    const inputValue = event.target.value;
+    const regex = /^\d*\.?\d{0,1}$/; // Regular expression to allow only numbers to one decimal place
+    if (regex.test(inputValue) && 0 <= inputValue && inputValue <= 10) {
+      setMaxCvssScore(inputValue);
+    }
   };
 
   const titleForm = (
@@ -126,6 +164,49 @@ export function TopicSearchModal(props) {
           size="small"
           sx={{ width: "95%" }}
         />
+      </Grid>
+    </Grid>
+  );
+
+  const cvssForm = (
+    <Grid container sx={{ margin: 1.5 }} alignItems={"center"}>
+      <Grid item xs={2} md={2}>
+        <Typography sx={{ marginTop: "10px" }}>CVSS v3</Typography>
+      </Grid>
+      <Grid item xs={10} md={10}>
+        <ToggleButtonGroup
+          color="primary"
+          exclusive
+          value={cvssName}
+          onChange={handleCvssName}
+          sx={{ width: "95%" }}
+          fullWidth
+        >
+          {cvssNames.map((cvssName) => (
+            <ToggleButton key={cvssName} value={cvssName}>
+              {cvssName}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+        <Box display="flex" flexDirection="row" sx={{ mt: 2 }}>
+          <TextField
+            value={minCvssScore}
+            onChange={handleMinCvssScore}
+            variant="outlined"
+            size="small"
+            sx={{ width: "40%" }}
+          />
+          <Box display="flex" alignItems="center" justifyContent="center" sx={{ width: "15%" }}>
+            <Divider orientation="horizontal" sx={{ borderColor: "black", width: "20%" }} />
+          </Box>
+          <TextField
+            value={maxCvssScore}
+            onChange={handleMaxCvssScore}
+            variant="outlined"
+            size="small"
+            sx={{ width: "40%" }}
+          />
+        </Box>
       </Grid>
     </Grid>
   );
@@ -251,6 +332,7 @@ export function TopicSearchModal(props) {
             {mispForm}
             {adModeChange && (
               <Box>
+                {cvssForm}
                 {dateForm}
                 {uuidForm}
                 {creatorForm}

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -332,7 +332,13 @@ export const drawerParams = {
   hoverColor: brown[700],
 };
 
-export const cvssNames = ["None", "Low", "Medium", "High", "Critical"];
+export const cvssRatings = {
+  None: { min: 0.0, max: 0.0 },
+  Low: { min: 0.1, max: 3.9 },
+  Medium: { min: 4.0, max: 6.9 },
+  High: { min: 7.0, max: 8.9 },
+  Critical: { min: 9.0, max: 10.0 },
+};
 
 export const cvssProps = {
   None: {

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -332,6 +332,8 @@ export const drawerParams = {
   hoverColor: brown[700],
 };
 
+export const cvssNames = ["None", "Low", "Medium", "High", "Critical"];
+
 export const cvssProps = {
   None: {
     cvssBgcolor: grey[600],

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -120,7 +120,7 @@ export const compareSSVCPriority = (prio1, prio2) => {
   else return 1;
 };
 
-export const cvssSeverityRating = (cvssScore) => {
+export const cvssConvertToName = (cvssScore) => {
   let rating;
   if (0 < cvssScore && cvssScore < 4.0) {
     rating = "Low";
@@ -134,6 +134,29 @@ export const cvssSeverityRating = (cvssScore) => {
     rating = "None";
   }
   return rating;
+};
+
+export const cvssConvertToScore = (cvssName) => {
+  let minCvssScore;
+  let maxCvssScore;
+  if (cvssName === "None") {
+    minCvssScore = 0.0;
+    maxCvssScore = 0.0;
+  } else if (cvssName === "Low") {
+    minCvssScore = 0.1;
+    maxCvssScore = 3.9;
+  } else if (cvssName === "Medium") {
+    minCvssScore = 4.0;
+    maxCvssScore = 6.9;
+  } else if (cvssName === "High") {
+    minCvssScore = 7.0;
+    maxCvssScore = 8.9;
+  } else if (cvssName === "Critical") {
+    minCvssScore = 9.0;
+    maxCvssScore = 10.0;
+  }
+
+  return [minCvssScore, maxCvssScore];
 };
 
 export const checkAdmin = (member, pteamId) => {

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -1,5 +1,7 @@
 import { addMinutes, format } from "date-fns";
 
+import { cvssRatings } from "./const";
+
 export const a11yProps = (index) => ({
   id: `tab-${index}`,
   "aria-controls": `tabpanel-${index}`,
@@ -137,26 +139,11 @@ export const cvssConvertToName = (cvssScore) => {
 };
 
 export const cvssConvertToScore = (cvssName) => {
-  let minCvssScore;
-  let maxCvssScore;
-  if (cvssName === "None") {
-    minCvssScore = 0.0;
-    maxCvssScore = 0.0;
-  } else if (cvssName === "Low") {
-    minCvssScore = 0.1;
-    maxCvssScore = 3.9;
-  } else if (cvssName === "Medium") {
-    minCvssScore = 4.0;
-    maxCvssScore = 6.9;
-  } else if (cvssName === "High") {
-    minCvssScore = 7.0;
-    maxCvssScore = 8.9;
-  } else if (cvssName === "Critical") {
-    minCvssScore = 9.0;
-    maxCvssScore = 10.0;
+  const rating = cvssRatings[cvssName];
+  if (rating) {
+    return [rating.min, rating.max];
   }
-
-  return [minCvssScore, maxCvssScore];
+  return [undefined, undefined];
 };
 
 export const checkAdmin = (member, pteamId) => {


### PR DESCRIPTION
## PR の目的
- CVSSを利用したトピックの検索ができるようにUI画面を作成しました

## 経緯・意図・意思決定
### 仕様
- 追加する位置
  - Topic Tagsの下にCVSSのスコアを入力できるような項目を追加しました
- トグルボタン 
  - トグルボタン（None, low, Criticalなど）を押すと下に並んでいるテキストボックスに自動で値が入ります
  - トグルボタンは1つだけ押せるようにしています
  - 手動でテキストボックスに値を入れた時、トグルボタンが解除されるようにしています
- テキストボックへの入力
  - 0~10の数字と少数第1位の確認を行い、それ以外の値(文字列、11以上0未満の値、少数第2位など)は入力できないようにしています
  - テキストボックスに入れる値を左右逆にし、大小が反対になっていてもエラー処理は行わないようにしています(大小逆の場合、API的に0件ヒットします)
  - 入力フィールドをユーザーに使いやすくするための表示（数字であること、最小値、最大値の指定に関する表示）は別のPRで対応する予定です
![スクリーンショット 2025-01-07 17 16 56（2）](https://github.com/user-attachments/assets/94fd48a4-8946-4f67-820e-023bd0176d7d)

### 実装
- web/src/utils/func.js
  - cvssConvertToScore:  CVSSの名前からスコア変換する関数を作成しました
  - cvssConvertToName:  CVSSのスコアから名前に変換する関数がcvssSeverityRatingという名前でありましたが、上記の関数と区別しやすくするため変数名を変更しました。それに伴いTopicDetailPage.jsxやTopicManagementPage.jsxにあったcvssSeverityRatingを新しい変数名に変更しています
- web/src/utils/const.js
  - "None", "Low", "Medium", "High", "Critical"をリストでまとめました
- web/src/pages/TopicManagement/TopicManagementPage.jsx
   - TopicSearch APIのクエリパラメータにcvssの最小値、最大値を追加しました
- web/src/pages/TopicManagement/TopicSearchModal.jsx
  - CVSSの値を使用してTopic検索が行えるように、トグルボタンとテキストフィールドを追加しました
  - 0~10の数字と少数第1位以外の値は入力できないようにするため、handleMinCvssScore、handleMaxCvssScoreで条件を絞っています。正規表現を使って少数第1位以降の値が入らないようにしています。
