### PR TITLE
Implement ErrorBoundary in useGetPTeamInvitationQuery of AcceptPTeamInvitation

### DIFF
--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
@@ -27,7 +27,10 @@ export function AcceptPTeamInvitation() {
   } = useGetPTeamInvitationQuery(tokenId, { skip });
 
   if (skip) return <></>;
-  if (detailError) throw new APIError(errorToString(detailError), { api: "getPTeamInvitation" });
+  if (detailError)
+    throw new APIError("This invitation is invalid or already expired.", {
+      api: "getPTeamInvitation",
+    });
   if (detailIsLoading) return <>Now loading user info...</>;
 
   const handleAccept = async (event) => {

--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useApplyPTeamInvitationMutation, useGetPTeamInvitationQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { commonButtonStyle } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
@@ -26,7 +27,7 @@ export function AcceptPTeamInvitation() {
   } = useGetPTeamInvitationQuery(tokenId, { skip });
 
   if (skip) return <></>;
-  if (detailError) return <>{"This invitation is invalid or already expired."}</>;
+  if (detailError) throw new APIError(errorToString(detailError), { api: "getPTeamInvitation" });
   if (detailIsLoading) return <>Now loading user info...</>;
 
   const handleAccept = async (event) => {


### PR DESCRIPTION
## PR の目的
- AcceptPTeamInvitationのuseGetPTeamInvitationQueryにErrorBoundaryを実装（検証済み）

## 経緯・意図・意思決定
- RTKクエリによるエラー検知において、ErrorBoundaryを用いてページトップで表示するように統一するため