### PR TITLE
prevent updating auth by non-admin

### DIFF
--- a/web/src/pages/PTeam/AuthAdminCheckbox.jsx
+++ b/web/src/pages/PTeam/AuthAdminCheckbox.jsx
@@ -1,0 +1,28 @@
+import { Box, Checkbox } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+
+export function AuthAdminCheckbox(props) {
+  const { checked, editable, modified, onChange } = props;
+
+  return (
+    <>
+      <Box display="flex" flexDirection="row" alignItems="center" width="40px">
+        <Checkbox
+          checked={checked}
+          disabled={!editable}
+          onChange={editable ? onChange : undefined}
+          fontSize="small"
+        />
+        {modified && "*"}
+      </Box>
+    </>
+  );
+}
+
+AuthAdminCheckbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  editable: PropTypes.bool.isRequired,
+  modified: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+};

--- a/web/src/pages/PTeam/PTeamAuthEditor.jsx
+++ b/web/src/pages/PTeam/PTeamAuthEditor.jsx
@@ -20,10 +20,51 @@ import dialogStyle from "../../cssModule/dialog.module.css";
 import { useUpdatePTeamMemberMutation } from "../../services/tcApi";
 import { errorToString } from "../../utils/func";
 
-export function PTeamAuthEditor(props) {
-  const { pteamId, memberUserId, userEmail, isCurrentMemberAdmin, onClose } = props;
+function AdminCheckbox(props) {
+  const { checked, editable, modified, onChange } = props;
 
-  const [checked, setChecked] = useState(isCurrentMemberAdmin);
+  return (
+    <>
+      <Box display="flex" flexDirection="row" alignItems="center" width="40px">
+        <Checkbox
+          checked={checked}
+          disabled={!editable}
+          onChange={editable ? onChange : undefined}
+          fontSize="small"
+        />
+        {modified && "*"}
+      </Box>
+    </>
+  );
+}
+
+AdminCheckbox.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  editable: PropTypes.bool.isRequired,
+  modified: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+function UpdateAuthButton(props) {
+  const { disabled, onUpdate } = props;
+
+  return (
+    <Button disabled={disabled} onClick={onUpdate} className={dialogStyle.submit_btn}>
+      Update
+    </Button>
+  );
+}
+
+UpdateAuthButton.propTypes = {
+  disabled: PropTypes.bool.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};
+
+export function PTeamAuthEditor(props) {
+  const { pteamId, memberUserId, userEmail, isTargetMemberAdmin, isCurrentUserAdmin, onClose } =
+    props;
+
+  const [checked, setChecked] = useState(isTargetMemberAdmin);
 
   const [updatePTeamMember] = useUpdatePTeamMemberMutation();
 
@@ -33,7 +74,7 @@ export function PTeamAuthEditor(props) {
     setChecked(event.target.checked);
   };
 
-  const handleSave = async (targets) => {
+  const handleSave = async () => {
     function onSuccess(success) {
       enqueueSnackbar("Update pteam authority succeeded", { variant: "success" });
     }
@@ -76,9 +117,14 @@ export function PTeamAuthEditor(props) {
           <TableBody>
             <TableRow>
               <TableCell>
-                <Checkbox checked={checked} onChange={handleCheckedChange} fontSize="small" />
+                <AdminCheckbox
+                  checked={checked}
+                  editable={isCurrentUserAdmin}
+                  modified={isTargetMemberAdmin !== checked}
+                  onChange={handleCheckedChange}
+                />
               </TableCell>
-              <TableCell>Administrator</TableCell>
+              <TableCell>Role</TableCell>
               <TableCell>To administrate the pteam.</TableCell>
             </TableRow>
           </TableBody>
@@ -86,9 +132,7 @@ export function PTeamAuthEditor(props) {
       </TableContainer>
       <Box display="flex" mt={2}>
         <Box flexGrow={1} />
-        <Button onClick={handleSave} className={dialogStyle.submit_btn}>
-          Update
-        </Button>
+        <UpdateAuthButton disabled={isTargetMemberAdmin === checked} onUpdate={handleSave} />
       </Box>
     </>
   );
@@ -98,6 +142,7 @@ PTeamAuthEditor.propTypes = {
   pteamId: PropTypes.string.isRequired,
   memberUserId: PropTypes.string,
   userEmail: PropTypes.string,
-  isCurrentMemberAdmin: PropTypes.bool.isRequired,
+  isTargetMemberAdmin: PropTypes.bool.isRequired,
+  isCurrentUserAdmin: PropTypes.bool.isRequired,
   onClose: PropTypes.func,
 };

--- a/web/src/pages/PTeam/PTeamAuthEditor.jsx
+++ b/web/src/pages/PTeam/PTeamAuthEditor.jsx
@@ -85,7 +85,7 @@ export function PTeamAuthEditor(props) {
                   onChange={handleCheckedChange}
                 />
               </TableCell>
-              <TableCell>Role</TableCell>
+              <TableCell>Administrator</TableCell>
               <TableCell>To administrate the pteam.</TableCell>
             </TableRow>
           </TableBody>

--- a/web/src/pages/PTeam/PTeamAuthEditor.jsx
+++ b/web/src/pages/PTeam/PTeamAuthEditor.jsx
@@ -1,8 +1,6 @@
 import { Close as CloseIcon } from "@mui/icons-material";
 import {
   Box,
-  Button,
-  Checkbox,
   IconButton,
   Table,
   TableBody,
@@ -20,45 +18,8 @@ import dialogStyle from "../../cssModule/dialog.module.css";
 import { useUpdatePTeamMemberMutation } from "../../services/tcApi";
 import { errorToString } from "../../utils/func";
 
-function AdminCheckbox(props) {
-  const { checked, editable, modified, onChange } = props;
-
-  return (
-    <>
-      <Box display="flex" flexDirection="row" alignItems="center" width="40px">
-        <Checkbox
-          checked={checked}
-          disabled={!editable}
-          onChange={editable ? onChange : undefined}
-          fontSize="small"
-        />
-        {modified && "*"}
-      </Box>
-    </>
-  );
-}
-
-AdminCheckbox.propTypes = {
-  checked: PropTypes.bool.isRequired,
-  editable: PropTypes.bool.isRequired,
-  modified: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
-
-function UpdateAuthButton(props) {
-  const { disabled, onUpdate } = props;
-
-  return (
-    <Button disabled={disabled} onClick={onUpdate} className={dialogStyle.submit_btn}>
-      Update
-    </Button>
-  );
-}
-
-UpdateAuthButton.propTypes = {
-  disabled: PropTypes.bool.isRequired,
-  onUpdate: PropTypes.func.isRequired,
-};
+import { AuthAdminCheckbox } from "./AuthAdminCheckbox";
+import { UpdateAuthButton } from "./UpdateAuthButton";
 
 export function PTeamAuthEditor(props) {
   const { pteamId, memberUserId, userEmail, isTargetMemberAdmin, isCurrentUserAdmin, onClose } =
@@ -117,7 +78,7 @@ export function PTeamAuthEditor(props) {
           <TableBody>
             <TableRow>
               <TableCell>
-                <AdminCheckbox
+                <AuthAdminCheckbox
                   checked={checked}
                   editable={isCurrentUserAdmin}
                   modified={isTargetMemberAdmin !== checked}

--- a/web/src/pages/PTeam/PTeamMember.jsx
+++ b/web/src/pages/PTeam/PTeamMember.jsx
@@ -78,7 +78,7 @@ export function PTeamMember(props) {
                           pteamId={pteamId}
                           memberUserId={member.user_id}
                           userEmail={member.email}
-                          isCurrentMemberAdmin={checkAdmin(member, pteamId)}
+                          isTargetMemberAdmin={checkAdmin(member, pteamId)}
                         />
                       </TableCell>
                     </TableRow>

--- a/web/src/pages/PTeam/PTeamMemberMenu.jsx
+++ b/web/src/pages/PTeam/PTeamMemberMenu.jsx
@@ -15,7 +15,7 @@ import { PTeamAuthEditor } from "./PTeamAuthEditor";
 import { PTeamMemberRemoveModal } from "./PTeamMemberRemoveModal";
 
 export function PTeamMemberMenu(props) {
-  const { pteamId, memberUserId, userEmail, isCurrentMemberAdmin } = props;
+  const { pteamId, memberUserId, userEmail, isTargetMemberAdmin } = props;
 
   const [openAuth, setOpenAuth] = useState(false);
   const [openRemove, setOpenRemove] = useState(false);
@@ -90,20 +90,23 @@ export function PTeamMemberMenu(props) {
             pteamId={pteamId}
             memberUserId={memberUserId}
             userEmail={userEmail}
-            isCurrentMemberAdmin={isCurrentMemberAdmin}
+            isTargetMemberAdmin={isTargetMemberAdmin}
+            isCurrentUserAdmin={isCurrentUserAdmin}
             onClose={() => setOpenAuth(false)}
           />
         </DialogContent>
       </Dialog>
-      <Dialog open={openRemove} onClose={() => setOpenRemove(false)}>
-        <PTeamMemberRemoveModal
-          memberUserId={memberUserId}
-          userName={userEmail}
-          pteamId={pteamId}
-          pteamName={pteam.pteam_name}
-          onClose={() => setOpenRemove(false)}
-        />
-      </Dialog>
+      {(isCurrentUserAdmin || memberUserId === userMe.user_id) && (
+        <Dialog open={openRemove} onClose={() => setOpenRemove(false)}>
+          <PTeamMemberRemoveModal
+            memberUserId={memberUserId}
+            userName={userEmail}
+            pteamId={pteamId}
+            pteamName={pteam.pteam_name}
+            onClose={() => setOpenRemove(false)}
+          />
+        </Dialog>
+      )}
     </>
   );
 }
@@ -112,5 +115,5 @@ PTeamMemberMenu.propTypes = {
   pteamId: PropTypes.string.isRequired,
   memberUserId: PropTypes.string.isRequired,
   userEmail: PropTypes.string.isRequired,
-  isCurrentMemberAdmin: PropTypes.bool.isRequired,
+  isTargetMemberAdmin: PropTypes.bool.isRequired,
 };

--- a/web/src/pages/PTeam/UpdateAuthButton.jsx
+++ b/web/src/pages/PTeam/UpdateAuthButton.jsx
@@ -1,0 +1,20 @@
+import { Button } from "@mui/material";
+import PropTypes from "prop-types";
+import React from "react";
+
+import dialogStyle from "../../cssModule/dialog.module.css";
+
+export function UpdateAuthButton(props) {
+  const { disabled, onUpdate } = props;
+
+  return (
+    <Button disabled={disabled} onClick={onUpdate} className={dialogStyle.submit_btn}>
+      Update
+    </Button>
+  );
+}
+
+UpdateAuthButton.propTypes = {
+  disabled: PropTypes.bool.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## PR の目的

- TeamAuth が admin でないユーザでも更新可能に見える不具合を修正
  - 実際には api が 403 を返すので、実害はない
  - 変数名 currentMember が api 側の currentUser と紛らわしいため、targetMember に変更
- パラメータが未変更状態でも update ボタンを押せてしまうので、こちらも未変更で押せないように修正
- reat-testing-library の題材として利用しているため、チェックボックスとボタンを子コンポーネントに切り出している
