### PR TITLE
Add error  boundary to tag page

### DIFF
--- a/web/src/pages/Tag/PTeamTaggedTopics.jsx
+++ b/web/src/pages/Tag/PTeamTaggedTopics.jsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetPTeamMembersQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { sortedSSVCPriorities } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
@@ -25,7 +26,7 @@ export function PTeamTaggedTopics(props) {
   } = useGetPTeamMembersQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (membersError) return <>{`Cannot get PTeamMembers: ${errorToString(membersError)}`}</>;
+  if (membersError) throw new APIError(errorToString(membersError), { api: "getPTeamMembers" });
   if (membersIsLoading) return <>Now loading PTeamMembers...</>;
 
   if (taggedTopics === undefined) {

--- a/web/src/pages/Tag/ReportCompletedActions.jsx
+++ b/web/src/pages/Tag/ReportCompletedActions.jsx
@@ -24,6 +24,7 @@ import {
   useUpdateTicketStatusMutation,
   useGetUserMeQuery,
 } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
 import { ActionTypeChip } from "./ActionTypeChip";
@@ -49,7 +50,7 @@ export function ReportCompletedActions(props) {
   const [updateTicketStatus] = useUpdateTicketStatusMutation();
 
   if (skip) return <></>;
-  if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
+  if (userMeError) throw new APIError(errorToString(userMeError), { api: "getUserMe" });
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
 
   const handleAction = async () =>

--- a/web/src/pages/Tag/TagPage.jsx
+++ b/web/src/pages/Tag/TagPage.jsx
@@ -12,6 +12,7 @@ import {
   useGetTagsQuery,
   useGetDependenciesQuery,
 } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError.js";
 import { noPTeamMessage } from "../../utils/const";
 import { a11yProps, errorToString } from "../../utils/func.js";
 
@@ -61,15 +62,15 @@ export function Tag() {
 
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (!getTopicIdsReady) return <></>;
-  if (allTagsError) return <>{`Cannot get allTags: ${errorToString(allTagsError)}`}</>;
+  if (allTagsError) throw new APIError(errorToString(allTagsError), { api: "getTags" });
   if (allTagsIsLoading) return <>Now loading allTags...</>;
-  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamError) throw new APIError(errorToString(pteamError), { api: "getPTeam" });
   if (pteamIsLoading) return <>Now loading Team...</>;
   if (serviceDependenciesError)
-    return <>{`Cannot get serviceDependencies: ${errorToString(serviceDependenciesError)}`}</>;
+    throw new APIError(errorToString(serviceDependenciesError), { api: "getDependencies" });
   if (serviceDependenciesIsLoading) return <>Now loading serviceDependencies...</>;
   if (taggedTopicsError)
-    return <>{`Cannot get TaggedTopics: ${errorToString(taggedTopicsError)}`}</>;
+    throw new APIError(errorToString(taggedTopicsError), { api: "getPTeamServiceTaggedTopicIds" });
   if (taggedTopicsIsLoading) return <>Now loading TaggedTopics...</>;
 
   const numSolved = taggedTopics.solved?.topic_ids?.length ?? 0;

--- a/web/src/pages/Tag/TopicTagSelector.jsx
+++ b/web/src/pages/Tag/TopicTagSelector.jsx
@@ -23,6 +23,7 @@ import { FixedSizeList } from "react-window";
 import dialogStyle from "../../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useCreateTagMutation, useGetTagsQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { commonButtonStyle } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
@@ -53,7 +54,7 @@ export function TopicTagSelector(props) {
   }, [allTags, search]);
 
   if (skip) return <></>;
-  if (allTagsError) return <>{`Cannot get allTags: ${errorToString(allTagsError)}`}</>;
+  if (allTagsError) throw new APIError(errorToString(allTagsError), { api: "getTags" });
   if (allTagsIsLoading) return <>Now loading allTags...</>;
 
   const handleCreateTag = async () => {

--- a/web/src/pages/Tag/TopicTicketAccordion.jsx
+++ b/web/src/pages/Tag/TopicTicketAccordion.jsx
@@ -22,6 +22,7 @@ import React from "react";
 import { SSVCPriorityStatusChip } from "../../components/SSVCPriorityStatusChip";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetThreatQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import {
   safetyImpactDescription,
   safetyImpactProps,
@@ -75,12 +76,11 @@ export function TopicTicketAccordion(props) {
     data: threat,
     error: threatError,
     isLoading: threatIsLoading,
-  } = useGetThreatQuery(ticket.threat_id, { skipByAuth });
+  } = useGetThreatQuery(ticket.ticket_id, { skipByAuth });
 
   if (skipByAuth) return <></>;
   if (threatIsLoading) return ErrorAccordion("Now loading Threat...", defaultExpanded);
-  if (threatError)
-    return ErrorAccordion(`Cannot get Threat: ${errorToString(threatError)}`, defaultExpanded);
+  if (threatError) throw new APIError(errorToString(threatError), { api: "getThreat" });
 
   const StyledTooltip = styled(({ className, ...props }) => (
     <Tooltip {...props} classes={{ popper: className }} />

--- a/web/src/pages/Tag/TopicTicketAccordion.jsx
+++ b/web/src/pages/Tag/TopicTicketAccordion.jsx
@@ -76,7 +76,7 @@ export function TopicTicketAccordion(props) {
     data: threat,
     error: threatError,
     isLoading: threatIsLoading,
-  } = useGetThreatQuery(ticket.ticket_id, { skipByAuth });
+  } = useGetThreatQuery(ticket.threat_id, { skipByAuth });
 
   if (skipByAuth) return <></>;
   if (threatIsLoading) return ErrorAccordion("Now loading Threat...", defaultExpanded);


### PR DESCRIPTION
## PR の目的
- Tagsページ下のコンポーネントに対して、RTKQueryのエラーをAPIErrorを用いてthrowするように修正
- 手動で表示のテストは行いましたが、getTagsやgetUserMeについてはエラーを発生させる方法がわからず、エラー処理のif文に強制的に分岐するようにし、表示が想定通りにでるかどうかのみ確認しています。
  - 良い方法があったら教えていただけると幸いです。