### PR TITLE
topic/implement-ErrorBoundary-in-Status

### DIFF
--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -17,6 +17,7 @@ import { useLocation, useNavigate } from "react-router";
 import styles from "../../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useDeletePTeamServiceMutation, useGetPTeamQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
 export function PTeamServiceDelete(props) {
@@ -39,7 +40,10 @@ export function PTeamServiceDelete(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamError)
+    throw new APIError(errorToString(pteamError), {
+      api: "getPTeam",
+    });
   if (pteamIsLoading) return <>Now loading Team...</>;
 
   const services = pteam.services;

--- a/web/src/pages/Status/PTeamServicesListModal.jsx
+++ b/web/src/pages/Status/PTeamServicesListModal.jsx
@@ -24,6 +24,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetPTeamServiceThumbnailQuery, useGetPTeamQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
 const noImageAvailableUrl = "images/no-image-available-720x480.png";
@@ -91,7 +92,10 @@ export function PTeamServicesListModal(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamError)
+    throw new APIError(errorToString(pteamError), {
+      api: "getPTeam",
+    });
   if (pteamIsLoading) return <>Now loading Team...</>;
 
   const targetServices = pteam.services

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -38,6 +38,7 @@ import {
   useGetPTeamTagsSummaryQuery,
   useGetPTeamServiceTagsSummaryQuery,
 } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { noPTeamMessage, sortedSSVCPriorities, ssvcPriorityProps } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
@@ -185,18 +186,25 @@ export function Status() {
 
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (skipByAuth || !pteamId) return <></>;
-  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamError)
+    throw new APIError(errorToString(pteamError), {
+      api: "getPTeam",
+    });
   if (pteamIsLoading) return <>Now loading Team...</>;
 
   if (isActiveAllServicesMode) {
     if (pteamTagsSummaryError)
-      return <>{`Cannot get pteamTagsSummary: ${errorToString(pteamTagsSummaryError)}`}</>;
+      throw new APIError(errorToString(pteamTagsSummaryError), {
+        api: "getPTeamTagsSummary",
+      });
 
     if (!pteamTagsSummary || pteamTagsSummaryIsFetching)
       return <>Now loading pteamTagsSummary...</>;
   } else {
     if (serviceTagsSummaryError)
-      return <>{`Cannot get serviceTagsSummary: ${errorToString(serviceTagsSummaryError)}`}</>;
+      throw new APIError(errorToString(serviceTagsSummaryError), {
+        api: "getPTeamServiceTagsSummary",
+      });
 
     if (
       (serviceId || pteam.services.length > 0) &&


### PR DESCRIPTION
## PR の目的
-  web/src/pages/Status/StatusPage.jsxの下記Errorに対し、ErrorBoundaryを実装しました
   - pteamError
   - pteamTagsSummaryError
   - serviceTagsSummaryError
- web/src/pages/Status/PTeamServicesListModal.jsx の下記Errorに対し、ErrorBoundaryを実装しました
  - pteamError
- web/src/pages/Status/PTeamServiceDelete.jsxの下記Errorに対し、ErrorBoundaryを実装しました
  - pteamError
