### PR TITLE
app error throw

### DIFF
--- a/web/src/pages/App/AppBar.jsx
+++ b/web/src/pages/App/AppBar.jsx
@@ -2,6 +2,7 @@ import { Menu as MenuIcon } from "@mui/icons-material";
 import { AppBar as MuiAppBar, Box, Button, Divider, IconButton, Toolbar } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
@@ -10,6 +11,7 @@ import { tcApi } from "../../services/tcApi";
 import { setDrawerOpen } from "../../slices/system";
 import { drawerWidth } from "../../utils/const";
 
+import { AppFallback } from "./AppFallback";
 import { TeamSelector } from "./TeamSelector";
 
 const StyledAppBar = styled(MuiAppBar, {
@@ -65,7 +67,9 @@ export function AppBar() {
           </IconButton>
           <Divider orientation="vertical" flexItem sx={{ mr: 2 }} />
           <Box flexGrow={1} />
-          <TeamSelector />
+          <ErrorBoundary FallbackComponent={AppFallback}>
+            <TeamSelector />
+          </ErrorBoundary>
           <Button color="inherit" onClick={handleLogout}>
             Logout
           </Button>

--- a/web/src/pages/App/AppPage.jsx
+++ b/web/src/pages/App/AppPage.jsx
@@ -1,29 +1,25 @@
 import { Box } from "@mui/material";
-import { useSnackbar } from "notistack";
 import React, { useEffect } from "react";
 import { useCookies } from "react-cookie";
 import { ErrorBoundary } from "react-error-boundary";
 import { useDispatch, useSelector } from "react-redux";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
-import { useGetUserMeQuery, useTryLoginMutation } from "../../services/tcApi";
+import { useTryLoginMutation } from "../../services/tcApi";
 import { setAuthToken } from "../../slices/auth";
-import { LocationReader } from "../../utils/LocationReader";
 import { mainMaxWidth } from "../../utils/const";
-import { errorToString } from "../../utils/func";
 import { authCookieName } from "../Login/LoginPage";
 
 import { AppBar } from "./AppBar";
 import { AppFallback } from "./AppFallback";
 import { Drawer } from "./Drawer";
 import { Main } from "./Main";
+import { ParamsChecker } from "./ParamsChecker";
 
 export function App() {
   /* eslint-disable-next-line no-unused-vars */
   const [cookies, _setCookie, _removeCookie] = useCookies([authCookieName]);
-
-  const { enqueueSnackbar } = useSnackbar();
 
   const skip = useSkipUntilAuthTokenIsReady();
 
@@ -32,12 +28,6 @@ export function App() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const {
-    data: userMe,
-    error: userMeError,
-    isLoading: userMeIsLoading,
-    isFetching: userMeIsFetching,
-  } = useGetUserMeQuery(undefined, { skip });
   const [tryLogin] = useTryLoginMutation();
 
   useEffect(() => {
@@ -61,34 +51,6 @@ export function App() {
     _checkToken();
   }, [cookies, dispatch, location, navigate, skip, tryLogin]);
 
-  useEffect(() => {
-    if (!userMe || userMeIsFetching) return;
-    const params = new URLSearchParams(location.search);
-    const locationReader = new LocationReader(location);
-    if (
-      locationReader.isStatusPage() ||
-      locationReader.isTagPage() ||
-      locationReader.isPTeamPage()
-    ) {
-      if (!userMe.pteam_roles.length > 0) {
-        if (params.get("pteamId")) {
-          navigate(location.pathname);
-        }
-        return;
-      }
-      const pteamIdx = params.get("pteamId") || userMe.pteam_roles[0].pteam.pteam_id;
-      if (params.get("pteamId") !== pteamIdx) {
-        params.set("pteamId", pteamIdx);
-        navigate(location.pathname + "?" + params.toString());
-        return;
-      }
-    }
-  }, [dispatch, enqueueSnackbar, navigate, location, userMe, userMeIsFetching]);
-
-  if (skip) return <></>;
-  if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
-  if (userMeIsLoading) return <>Now loading UserInfo...</>;
-
   return (
     <>
       <Box flexGrow={1}>
@@ -99,7 +61,7 @@ export function App() {
         <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" m={1}>
           <Box display="flex" flexDirection="column" flexGrow={1} maxWidth={mainMaxWidth}>
             <ErrorBoundary FallbackComponent={AppFallback}>
-              <Outlet />
+              <ParamsChecker />
             </ErrorBoundary>
           </Box>
         </Box>

--- a/web/src/pages/App/ParamsChecker.jsx
+++ b/web/src/pages/App/ParamsChecker.jsx
@@ -1,0 +1,56 @@
+import { useSnackbar } from "notistack";
+import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+
+import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
+import { useGetUserMeQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
+import { LocationReader } from "../../utils/LocationReader";
+import { errorToString } from "../../utils/func";
+
+export function ParamsChecker() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const skip = useSkipUntilAuthTokenIsReady();
+
+  const {
+    data: userMe,
+    error: userMeError,
+    isLoading: userMeIsLoading,
+    isFetching: userMeIsFetching,
+  } = useGetUserMeQuery(undefined, { skip });
+
+  useEffect(() => {
+    if (!userMe || userMeIsFetching) return;
+    const params = new URLSearchParams(location.search);
+    const locationReader = new LocationReader(location);
+    if (
+      locationReader.isStatusPage() ||
+      locationReader.isTagPage() ||
+      locationReader.isPTeamPage()
+    ) {
+      if (!userMe.pteam_roles.length > 0) {
+        if (params.get("pteamId")) {
+          navigate(location.pathname);
+        }
+        return;
+      }
+      const pteamIdx = params.get("pteamId") || userMe.pteam_roles[0].pteam.pteam_id;
+      if (params.get("pteamId") !== pteamIdx) {
+        params.set("pteamId", pteamIdx);
+        navigate(location.pathname + "?" + params.toString());
+        return;
+      }
+    }
+  }, [dispatch, enqueueSnackbar, navigate, location, userMe, userMeIsFetching]);
+
+  if (skip) return <></>;
+  if (userMeError) throw new APIError(errorToString(userMeError), { api: "getUserMe" });
+  if (userMeIsLoading) return <>Now loading UserInfo...</>;
+
+  return <Outlet />;
+}

--- a/web/src/pages/App/ParamsChecker.jsx
+++ b/web/src/pages/App/ParamsChecker.jsx
@@ -5,7 +5,7 @@ import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetUserMeQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
-import { checkPTeamIdInParams } from "../../utils/locationChecker";
+import { navigateSpecifiedPteam } from "../../utils/locationChecker";
 
 export function ParamsChecker() {
   const navigate = useNavigate();
@@ -22,7 +22,7 @@ export function ParamsChecker() {
 
   useEffect(() => {
     if (!userMe || userMeIsFetching) return;
-    checkPTeamIdInParams(location, userMe.pteam_roles, navigate);
+    navigateSpecifiedPteam(location, userMe.pteam_roles, navigate);
   }, [navigate, location, userMe, userMeIsFetching]);
 
   if (skip) return <></>;

--- a/web/src/pages/App/TeamSelector.jsx
+++ b/web/src/pages/App/TeamSelector.jsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetUserMeQuery } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { LocationReader } from "../../utils/LocationReader";
 import { drawerParams } from "../../utils/const";
 import { errorToString } from "../../utils/func";
@@ -50,7 +51,7 @@ export function TeamSelector() {
   }, [userMe, locationReader]);
 
   if (skip) return <></>;
-  if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
+  if (userMeError) throw new APIError(errorToString(userMeError), { api: "getUserMe" });
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
 
   const switchToPTeam = (teamId) => {

--- a/web/src/tests/locationChecker.test.js
+++ b/web/src/tests/locationChecker.test.js
@@ -1,0 +1,71 @@
+import { checkPTeamIdInParams } from "../utils/locationChecker";
+
+test.each([
+  // not navigate
+  {
+    locationPathname: "/",
+    locationSearch: "?pteamId=dummyPteamId1",
+    pteamRoles: [{ pteam: { pteam_id: "dummyPteamId1" } }],
+    navigateCallCount: 0,
+    expectedParam: "",
+  },
+  // navigate location.pathname in status page
+  // in status page
+  {
+    locationPathname: "/",
+    locationSearch: "?pteamId=dummyPteamId1",
+    pteamRoles: [],
+    navigateCallCount: 1,
+    expectedParam: "",
+  },
+  // navigate location.pathname in tag page
+  {
+    locationPathname: "/tags/dummyTagId1",
+    locationSearch: "?pteamId=dummyPteamId1",
+    pteamRoles: [],
+    navigateCallCount: 1,
+    expectedParam: "",
+  },
+  // navigate location.pathname in pteam page
+  {
+    locationPathname: "/pteam",
+    locationSearch: "?pteamId=dummyPteamId1",
+    pteamRoles: [],
+    navigateCallCount: 1,
+    expectedParam: "",
+  },
+  // not navigate in other page
+  {
+    locationPathname: "/other",
+    locationSearch: "?pteamId=dummyPteamId1",
+    pteamRoles: [],
+    navigateCallCount: 0,
+    expectedParam: "",
+  },
+  // navigate location.pathname and pteamId in status page
+  {
+    locationPathname: "/",
+    locationSearch: "",
+    pteamRoles: [{ pteam: { pteam_id: "pteamId1" } }],
+    navigateCallCount: 1,
+    expectedParam: "pteamId=pteamId1",
+  },
+])(
+  "checkPTeamIdInParams not navigate",
+  ({ locationPathname, locationSearch, pteamRoles, navigateCallCount, expectedParam }) => {
+    const location = {
+      pathname: locationPathname,
+      search: locationSearch,
+    };
+    const mockNavigate = jest.fn();
+
+    checkPTeamIdInParams(location, pteamRoles, mockNavigate);
+
+    expect(mockNavigate).toBeCalledTimes(navigateCallCount);
+    if (navigateCallCount === 1) {
+      const expectNavigatePath =
+        expectedParam === "" ? locationPathname : locationPathname + "?" + expectedParam;
+      expect(mockNavigate.mock.calls[0][0]).toBe(expectNavigatePath);
+    }
+  },
+);

--- a/web/src/tests/locationChecker.test.js
+++ b/web/src/tests/locationChecker.test.js
@@ -51,7 +51,7 @@ test.each([
     expectedParam: "pteamId=pteamId1",
   },
 ])(
-  "checkPTeamIdInParams not navigate",
+  "checkPTeamIdInParams test",
   ({ locationPathname, locationSearch, pteamRoles, navigateCallCount, expectedParam }) => {
     const location = {
       pathname: locationPathname,

--- a/web/src/tests/locationChecker.test.js
+++ b/web/src/tests/locationChecker.test.js
@@ -1,4 +1,4 @@
-import { checkPTeamIdInParams } from "../utils/locationChecker";
+import { navigateSpecifiedPteam } from "../utils/locationChecker";
 
 test.each([
   // not navigate
@@ -50,7 +50,7 @@ test.each([
     expectedParam: "pteamId=pteamId1",
   },
 ])(
-  "checkPTeamIdInParams test",
+  "navigateSpecifiedPteam test",
   ({ locationPathname, locationSearch, pteamRoles, navigateCallCount, expectedParam }) => {
     const location = {
       pathname: locationPathname,
@@ -58,13 +58,13 @@ test.each([
     };
     const mockNavigate = jest.fn();
 
-    checkPTeamIdInParams(location, pteamRoles, mockNavigate);
+    navigateSpecifiedPteam(location, pteamRoles, mockNavigate);
 
     expect(mockNavigate).toBeCalledTimes(navigateCallCount);
     if (navigateCallCount === 1) {
       const expectNavigatePath =
         expectedParam === "" ? locationPathname : locationPathname + "?" + expectedParam;
-      expect(mockNavigate.mock.calls[0][0]).toBe(expectNavigatePath);
+      expect(mockNavigate).toHaveBeenCalledWith(expectNavigatePath);
     }
   },
 );

--- a/web/src/tests/locationChecker.test.js
+++ b/web/src/tests/locationChecker.test.js
@@ -10,7 +10,6 @@ test.each([
     expectedParam: "",
   },
   // navigate location.pathname in status page
-  // in status page
   {
     locationPathname: "/",
     locationSearch: "?pteamId=dummyPteamId1",

--- a/web/src/utils/locationChecker.js
+++ b/web/src/utils/locationChecker.js
@@ -1,0 +1,20 @@
+import { LocationReader } from "./LocationReader";
+
+export const checkPTeamIdInParams = (location, pteam_roles, navigate) => {
+  const params = new URLSearchParams(location.search);
+  const locationReader = new LocationReader(location);
+
+  if (locationReader.isStatusPage() || locationReader.isTagPage() || locationReader.isPTeamPage()) {
+    if (!pteam_roles.length > 0) {
+      if (params.get("pteamId")) {
+        navigate(location.pathname);
+      }
+      return;
+    }
+    const pteamIdx = params.get("pteamId") || pteam_roles[0].pteam.pteam_id;
+    if (params.get("pteamId") !== pteamIdx) {
+      params.set("pteamId", pteamIdx);
+      navigate(location.pathname + "?" + params.toString());
+    }
+  }
+};

--- a/web/src/utils/locationChecker.js
+++ b/web/src/utils/locationChecker.js
@@ -1,6 +1,6 @@
 import { LocationReader } from "./LocationReader";
 
-export const checkPTeamIdInParams = (location, pteam_roles, navigate) => {
+export const navigateSpecifiedPteam = (location, pteam_roles, navigate) => {
   const params = new URLSearchParams(location.search);
   const locationReader = new LocationReader(location);
 


### PR DESCRIPTION
## PR の目的
- AppPageで検知するエラーに対し、ErrorBoundaryでエラー表示するよう変更
  - AppPage.jsxのuserMeErrorに対し、ErrorBoundaryでエラー表示する
    - API呼び出しを含む「指定したpteamIdに所属していなければnavigate」の機能を、新コンポーネントParamsCheckerに切り出す。これを既存の各ページ用ErrorBoundaryの下位に置く
    - ParamsChecker内のエラー検知箇所でthrow
    - 「指定したpteamIdに所属していなければnavigate」の機能をテストするため、コンポーネントからロジックをlocationChecker.jsに切り出す
  - TeamSelector.jsxのuserMeErrorに対し、ErrorBoundaryでエラー表示する
    - エラー検知箇所でthrow
    - TeamSelectorの上位にErrorBoundaryを置く


