### PR TITLE
Implement ErrorBoundary in useGetUserMeQuery of AcceptPage

### DIFF
--- a/web/src/pages/Account/AccountPage.jsx
+++ b/web/src/pages/Account/AccountPage.jsx
@@ -16,6 +16,7 @@ import React, { useState } from "react";
 import { UUIDTypography } from "../../components/UUIDTypography";
 import { useSkipUntilAuthTokenIsReady } from "../../hooks/auth";
 import { useGetUserMeQuery, useUpdateUserMutation } from "../../services/tcApi";
+import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
 export function Account() {
@@ -35,7 +36,10 @@ export function Account() {
   } = useGetUserMeQuery(undefined, { skip });
 
   if (skip) return <></>;
-  if (userMeError) return <>{`Cannot get user info: ${errorToString(userMeError)}`}</>;
+  if (userMeError)
+    throw new APIError(errorToString(userMeError), {
+      api: "getUserMe",
+    });
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
 
   const handleEditMode = () => {


### PR DESCRIPTION
## PR の目的
- web/src/pages/Account/AccountPage.jsxのuserMeErrorに対し、ErrorBoundaryを実装（検証済み）

## 経緯・意図・意思決定
- RTKクエリによるエラー検知において、ErrorBoundaryを用いてページトップで表示するように統一するため
