### PR TITLE
throw error in components

### DIFF
--- a/web/src/components/PTeamLabel.jsx
+++ b/web/src/components/PTeamLabel.jsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useGetUserMeQuery } from "../services/tcApi";
+import { APIError } from "../utils/APIError";
 import { errorToString } from "../utils/func";
 
 import { PTeamSettingsModal } from "./PTeamSettingsModal";
@@ -23,7 +24,10 @@ export function PTeamLabel(props) {
   } = useGetUserMeQuery(undefined, { skip });
 
   if (skip) return <></>;
-  if (userMeError) return <>{`Cannot get UserInfo: ${errorToString(userMeError)}`}</>;
+  if (userMeError)
+    throw new APIError(errorToString(userMeError), {
+      api: "getUserMe",
+    });
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
 
   const pteamName =

--- a/web/src/components/PTeamSettingsModal.jsx
+++ b/web/src/components/PTeamSettingsModal.jsx
@@ -17,6 +17,7 @@ import { TabPanel } from "../components/TabPanel";
 import dialogStyle from "../cssModule/dialog.module.css";
 import { useSkipUntilAuthTokenIsReady } from "../hooks/auth";
 import { useGetPTeamQuery } from "../services/tcApi";
+import { APIError } from "../utils/APIError";
 import { a11yProps, errorToString } from "../utils/func.js";
 
 import { PTeamGeneralSetting } from "./PTeamGeneralSetting";
@@ -35,7 +36,10 @@ export function PTeamSettingsModal(props) {
   } = useGetPTeamQuery(pteamId, { skip });
 
   if (skip) return <></>;
-  if (pteamError) return <>{`Cannot get Team: ${errorToString(pteamError)}`}</>;
+  if (pteamError)
+    throw new APIError(errorToString(pteamError), {
+      api: "getPTeam",
+    });
   if (pteamIsLoading) return <>Now loading Team...</>;
 
   const handleClose = () => onSetShow(false);


### PR DESCRIPTION
## PR の目的
- componentsディレクトリにあるコンポーネントにおいて検知するエラーに対し、ErrorBoundaryでエラー表示するよう変更
  - PTeamLabel.jsxのgetUserMeに対し、ErrorBoundaryでエラー表示する
  - PTeamSettingsModal.jsxのgetPTeamに対し、ErrorBoundaryでエラー表示する

## 経緯・意図・意思決定
  - PTeamNotificationSetting.jsxの connectFailMessageにおいて、MutationのRTKクエリがエラーの場合にメッセージを出す処理があるが、既存コードは、unwrap().catch()でエラー検知してメッセージ表示しており、問題なし。

