### PR TITLE
skip metrics without other

### DIFF
--- a/scripts/vulnrichment2tc.py
+++ b/scripts/vulnrichment2tc.py
@@ -135,6 +135,9 @@ def _get_cve_data_from_json_data(vulnrichment_json: dict) -> tuple:
         )
     )
 
+    if all("other" not in x for x in adp_vulnrichment["metrics"]):
+        return ()
+
     metric = next(
         filter(lambda x: "other" in x and x["other"]["type"] == "ssvc", adp_vulnrichment["metrics"])
     )


### PR DESCRIPTION
## PR の目的
- 2025/1/24に実行したvulnrichment2tcがエラーとなった問題を修正した
  - vulnrichment2tc.py は、
containers > adp  > ("title" == "CISA ADP Vulnrichment" な要素のmetrics)
にotherが必ずある前提でしたが、下記にはotherが無いので落ちました。
https://github.com/cisagov/vulnrichment/blob/d9817755a65e9f6ca60fd4c06f964e49c4edfefa/2012/2xxx/CVE-2012-2897.json#L85

## 経緯・意図・意思決定
同じ修正をdeployリポジトリmainブランチに反映済。
定期実行で成功実績あり。
