### PR TITLE
Fix/e2e test envvar

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./web
         env:
           VITE_API_BASE_URL: "http://traefik/api"
-          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
@@ -46,10 +46,11 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_AUTH_EMULATOR_URL: "http://testfirebase:9099"
           VITE_METEMCYBER_AUTH_URL: "http://testfirebase:9099"
+          VITE_PUBLIC_URL: ""
       - name: docker compose build
         run: docker compose -f docker-compose-e2e.yml build
       - name: migrate db
-        run: docker compose -f docker-compose-e2e.yml run api sh -c "cd app && alembic upgrade head"
+        run: docker compose -f docker-compose-e2e.yml run --rm api sh -c "cd app && alembic upgrade head"
       - name: e2etest
         run: docker compose -f docker-compose-e2e.yml run --rm e2eclient pytest -s e2etests/test_e2e.py
       - name: docker compose down


### PR DESCRIPTION
## PR の目的
e2etestを修正
- VITE_PUBLIC_URLの環境変数を追加
- migrationの実行時に `--rm` オプションを実行
  - teste2e.sh の実行オプションと合わせた形 
  - `--rm` オプションを指定し、マイグレーション時にコンテナを削除しないと test実行時にAPIコンテナが起動していないようで失敗する


## 経緯・意図・意思決定

手動実行で動作確認済み
https://github.com/nttcom/threatconnectome/actions/runs/13047075275/workflow

## 参考文献
