### PR TITLE
not check email

### DIFF
--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -77,7 +77,7 @@ def verify_id_token(
 def get_current_user(
     user_info: auth.UserRecord = Depends(verify_id_token), db: Session = Depends(get_db)
 ) -> Account:
-    user = persistence.get_account_by_firebase_uid(db, user_info.uid)
+    user = persistence.get_account_by_uid(db, user_info.uid)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -195,7 +195,7 @@ class Account(Base):
     __tablename__ = "account"
 
     user_id: Mapped[StrUUID] = mapped_column(primary_key=True)
-    uid: Mapped[str | None] = mapped_column(unique=True)  # UID on Firebase
+    uid: Mapped[str | None] = mapped_column(unique=True)
     email: Mapped[Str255 | None]
     disabled: Mapped[bool] = mapped_column(default=False)
     years: Mapped[int | None]

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -9,7 +9,7 @@ from app import models
 ### Account
 
 
-def get_account_by_firebase_uid(db: Session, uid: str) -> models.Account | None:
+def get_account_by_uid(db: Session, uid: str) -> models.Account | None:
     return db.scalars(select(models.Account).where(models.Account.uid == uid)).one_or_none()
 
 

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -15,7 +15,6 @@ router = APIRouter(
 
 @router.post("/token", response_model=Token)
 def login_for_access_token(username: str = Form(), password: SecretStr = Form()) -> Token:
-    # get_access_token_from_firebase(username, password.get_secret_value())
     payload = {
         "email": username,
         "password": password.get_secret_value(),

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -44,8 +44,8 @@ def create_user(
             detail="The requested Email information could not be retrieved.",
         )
 
-    if persistence.get_account_by_email(db, email):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already used")
+    if persistence.get_account_by_firebase_uid(db, uid):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uid already used")
 
     account = models.Account(**data.model_dump(), uid=uid, email=email)
     persistence.create_account(db, account)

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -44,7 +44,7 @@ def create_user(
             detail="The requested Email information could not be retrieved.",
         )
 
-    if persistence.get_account_by_firebase_uid(db, uid):
+    if persistence.get_account_by_uid(db, uid):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uid already used")
 
     account = models.Account(**data.model_dump(), uid=uid, email=email)

--- a/api/app/tests/medium/routers/test_users.py
+++ b/api/app/tests/medium/routers/test_users.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from app import models, persistence
 from app.constants import ZERO_FILLED_UUID
 from app.main import app
 from app.tests.medium.constants import USER1, USER2
@@ -16,6 +17,17 @@ client = TestClient(app)
 
 
 def test_create_user():
+    user1 = create_user(USER1)
+    assert user1.email == USER1["email"]
+    assert user1.years == USER1["years"]
+    assert user1.user_id != ZERO_FILLED_UUID
+
+
+def test_duplicate_email(testdb):
+    email = USER1["email"]
+    account = models.Account(uid="test_uid1", email=email, years=2)
+    persistence.create_account(testdb, account)
+
     user1 = create_user(USER1)
     assert user1.email == USER1["email"]
     assert user1.years == USER1["years"]

--- a/api/app/tests/medium/routers/test_users.py
+++ b/api/app/tests/medium/routers/test_users.py
@@ -23,7 +23,7 @@ def test_create_user():
     assert user1.user_id != ZERO_FILLED_UUID
 
 
-def test_duplicate_email(testdb):
+def test_duplicate_email_user_can_be_registered(testdb):
     email = USER1["email"]
     account = models.Account(uid="test_uid1", email=email, years=2)
     persistence.create_account(testdb, account)

--- a/web/src/pages/PTeam/PTeamMember.jsx
+++ b/web/src/pages/PTeam/PTeamMember.jsx
@@ -49,7 +49,7 @@ export function PTeamMember(props) {
                   .filter((member) => member.disabled === false)
                   .map((member) => (
                     <TableRow
-                      key={member.email}
+                      key={member.user_id}
                       sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                     >
                       <TableCell align="left" style={{ width: "30%" }}>

--- a/web/src/pages/Tag/AssigneesSelector.jsx
+++ b/web/src/pages/Tag/AssigneesSelector.jsx
@@ -9,10 +9,10 @@ import { errorToString, setEquals } from "../../utils/func";
 export function AssigneesSelector(props) {
   const { pteamId, serviceId, topicId, tagId, ticketId, currentAssigneeIds, members } = props;
 
-  const [assigneeEmails, setAssigneeEmails] = useState(
+  const [assigneeUserIds, setAssigneeUserIds] = useState(
     Object.values(members)
       .filter((member) => currentAssigneeIds.includes(member.user_id))
-      .map((member) => member.email),
+      .map((member) => member.user_id),
   );
 
   const { enqueueSnackbar } = useSnackbar();
@@ -21,7 +21,7 @@ export function AssigneesSelector(props) {
 
   const handleApply = async () => {
     const newAssigneeIds = Object.values(members)
-      .filter((member) => assigneeEmails.includes(member.email))
+      .filter((member) => assigneeUserIds.includes(member.user_id))
       .map((member) => member.user_id);
     if (setEquals(new Set(newAssigneeIds), new Set(currentAssigneeIds))) return; // not modified
 
@@ -39,7 +39,7 @@ export function AssigneesSelector(props) {
     const {
       target: { value },
     } = event;
-    setAssigneeEmails((typeof value === "string" ? value.split(",") : value).sort());
+    setAssigneeUserIds((typeof value === "string" ? value.split(",") : value).sort());
   };
 
   if (!pteamId || !serviceId || !topicId || !tagId || !ticketId || !members) return <></>;
@@ -49,12 +49,19 @@ export function AssigneesSelector(props) {
       <Select
         multiple
         displayEmpty
-        value={assigneeEmails}
+        value={assigneeUserIds}
         onChange={handleAssigneesChange}
         onClose={handleApply}
         input={<Input sx={{ display: "flex", fontSize: 14 }} />}
         renderValue={(selected) => {
-          return selected.length === 0 ? <em>Select assignees</em> : selected.join(", ");
+          return selected.length === 0 ? (
+            <em>Select assignees</em>
+          ) : (
+            Object.values(members)
+              .filter((member) => selected.includes(member.user_id))
+              .map((member) => member.email)
+              .join(", ")
+          );
         }}
         MenuProps={{
           PaperProps: {
@@ -70,8 +77,8 @@ export function AssigneesSelector(props) {
           <em>Select assignees</em>
         </MenuItem>
         {Object.values(members).map((member) => (
-          <MenuItem key={member.user_id} value={member.email}>
-            <Checkbox checked={assigneeEmails.includes(member.email)} />
+          <MenuItem key={member.user_id} value={member.user_id}>
+            <Checkbox checked={assigneeUserIds.includes(member.user_id)} />
             <ListItemText primary={member.email} sx={{ "& span": { fontSize: 14 } }} />
           </MenuItem>
         ))}


### PR DESCRIPTION
## PR の目的
- [Post /users]APIにおいて、EMailアドレスの重複を許容する。
  - 従来、EMailアドレスが重複していると400エラーとしていたが、uidが重複していると400エラーとするよう修正
  - APIテスト追加。DBに同じEMailアドレスを登録した状態で[Post /users]APIで登録できることを確認
  - UI層でEMail重複に対応していない箇所を修正
    -  Teamページにおいて、メンバー一覧のkeyをemailからuser_idに変更
    - Assignee選択コンポーネントにおいて、選択済Assigneeの管理をemailからuser_idに変更
  - SAMLログインの動作確認は本番環境でないと困難なため、未実施。UI層の動作確認は、別emailで登録したアカウントをSQLで同一emailに変更してテスト実施した。

## 経緯・意図・意思決定
EMailログインとSAMLログインとで同じEMailアドレスを使用したところ、後から実行したSAMLログインでエラーが発生した。
TCのアカウント登録でEMailアドレスの重複を許容していなかったのが原因。
そのため、EMailアドレスの重複を許容するよう仕様変更した。
