### PR TITLE
add healthcheck otpion

### DIFF
--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -40,6 +40,18 @@ services:
     volumes:
       - ./api/app:/app:ro
       - ./key:/key:ro
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import requests, sys; sys.exit(0 if requests.get('http://localhost/api/').status_code == 404 else 1)",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
   testdb:
     image: postgres:14
     command:
@@ -65,8 +77,10 @@ services:
   traefik:
     image: traefik:latest
     depends_on:
-      - api
-      - web
+      api:
+        condition: service_healthy
+      web:
+        condition: service_started
     ports:
       - 80:80
       - 8080:8080


### PR DESCRIPTION
## PR の目的

e2eテストが一定確率で失敗していた事象の修正
e2eテスト実行時にAPIコンテナが起動していることをhealthcheckで保証するのが目的

## 経緯・意図・意思決定

e2eテストの失敗要因として、APIコンテナが起動していないのが原因と思われるタイムアウトがあった。
その対策として、APIコンテナにhealthcheckを追加し、APIサーバが起動してからtraefik -> e2eclient のコンテナが起動するように設定した。

現状のAPIコンテナはhealthcheck用のエンドポイントが存在しないため、APIにアクセスして404が帰ってくることをhealthcheckの条件としている
また python のslimコンテナにはcurlが存在しないため、pythonの `-c` オプションでpythonスクリプトを実行している

## 参考文献
https://docs.docker.com/reference/compose-file/services/#healthcheck