### PR TITLE
temporal commit for supporting keycloak & supabase

### DIFF
--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -9,6 +9,7 @@ import { BrowserRouter as Router, Navigate, Route, Routes } from "react-router-d
 import {
   AcceptPTeamInvitation,
   Account,
+  AuthKeycloakCallback,
   App,
   EmailVerification,
   Login,
@@ -53,6 +54,7 @@ root.render(
                 <Route path="/reset_password" element={<ResetPassword />} />
                 <Route path="/sign_up" element={<SignUp />} />
                 <Route path="/email_verification" element={<EmailVerification />} />
+                <Route path="/auth_keycloak_callback" element={<AuthKeycloakCallback />} />
                 <Route path="/" element={<App />}>
                   <Route index element={<Status />} />
                   <Route path="account">

--- a/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.jsx
+++ b/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import Supabase from "../../utils/Supabase";
+
+const supabase =
+  import.meta.env.VITE_AUTH_SERVICE === "supabase" ? Supabase.getClient() : undefined;
+
+export function AuthKeycloakCallback() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [message, setMessage] = useState("Now checking AuthCode...");
+
+  const params = new URLSearchParams(location.search);
+  const code = params.get("code");
+
+  useEffect(() => {
+    if (!code) {
+      //navigate("/login", { state: { message: "AuthError: missing auth code" } });
+      setMessage("Missing Auth code");
+      return;
+    }
+    const _verifyCode = async (code) => {
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        console.log(error);
+        setMessage(error.message);
+        return;
+        //navigate("/login", { state: { message: `AuthCodeError: ${error}` } });
+      }
+      console.log("auth succeeded!");
+      navigate("/");
+    };
+    _verifyCode(code);
+  }, [code, navigate]);
+
+  console.log(params);
+  return (
+    <>
+      <p>code: {code}</p>
+      <p>{message}</p>
+    </>
+  );
+}

--- a/web/src/pages/Login/LoginPage.jsx
+++ b/web/src/pages/Login/LoginPage.jsx
@@ -182,7 +182,8 @@ export function Login() {
         </Button>
       </Box>
       {/* show saml login button if samlProviderId is set as env */}
-      {Firebase.getSamlProvider() != null && ( // FIXME
+      {
+        // FIXME
         <>
           <Divider />
           <Button
@@ -194,7 +195,7 @@ export function Login() {
             Log In with SAML
           </Button>
         </>
-      )}
+      }
       <Divider />
       <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" mt={1}>
         <Typography mr={1}>No metemcyber account?</Typography>

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -1,6 +1,7 @@
 import { AcceptPTeamInvitation } from "./AcceptPTeamInvitation/AcceptPTeamInvitationPage";
 import { Account } from "./Account/AccountPage";
 import { App } from "./App/AppPage";
+import { AuthKeycloakCallback } from "./AuthKeycloakCallback/AuthKeycloakCallbackPage";
 import { EmailVerification } from "./EmailVerification/EmailVerificationPage";
 import { Login } from "./Login/LoginPage";
 import { PTeam } from "./PTeam/PTeamPage";
@@ -15,6 +16,7 @@ export {
   AcceptPTeamInvitation,
   Account,
   App,
+  AuthKeycloakCallback,
   EmailVerification,
   Login,
   PTeam,

--- a/web/src/providers/auth/SupabaseProvider.js
+++ b/web/src/providers/auth/SupabaseProvider.js
@@ -68,8 +68,20 @@ export class SupabaseProvider extends AuthProvider {
   }
 
   async signInWithSamlPopup() {
-    // TODO
-    throw new Error("Not implemented");
+    return await supabase.auth
+      .signInWithOAuth({
+        provider: "keycloak",
+        options: { scopes: "openid" },
+      })
+      .then((result) => {
+        if (!result.error) {
+          return new AuthData(result);
+        }
+        throw new SupabaseAuthError(result.error);
+      })
+      .catch((error) => {
+        throw error;
+      });
   }
 
   async sendPasswordResetEmail({ email, redirectTo }) {


### PR DESCRIPTION
## PR の目的

- keycloak OIDC + supabase での認証サポート
  - keycloak からのリダイレクトを処理するページを（仮）実装
  - GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI に "http://localhost:5173/auth_keycloak_callback" を設定する
  - https://supabase.com/docs/guides/auth/social-login/auth-keycloak#add-login-code-to-your-client-app
- 現状、exchangeCodeForSession が `invalid request: both auth code and code verifier should be non-empty` を返す
  - 直近で「まだ偶に起きる」「Firefox でのみ起きる」という人もいる模様？
  - 私の環境(Ubuntu20.04) では Firefox 132.0, Chrome 133.0 いずれでも 100% 発生する
