### PR TITLE
set auth provider as firebase

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -47,6 +47,7 @@ jobs:
           VITE_FIREBASE_AUTH_EMULATOR_URL: "http://testfirebase:9099"
           VITE_METEMCYBER_AUTH_URL: "http://testfirebase:9099"
           VITE_PUBLIC_URL: ""
+          VITE_AUTH_SERVICE: "firebase"
       - name: docker compose build
         run: docker compose -f docker-compose-e2e.yml build
       - name: migrate db


### PR DESCRIPTION
## PR の目的

認証機能の追加に伴い、e2eテストが失敗していた問題の対応
`VITE_AUTH_SERVICE` が設定されていなかったので `firebase` にセット

## 経緯・意図・意思決定

認証機能でsupabaseに対応した影響で、VITE_AUTH_SERVICE の環境変数により認証プロバイダーを設定する仕組みになっていたが追従できていなかったことの修正

テストで以下のエラーが発生していた
https://github.com/nttcom/threatconnectome/actions/runs/13568851478/job/37928333575#step:8:141
```
e2etests/test_e2e.py console: Error: Unsupported VITE_AUTH_SERVICE: undefined
```

## 参考文献
