### PR TITLE
Bugfix/fix docker compose supabase test

### DIFF
--- a/docker-compose-supabase-test.yml
+++ b/docker-compose-supabase-test.yml
@@ -20,6 +20,7 @@ services:
       WEBUI_URL: ${WEBUI_URL}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      DB_HOST: testdb
       TESTDB_HOST: testdb
       DB_PORT: 5432
       DB_SCHEMA: postgres

--- a/docker-compose-supabase-test.yml
+++ b/docker-compose-supabase-test.yml
@@ -115,8 +115,6 @@ services:
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
     # https://unix.stackexchange.com/a/294837
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
-    networks:
-      - test-network
 
   auth:
     container_name: supabase-auth
@@ -137,7 +135,7 @@ services:
       API_EXTERNAL_URL: http://localhost:8000
 
       GOTRUE_DB_DRIVER: postgres
-      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_DB_PASSWORD}@supabase-db:4431/postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_DB_PASSWORD}@supabase-db:5432/postgres
 
       GOTRUE_SITE_URL: http://localhost:3000
       GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
@@ -190,8 +188,6 @@ services:
       # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
       # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
       # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
-    networks:
-      - test-network
 
   meta:
     container_name: supabase-meta
@@ -204,7 +200,7 @@ services:
     environment:
       PG_META_PORT: 8080
       PG_META_DB_HOST: supabase-db
-      PG_META_DB_PORT: 4431
+      PG_META_DB_PORT: 5432
       PG_META_DB_NAME: postgres
       PG_META_DB_USER: supabase_admin
       PG_META_DB_PASSWORD: ${SUPABASE_DB_PASSWORD}
@@ -238,8 +234,8 @@ services:
       retries: 10
     environment:
       POSTGRES_HOST: /var/run/postgresql
-      PGPORT: 4431
-      POSTGRES_PORT: 4431
+      PGPORT: 5432
+      POSTGRES_PORT: 5432
       PGPASSWORD: ${SUPABASE_DB_PASSWORD}
       POSTGRES_PASSWORD: ${SUPABASE_DB_PASSWORD}
       PGDATABASE: postgres
@@ -252,10 +248,8 @@ services:
         "-c",
         "config_file=/etc/postgresql/postgresql.conf",
         "-c",
-        "log_min_messages=fatal", # prevents Realtime polling queries from appearing in logs
+        "log_min_messages=fatal" # prevents Realtime polling queries from appearing in logs
       ]
-    networks:
-      - test-network
 
 volumes:
   supabase-db-config:

--- a/docker-compose-supabase-test.yml
+++ b/docker-compose-supabase-test.yml
@@ -20,7 +20,7 @@ services:
       WEBUI_URL: ${WEBUI_URL}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
-      DB_HOST: testdb
+      TESTDB_HOST: testdb
       DB_PORT: 5432
       DB_SCHEMA: postgres
       SENDGRID_API_KEY: fake_api_key_for_sendgrid_test
@@ -115,6 +115,8 @@ services:
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
     # https://unix.stackexchange.com/a/294837
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
+    networks:
+      - test-network
 
   auth:
     container_name: supabase-auth
@@ -188,6 +190,8 @@ services:
       # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"
       # GOTRUE_HOOK_SEND_EMAIL_URI: "http://host.docker.internal:54321/functions/v1/email_sender"
       # GOTRUE_HOOK_SEND_EMAIL_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
+    networks:
+      - test-network
 
   meta:
     container_name: supabase-meta
@@ -250,6 +254,8 @@ services:
         "-c",
         "log_min_messages=fatal" # prevents Realtime polling queries from appearing in logs
       ]
+    networks:
+      - test-network
 
 volumes:
   supabase-db-config:


### PR DESCRIPTION
## PR の目的
- docker-compose -supabase-test.ymlで間違っていた部分を修正しました。

## 経緯・意図・意思決定
- supabase-dbのポートを5432番に直し、docker-compose-supabase-local.ymlと同じになるようにしました。
- testapiコンテナにある環境変数 TESTDB_HOST: testdbを追加しました。