### PR TITLE
refresh_access_token in supabase

### DIFF
--- a/api/app/auth/supabase_auth_module.py
+++ b/api/app/auth/supabase_auth_module.py
@@ -1,7 +1,8 @@
 import os
 
-from app.auth.auth_module import AuthModule
 from supabase import create_client
+
+from app.auth.auth_module import AuthModule
 
 from ..schemas import Token
 

--- a/api/app/auth/supabase_auth_module.py
+++ b/api/app/auth/supabase_auth_module.py
@@ -1,8 +1,7 @@
 import os
 
-from supabase import create_client
-
 from app.auth.auth_module import AuthModule
+from supabase import create_client
 
 from ..schemas import Token
 
@@ -34,7 +33,13 @@ class SupabaseAuthModule(AuthModule):
         )
 
     def refresh_access_token(self, refresh_token) -> Token:
-        return Token(access_token="", token_type="bearer", refresh_token="")
+        session_data = self.supabase.auth.get_session()
+        session = session_data.model_dump()
+        return Token(
+            access_token=session.get("access_token"),
+            token_type="bearer",
+            refresh_token=session.get("refresh_token"),
+        )
 
     def check_and_get_user_info(self, token):
         super().check_token(token)


### PR DESCRIPTION
## PR の目的
- [Post /auth/refresh] APIのSupabase側が未実装であったため、実装した

## 経緯・意図・意思決定
このAPIはUIで使われておらず、scriptsで使われているため、後回しにしていた

## 参考文献
https://supabase.com/docs/reference/python/auth-getsession
> If the session has an expired access token, this method will use the refresh token to get a new session.
