### PR TITLE
replace depreacted settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
     "python.languageServer": "Pylance",
 
     "black-formatter.args": ["--config", "api/pyproject.toml"],
-    "ruff.lint.args": ["--config", "api/pyproject.toml"],
+    "ruff.configuration": "api/pyproject.toml",
     //"ruff.fixAll": true,
     "files.insertFinalNewline": true,
     "editor.formatOnSave": true


### PR DESCRIPTION
## PR の目的

vscode用のruff設定がdeprecatedのものになっており、pyproject.toml の設定が反映されていなかったので修正する


## 経緯・意図・意思決定

`ruff.lint.args` はdeprecatedのため、 `ruff.configuration` に変更する
https://docs.astral.sh/ruff/editors/migration/#examples


## 参考文献
https://docs.astral.sh/ruff/editors/migration/#migrating-from-ruff-lsp
