### PR TITLE
bugfix/fix firebase tests

### DIFF
--- a/docker-compose-firebase-test.yml
+++ b/docker-compose-firebase-test.yml
@@ -23,6 +23,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_HOST: testdb
+      TESTDB_HOST: testdb
       DB_PORT: 5432
       DB_SCHEMA: postgres
       SYSTEM_EMAIL: ic-metemcyber@example.com

--- a/testapi.sh
+++ b/testapi.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-docker compose -f docker-compose-test.yml up --build -d
-docker compose -f docker-compose-test.yml exec testapi pytest -vv app/tests/ # --cov --cov-branch --cov-report=term-missing --cov-config=app/tests/.coveragerc
-docker compose -f docker-compose-test.yml down -v
+docker compose -f docker-compose-firebase-test.yml up --build -d
+docker compose -f docker-compose-firebase-test.yml exec testapi pytest -vv app/tests/ # --cov --cov-branch --cov-report=term-missing --cov-config=app/tests/.coveragerc
+docker compose -f docker-compose-firebase-test.yml down -v


### PR DESCRIPTION
## PR の目的
- testapi.shを実行した際に、エラーが出る問題を修正しました

## 経緯・意図・意思決定
- testapi.sh
  - 実行するファイル名を`docker-compose-test.yml`から`docker-compose-firebase-test.yml`に変更しました。
- docker-compose-firebase-test.yml
  - testapiコンテナの環境変数にTESTDB_HOST: testdbが抜けていたので、追加しました

