### PR TITLE
Fix/do not set force refresh

### DIFF
--- a/web/src/utils/Firebase.js
+++ b/web/src/utils/Firebase.js
@@ -1,5 +1,5 @@
 import { initializeApp } from "firebase/app";
-import { getAuth, connectAuthEmulator, SAMLAuthProvider } from "firebase/auth";
+import { connectAuthEmulator, getAuth, SAMLAuthProvider } from "firebase/auth";
 
 class Firebase {
   constructor() {

--- a/web/src/utils/Firebase.js
+++ b/web/src/utils/Firebase.js
@@ -48,7 +48,7 @@ class Firebase {
   }
 
   async getBearerToken() {
-    return await this.getAuth()?.currentUser?.getIdToken(true);
+    return await this.getAuth()?.currentUser?.getIdToken();
   }
 }
 


### PR DESCRIPTION
## PR の目的
getIdToken の引数 forceRefreshにtrueを指定しないことで、リクエストごとにfirebaseにトークン更新のリクエストが発生することを防ぐ

経緯・意図・意思決定
firebaseへのリクエストが  `auth/quota-exceeded` と表示され、APIへのリクエストができなくなる事象が発生
![image](https://github.com/user-attachments/assets/cae0af60-fe2a-4272-b40e-2f41a18cde4c)

調査した結果、`getIdToken(True)` (forcerefresh=True)と指定すると、リフレッシュトークンを利用したアクセストークンの更新が毎回発生するため、
大量のfirebaseへのリクエストが発生することが判明。

getIdToken ではtrueを指定しなくてもアクセストークンがExpireしたら更新処理が走ると思われるため、forcerefreshの指定を削除する
https://stackoverflow.com/questions/74344333/best-practice-to-get-users-idtoken-from-firebase-using-getidtoken-forceref
https://firebase.google.com/docs/reference/js/v8/firebase.User#getidtoken 

## 参考文献
https://stackoverflow.com/questions/74344333/best-practice-to-get-users-idtoken-from-firebase-using-getidtoken-forceref
https://firebase.google.com/docs/reference/js/v8/firebase.User#getidtoken 
https://zenn.dev/yuta4j1/scraps/1c1ba3663a9a15
https://github.com/firebase/firebase-js-sdk/blob/main/packages/auth/src/core/user/token_manager.ts#L76-L96