### PR TITLE
bugfix/change Variable Names

### DIFF
--- a/docker-compose-supabase-local.yml
+++ b/docker-compose-supabase-local.yml
@@ -101,7 +101,7 @@ services:
       retries: 3
     environment:
       STUDIO_PG_META_URL: http://meta:8080
-      POSTGRES_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      POSTGRES_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
 
       DEFAULT_ORGANIZATION_NAME: Default Organization
       DEFAULT_PROJECT_NAME: Default Project
@@ -165,7 +165,7 @@ services:
       API_EXTERNAL_URL: http://localhost:8000
 
       GOTRUE_DB_DRIVER: postgres
-      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_DB_PASSWORD}@supabase-db:5432/postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_POSTGRES_PASSWORD}@supabase-db:5432/postgres
 
       GOTRUE_SITE_URL: http://localhost:3000
       GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
@@ -233,7 +233,7 @@ services:
       PG_META_DB_PORT: 5432
       PG_META_DB_NAME: postgres
       PG_META_DB_USER: supabase_admin
-      PG_META_DB_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      PG_META_DB_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
 
   supabase-db:
     container_name: supabase-db
@@ -266,8 +266,8 @@ services:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: 5432
       POSTGRES_PORT: 5432
-      PGPASSWORD: ${SUPABASE_DB_PASSWORD}
-      POSTGRES_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      PGPASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
       PGDATABASE: postgres
       POSTGRES_DB: postgres
       JWT_SECRET: ${JWT_SECRET}

--- a/docker-compose-supabase-test.yml
+++ b/docker-compose-supabase-test.yml
@@ -72,7 +72,7 @@ services:
       retries: 3
     environment:
       STUDIO_PG_META_URL: http://meta:8080
-      POSTGRES_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      POSTGRES_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
 
       DEFAULT_ORGANIZATION_NAME: Default Organization
       DEFAULT_PROJECT_NAME: Default Project
@@ -138,7 +138,7 @@ services:
       API_EXTERNAL_URL: http://localhost:8000
 
       GOTRUE_DB_DRIVER: postgres
-      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_DB_PASSWORD}@supabase-db:5432/postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${SUPABASE_POSTGRES_PASSWORD}@supabase-db:5432/postgres
 
       GOTRUE_SITE_URL: http://localhost:3000
       GOTRUE_URI_ALLOW_LIST: ${ADDITIONAL_REDIRECT_URLS}
@@ -208,7 +208,7 @@ services:
       PG_META_DB_PORT: 5432
       PG_META_DB_NAME: postgres
       PG_META_DB_USER: supabase_admin
-      PG_META_DB_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      PG_META_DB_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
 
   supabase-db:
     container_name: supabase-db
@@ -241,8 +241,8 @@ services:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: 5432
       POSTGRES_PORT: 5432
-      PGPASSWORD: ${SUPABASE_DB_PASSWORD}
-      POSTGRES_PASSWORD: ${SUPABASE_DB_PASSWORD}
+      PGPASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${SUPABASE_POSTGRES_PASSWORD}
       PGDATABASE: postgres
       POSTGRES_DB: postgres
       JWT_SECRET: ${JWT_SECRET}


### PR DESCRIPTION
## PR の目的
- .env.supabase.exampleとdocker-compseファイルにある環境変数名が一致していないため修正しました

## 経緯・意図・意思決定
- `SUPABASE_DB_PASSWORD`を`SUPABASE_POSTGRES_PASSWORD`に修正しました