### PR TITLE
support OAuth login -- supabase + keycloak

### DIFF
--- a/web/.env.supabase.example
+++ b/web/.env.supabase.example
@@ -1,9 +1,9 @@
 VITE_PUBLIC_URL=
 VITE_API_BASE_URL=http://localhost/api
-VITE_METEMCYBER_AUTH_URL=
 VITE_SYSTEM_EMAIL=
 
 VITE_AUTH_SERVICE=supabase
+VITE_KEYCLOAK_ENABLED=false
 
 # SUPABASE_URL: URL which the kong container (not auth container) listens to
 VITE_SUPABASE_URL=http://localhost:8000

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -10,6 +10,7 @@ import {
   AcceptPTeamInvitation,
   Account,
   App,
+  AuthKeycloakCallback,
   EmailVerification,
   Login,
   ResetPassword,
@@ -50,9 +51,10 @@ root.render(
             >
               <Routes>
                 <Route exact path="/login" element={<Login />} />
+                <Route path="/auth_keycloak_callback" element={<AuthKeycloakCallback />} />
+                <Route path="/email_verification" element={<EmailVerification />} />
                 <Route path="/reset_password" element={<ResetPassword />} />
                 <Route path="/sign_up" element={<SignUp />} />
-                <Route path="/email_verification" element={<EmailVerification />} />
                 <Route path="/" element={<App />}>
                   <Route index element={<Status />} />
                   <Route path="account">

--- a/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.jsx
+++ b/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.jsx
@@ -1,0 +1,77 @@
+import { Link, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useCreateUserMutation, useTryLoginMutation } from "../../services/tcApi";
+import { setAuthUserIsReady } from "../../slices/auth";
+import Supabase from "../../utils/Supabase";
+import { rootPrefix } from "../../utils/const";
+import { errorToString } from "../../utils/func";
+
+/* Note: currently, work with supabase only. */
+const supabase =
+  import.meta.env.VITE_AUTH_SERVICE === "supabase" ? Supabase.getClient() : undefined;
+
+export function AuthKeycloakCallback() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [message, setMessage] = useState("Now checking AuthCode...");
+  const redirectedFrom = useSelector((state) => state.auth.redirectedFrom);
+
+  const params = new URLSearchParams(location.search);
+
+  const [tryLogin] = useTryLoginMutation();
+  const [createUser] = useCreateUserMutation();
+
+  useEffect(() => {
+    const _checkSessionAndNavigateToInternalPage = async () => {
+      const navigateTo = {
+        pathname: redirectedFrom.from || "/",
+        search: redirectedFrom.search ?? "",
+      };
+      const { data, error } = await supabase.auth.getSession();
+      if (!data?.session) {
+        console.log(error);
+        setMessage(`Cannot get session: ${error?.message}`);
+        return;
+      }
+      try {
+        await tryLogin()
+          .unwrap()
+          .catch(async (error) => {
+            switch (error.data?.detail) {
+              case "No such user": {
+                await createUser({})
+                  .unwrap()
+                  .catch((error2) => {
+                    throw new Error(`Cannot create user: ${errorToString(error2)}`);
+                  });
+                if (navigateTo.pathname === "/") {
+                  navigateTo.pathname = "/account";
+                  navigateTo.search = "";
+                }
+                break;
+              }
+              default:
+                throw new Error(`Something went wrong: ${errorToString(error)}`);
+            }
+          });
+      } catch (error) {
+        setMessage(error.message);
+        console.error(error);
+        return;
+      }
+      navigate(navigateTo);
+    };
+    _checkSessionAndNavigateToInternalPage();
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, []);
+
+  return (
+    <>
+      <Typography>{message}</Typography>
+      <Link href={`${rootPrefix}/login`}>Back to login</Link>
+    </>
+  );
+}

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -1,6 +1,7 @@
 import { AcceptPTeamInvitation } from "./AcceptPTeamInvitation/AcceptPTeamInvitationPage";
 import { Account } from "./Account/AccountPage";
 import { App } from "./App/AppPage";
+import { AuthKeycloakCallback } from "./AuthKeycloakCallback/AuthKeycloakCallbackPage";
 import { EmailVerification } from "./EmailVerification/EmailVerificationPage";
 import { Login } from "./Login/LoginPage";
 import { PTeam } from "./PTeam/PTeamPage";
@@ -15,6 +16,7 @@ export {
   AcceptPTeamInvitation,
   Account,
   App,
+  AuthKeycloakCallback,
   EmailVerification,
   Login,
   PTeam,

--- a/web/src/providers/auth/AuthContext.jsx
+++ b/web/src/providers/auth/AuthContext.jsx
@@ -14,6 +14,7 @@ export function AuthProvider(props) {
   const createUserWithEmailAndPassword = authProvider.createUserWithEmailAndPassword;
   const signInWithEmailAndPassword = authProvider.signInWithEmailAndPassword;
   const signInWithSamlPopup = authProvider.signInWithSamlPopup;
+  const signInWithRedirect = authProvider.signInWithRedirect;
   const signOut = authProvider.signOut;
   const sendEmailVerification = authProvider.sendEmailVerification;
   const sendPasswordResetEmail = authProvider.sendPasswordResetEmail;
@@ -27,6 +28,7 @@ export function AuthProvider(props) {
         createUserWithEmailAndPassword,
         signInWithEmailAndPassword,
         signInWithSamlPopup,
+        signInWithRedirect,
         signOut,
         sendEmailVerification,
         sendPasswordResetEmail,

--- a/web/src/providers/auth/AuthProvider.js
+++ b/web/src/providers/auth/AuthProvider.js
@@ -26,6 +26,10 @@ export class AuthProvider {
   async signInWithSamlPopup() {
     throw new Error("Not implemented");
   }
+  async signInWithRedirect() {
+    // for OAuth
+    throw new Error("Not implemented");
+  }
   async signOut() {
     throw new Error("Not implemented");
   }

--- a/web/src/providers/auth/SupabaseProvider.js
+++ b/web/src/providers/auth/SupabaseProvider.js
@@ -67,9 +67,25 @@ export class SupabaseProvider extends AuthProvider {
       });
   }
 
-  async signInWithSamlPopup() {
-    // TODO
-    throw new Error("Not implemented");
+  async signInWithRedirect({ provider, redirectTo }) {
+    let options = { redirectTo };
+    switch (provider) {
+      case "keycloak":
+        options["scopes"] = "openid";
+        break;
+      default:
+        throw new Error(`Implementation error. not defined provider: ${provider}`);
+    }
+    await supabase.auth
+      .signInWithOAuth({ provider, options })
+      .then((result) => {
+        if (result.error) {
+          throw new SupabaseAuthError(result.error);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   }
 
   async sendPasswordResetEmail({ email, redirectTo }) {


### PR DESCRIPTION
## PR の目的

- supabase + keycloak 構成での OAuth 認証機能を実装
  - 有効化するには `web/.env` に `VITE_KEYCLOAK_ENABLED=true` を設定する
  - redirectTo は `window.location.origin` をベースにしているので調整不要
    - 当然ながら、docker-compose.yml や keycloak 側に適切な設定を行う必要はある
  - 従来の SAML 連携ボタンの置き換えではなく追加の形式
    - 今後、keycloak 以外の provider のサポート追加も踏まえた形
    - firebase での OAuth 認証との共存については未対応（firebase 側が未調査のため）
      - 抽象化層の関数名は他と合わせて firebase api の名称（signInWithRedirect）にしてある

### 既知の不具合
- Keycloak 認証を行った場合、ログイン直後の自動ページ遷移が機能しない
  - 例えば、pteam invitation リンクにアクセス → 未ログインなのでログインページに自動遷移 → keycloak 認証 → Tc ログインと同時に pteam invitation ページに自動遷移、のケースで最後の自動遷移が機能しない
  - 自動遷移すべき対象は auth slice に格納しているが、keycloak へのリダイレクトを挟むことで slice データがクリアされているのではないか、と疑っている（詳細は未確認）
