### PR TITLE
Topic/added service name change

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -167,16 +167,25 @@ def update_pteam_service(
 ):
     """
     Update params of the pteam service.
-
+    - service_name
+      * max length: 255 in half-width or 127 in full-width
     - keywords
       * max number: 5
       * max length: 20 in half-width or 10 in full-width
     - description
       * max length: 300 in half-width or 150 in full-width
     """
+    max_service_name_length_in_half = 255
     max_keywords = 5
     max_keyword_length_in_half = 20
     max_description_length_in_half = 300
+    error_too_long_service_name = HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+            f"Too long service name. Max length is {max_service_name_length_in_half} in half-width "
+            f"or {int(max_service_name_length_in_half / 2)} in full-width"
+        ),
+    )
     error_too_many_keywords = HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail=f"Too many keywords, max number: {max_keywords}",
@@ -206,6 +215,11 @@ def update_pteam_service(
         raise NOT_A_PTEAM_MEMBER
 
     update_data = data.model_dump(exclude_unset=True)
+    if "service_name" in update_data.keys() and data.service_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot specify None for service_name",
+        )
     if "keywords" in update_data.keys() and data.keywords is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -249,6 +263,21 @@ def update_pteam_service(
         ):
             raise error_too_long_keyword
         service.keywords = sorted(fixed_words)
+    if data.service_name is not None:
+        update_service_name = data.service_name.strip()
+        if (
+            count_full_width_and_half_width_characters(update_service_name)
+            > max_service_name_length_in_half
+        ):
+            raise error_too_long_service_name
+
+        for service in pteam.services:
+            if service.service_name == update_service_name:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Service name already exists in the same team",
+                )
+        service.service_name = update_service_name
 
     need_fix_tickets = False
 

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -271,8 +271,8 @@ def update_pteam_service(
         ):
             raise error_too_long_service_name
 
-        for service in pteam.services:
-            if service.service_name == update_service_name:
+        for _service in pteam.services:
+            if _service.service_name == update_service_name:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Service name already exists in the same team",

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -116,6 +116,7 @@ class PTeamServiceResponse(ORMModel):
 
 
 class PTeamServiceUpdateRequest(ORMModel):
+    service_name: str | None = None
     description: str | None = None
     keywords: list[str] | None = None
     system_exposure: SystemExposureEnum | None = None
@@ -124,6 +125,7 @@ class PTeamServiceUpdateRequest(ORMModel):
 
 
 class PTeamServiceUpdateResponse(ORMModel):
+    service_name: str
     description: str | None
     keywords: list[str]
     system_exposure: SystemExposureEnum | None


### PR DESCRIPTION
## PR の目的
- update_pteam_serviceにサービス名を変更できる機能を追加しました

## 経緯・意図・意思決定

- api/app/routers/pteams.py
  - service_nameを変更できるようにしました
  - 文字数制限は半角255文字にしています。( sbomファイルアップロードしてサービス名を決める時の制限文字数と同じです)
  - 同一チーム内でサービス名が被った時、エラーが出るようにしています。
- api/app/schemas.py
   - PTeamServiceUpdateRequestとPTeamServiceUpdateResponseにservice_nameを追加しました

- テスト
  - 以下3つのテストを追加しました
    -  test_length_of_service_name
      - サービス名の文字数制限を半角、全角で検証しています。
    - test_it_should_return_200_when_service_name_is_not_specify
      - requestでservice_nameが指定されなかったとき、既存のservice_nameがresponseで返ってくるか検証しています。
    - test_it_should_return_400_when_naming_the_same_service_in_the_same_pteam
      - 同一チームにあるservice_nameと被った時、エラーが出るか検証しています。