### PR TITLE
Fix/UI warnings

### DIFF
--- a/web/src/pages/Tag/TopicTables/TopicTableRow.jsx
+++ b/web/src/pages/Tag/TopicTables/TopicTableRow.jsx
@@ -1,3 +1,4 @@
+import { TableCell, TableRow } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -14,6 +15,14 @@ import { errorToString } from "../../../utils/func";
 import { isRelatedAction } from "../../../utils/topicUtils.js";
 
 import { TopicTableRowView } from "./TopicTableRowView.jsx";
+
+function SimpleCell(value = "") {
+  return (
+    <TableRow>
+      <TableCell>{value}</TableCell>
+    </TableRow>
+  );
+}
 
 export function TopicTableRow(props) {
   const { pteamId, serviceId, tagId, topicId, references } = props;
@@ -61,21 +70,22 @@ export function TopicTableRow(props) {
     { skip: skipByAuth || skipByPTeamId || skipByServiceId || skipByTopicId || skipBytagId },
   );
 
-  if (skipByAuth || skipByPTeamId || skipByServiceId || skipByTopicId || skipBytagId) return <></>;
+  if (skipByAuth || skipByPTeamId || skipByServiceId || skipByTopicId || skipBytagId)
+    return SimpleCell("");
   if (allTagsError) throw new APIError(errorToString(allTagsError), { api: "getAllTags" });
-  if (allTagsIsLoading) return <>Now loading allTags...</>;
+  if (allTagsIsLoading) return SimpleCell("Now loading allTags...");
   if (membersError) throw new APIError(errorToString(membersError), { api: "getPTeamMembers" });
-  if (membersIsLoading) return <>Now loading PTeamMembers...</>;
+  if (membersIsLoading) return SimpleCell("Now loading PTeamMembers...");
   if (topicError) throw new APIError(errorToString(topicError), { api: "getTopic" });
-  if (topicIsLoading) return <>Now loading Topic...</>;
+  if (topicIsLoading) return SimpleCell("Now loading Topic...");
   if (pteamTopicActionsError)
     throw new APIError(errorToString(pteamTopicActionsError), { api: "getPTeamTopicActions" });
-  if (pteamTopicActionsIsLoading) return <>Now loading topicActions...</>;
+  if (pteamTopicActionsIsLoading) return SimpleCell("Now loading topicActions...");
   if (ticketsRelatedToServiceTopicTagError)
     throw new APIError(errorToString(ticketsRelatedToServiceTopicTagError), {
       api: "getTicketsRelatedToServiceTopicTag",
     });
-  if (ticketsRelatedToServiceTopicTagIsLoading) return <>Now loading tickets...</>;
+  if (ticketsRelatedToServiceTopicTagIsLoading) return SimpleCell("Now loading tickets...");
 
   const currentTagDict = allTags.find((tag) => tag.tag_id === tagId);
   const topicActions = pteamTopicActionsData.actions?.filter(

--- a/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
@@ -1,3 +1,4 @@
+import { TableCell, TableRow } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -14,6 +15,14 @@ import { errorToString } from "../../utils/func";
 import { pickAffectedVersions } from "../../utils/topicUtils";
 
 import { VulnerabilityDrawerView } from "./VulnerabilityDrawerView";
+
+function SimpleCell(value = "") {
+  return (
+    <TableRow>
+      <TableCell>{value}</TableCell>
+    </TableRow>
+  );
+}
 
 export function VulnerabilityDrawer(props) {
   const { open, setOpen, pteamId, serviceId, serviceTagId, topicId } = props;
@@ -47,16 +56,16 @@ export function VulnerabilityDrawer(props) {
     isLoading: topicActionsIsLoading,
   } = useGetTopicActionsQuery(topicId, { skip });
 
-  if (skip) return <></>;
+  if (skip) return SimpleCell("");
   if (pteamError) throw new APIError(errorToString(pteamError), { api: "getPTeam" });
   if (serviceTagError) throw new APIError(errorToString(serviceTagError), { api: "getTag" });
   if (topicError) throw new APIError(errorToString(topicError), { api: "getTopic" });
   if (topicActionsError)
     throw new APIError(errorToString(topicActionsError), { api: "getTopicActions" });
-  if (pteamIsLoading) return <>Now loading PTeam...</>;
-  if (serviceTagIsLoading) return <>Now loading Tag...</>;
-  if (topicIsLoading) return <>Now loading Topic...</>;
-  if (topicActionsIsLoading) return <>Now loading TopicActions...</>;
+  if (pteamIsLoading) return SimpleCell("Now loading PTeam...");
+  if (serviceTagIsLoading) return SimpleCell("Now loading Tag...");
+  if (topicIsLoading) return SimpleCell("Now loading Topic...");
+  if (topicActionsIsLoading) return SimpleCell("Now loading TopicActions...");
 
   const service = pteam.services.find((service) => service.service_id === serviceId);
   if (!service) throw new Error("No such service.");

--- a/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
@@ -40,7 +40,7 @@ export function VulnerabilityDrawerView(props) {
             <KeyboardDoubleArrowRightIcon fontSize="inherit" />
           </IconButton>
         </Tooltip>
-        <Link onClick={() => navigate(hrefToFullPage)} preventScrollReset={true}>
+        <Link onClick={() => navigate(hrefToFullPage)} preventscrollreset="true">
           <Tooltip title="Open in full page">
             <IconButton size="large">
               <OpenInFullIcon />

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -24,8 +24,6 @@ import { ArtifactTagView } from "../../components/ArtifactTagView";
 export function VulnerabilityView(props) {
   const { topic, topicActions, matchedTopicTag, service } = props;
 
-  window.scrollTo({ top: 0, behavior: "instant" });
-
   return (
     <>
       {/* Artifact Tag */}


### PR DESCRIPTION
## PR の目的

- 以下の warning に対処した
  ```
  Warning: validateDOMNesting(...): Text nodes cannot appear as a child of <tbody>.
  TopicTableRow@http://artemis.soum.co.jp:5173/src/pages/Tag/TopicTables/TopicTableRow.jsx?t=1741663615492:41:64
  ```
  ```
  Warning: validateDOMNesting(...): Text nodes cannot appear as a child of <tbody>.
  VulnerabilityDrawer@http://artemis.soum.co.jp:5173/src/pages/Vulnerability/VulnerabilityDrawer.jsx?t=1741663680092:42:74
  ```
  ```
  Warning: React does not recognize the `preventScrollReset` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `preventscrollreset` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
  ```
  ```
  Warning: Received `true` for a non-boolean attribute `preventscrollreset`.
  If you want to write it to the DOM, pass a string instead: preventscrollreset="true" or preventscrollreset={value.toString()}.
  ```
  - SimpleCell については共通化も考えたが、呼び出し側が何を期待しているのかは case by case なので、よほど多用されない限りは共通化しなくてよいと考えている。
  - preventscrollreset については公式ドキュメントに記載が見つからないので、warning の内容に従っている。
    - 動作的には（本対応の有無・preventscrollreset 設定の有無に関わらず）スクロール位置はリセットされない（されるケースに遭遇していない）。
- 不要な window.scrollTo があったので、ついでに削除。