### PR TITLE
fix providesTags id in getTag

### DIFF
--- a/web/src/pages/TopicDetail/TopicDetailPage.jsx
+++ b/web/src/pages/TopicDetail/TopicDetailPage.jsx
@@ -1,21 +1,9 @@
 import {
   KeyboardArrowUp as KeyboardArrowUpIcon,
   KeyboardArrowDown as KeyboardArrowDownIcon,
-  Recommend as RecommendIcon,
-  Warning as WarningIcon,
 } from "@mui/icons-material";
-import {
-  Avatar,
-  Badge,
-  Box,
-  Button,
-  Card,
-  Chip,
-  MenuItem,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { green, grey, yellow } from "@mui/material/colors";
+import { Avatar, Badge, Box, Button, Card, Chip, MenuItem, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -26,7 +14,6 @@ import { useGetTopicActionsQuery, useGetTopicQuery } from "../../services/tcApi"
 import { APIError } from "../../utils/APIError";
 import { cvssProps } from "../../utils/const";
 import { errorToString, cvssConvertToName } from "../../utils/func";
-import { pickAffectedVersions } from "../../utils/topicUtils";
 
 import { TopicSSVCCards } from "./TopicSSVCCards";
 

--- a/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
@@ -12,7 +12,6 @@ import {
 import { APIError } from "../../utils/APIError";
 import { rootPrefix } from "../../utils/const";
 import { errorToString } from "../../utils/func";
-import { pickAffectedVersions } from "../../utils/topicUtils";
 
 import { VulnerabilityDrawerView } from "./VulnerabilityDrawerView";
 

--- a/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
@@ -1,29 +1,9 @@
-import { Recommend as RecommendIcon, Warning as WarningIcon } from "@mui/icons-material";
 import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
 import OpenInFullIcon from "@mui/icons-material/OpenInFull";
-import {
-  Box,
-  Breadcrumbs,
-  Card,
-  Chip,
-  Drawer,
-  IconButton,
-  Link,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { green, yellow } from "@mui/material/colors";
+import { Box, Drawer, IconButton, Link, Stack, Tooltip, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
-
-import { ActionTypeIcon } from "../../components/ActionTypeIcon";
-import { ArtifactTagView } from "../../components/ArtifactTagView";
+import { useNavigate } from "react-router-dom";
 
 import { VulnerabilityView } from "./VulnerabilityView";
 

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -1,26 +1,8 @@
-import { Recommend as RecommendIcon, Warning as WarningIcon } from "@mui/icons-material";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
-import {
-  Box,
-  Breadcrumbs,
-  Card,
-  Chip,
-  Link,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { green, yellow } from "@mui/material/colors";
+import { Box, Breadcrumbs, Link, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
-
-import { ActionTypeIcon } from "../../components/ActionTypeIcon";
-import { ArtifactTagView } from "../../components/ArtifactTagView";
+import { useNavigate } from "react-router-dom";
 
 import { VulnerabilityView } from "./VulnerabilityView";
 

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -1,22 +1,15 @@
-import { Recommend as RecommendIcon, Warning as WarningIcon } from "@mui/icons-material";
-import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import {
   Box,
-  Breadcrumbs,
   Card,
   Chip,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
-  Stack,
-  Tooltip,
   Typography,
 } from "@mui/material";
-import { green, yellow } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import React from "react";
-import { useParams } from "react-router-dom";
 
 import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { ArtifactTagView } from "../../components/ArtifactTagView";

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -319,7 +319,6 @@ export const tcApi = createApi({
       query: (tagId) => ({
         url: `tags/${tagId}`,
       }),
-      providesTags: (result, error, tagId) => [{ type: "Tag", id: "ALL" }],
     }),
 
     createTag: builder.mutation({

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -319,7 +319,7 @@ export const tcApi = createApi({
       query: (tagId) => ({
         url: `tags/${tagId}`,
       }),
-      providesTags: (result, error, tagId) => [{ type: "Tag", id: tagId }],
+      providesTags: (result, error, tagId) => [{ type: "Tag", id: "ALL" }],
     }),
 
     createTag: builder.mutation({


### PR DESCRIPTION
## PR の目的
- PR#618において、tcApiにgetTagを追加したが、その際に指定したRTKクエリのTagが不要であったため削除する
  - ID指定でGetするため、他のIDのTagを生成するAPIの影響は受けない
  - 今後、updateTagのようなAPIが追加された場合、updateTag、getTagに{ type: "Tag", id: tagId }が必要になるが、必要になるまではTagを付けない方針
  - tcApiにgetTagを追加したため、下記を更新した
https://docs.google.com/spreadsheets/d/1PwlbM1CkC3XV7GF59FmIu8VVxvlaGUGZnAt_5gOnahg/edit?gid=1370518515#gid=1370518515
- PR#618において、コンポーネント分割時に不要なimportが残っていたため、削除する