### PR TITLE
change !!pteamId to !pteamId in the skip condition

### DIFF
--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -32,7 +32,7 @@ export function PTeamServiceDelete(props) {
   const params = new URLSearchParams(location.search);
   const serviceId = params.get("serviceId");
 
-  const skip = useSkipUntilAuthUserIsReady() || !!pteamId;
+  const skip = useSkipUntilAuthUserIsReady() || !pteamId;
   const {
     data: pteam,
     error: pteamError,


### PR DESCRIPTION
## PR の目的
- Delete Servicesモーダルの中身が表示されなくなっていた現象を修正

## 経緯・意図・意思決定
- web/src/pages/Status/PTeamServiceDelete.jsxにてskipが真の時の処理が実行され、returnの中身がレンダリングされていなかったため
   - pages/Status/PTeamServiceDelete.jsxにてpteamIdが存在するときにskipが真になるように設計されていた
      - const skip = useSkipUntilAuthUserIsReady() || !!pteamId;と設計されていた
      - !!pteamIdを!pteamIdに変更
   - 以前の以下のPRにて誤って!!pteamIdに変更されていた
      - https://github.com/nttcom/threatconnectome/pull/568
