### PR TITLE
Fix demo script

### DIFF
--- a/demo/files.d/.env
+++ b/demo/files.d/.env
@@ -1,13 +1,9 @@
+###### Threatconnectome
 WEBUI_URL=http://localhost
 DB_USER=postgres
 DB_PASSWORD=your_secret_password
-DB_HOST=db
-DB_PORT=5432
-DB_SCHEMA=postgres
-# firebase api key: any string is ok for emulator
-FIREBASE_API_KEY=firebase-emulator-api-key
-# fake_firebase_credentilas.json will be generated in demo_setup.sh
-FIREBASE_CRED=/key/firebase_credentials.json
-# firebase auth emulator host should be overridden in docker-compose-demo.yml
-FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
 SYSTEM_EMAIL=
+SENDGRID_API_KEY=
+
+###### Firebase
+FIREBASE_API_KEY=

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -14,11 +14,19 @@ services:
         condition: service_started
       db:
         condition: service_healthy
-    env_file:
-      - ./.env
     environment:
-      - AUTH_SERVICE=FIREBASE
-      - FIREBASE_AUTH_EMULATOR_HOST=firebase:9099 # use firebase auth emulator
+      WEBUI_URL: ${WEBUI_URL}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_SCHEMA: postgres
+      SYSTEM_EMAIL: ${SYSTEM_EMAIL}
+      SENDGRID_API_KEY: ${SENDGRID_API_KEY}
+      AUTH_SERVICE: FIREBASE
+      FIREBASE_API_KEY: ${FIREBASE_API_KEY}
+      FIREBASE_CRED: /key/firebase_credentials.json
+      FIREBASE_AUTH_EMULATOR_HOST: firebase:9099 # use firebase auth emulator
     labels:
       - traefik.http.routers.api.entrypoints=http
       - traefik.http.routers.api.priority=10


### PR DESCRIPTION
## PR の目的
- 機能追加の場合
  - 現在の実装に合わせ、デモ用の.envファイルから機密性の高いもの以外はdocker-compose-demo.yml内に定義するよう変更
  - 上記にともないdocker-compose-demo.yml上でコンテナに.envファイルを読み込む設定を削除し、enviromentに直接定義するように変更
 
  - ./demo_start.shでfirebaseのデモ環境が立ち上がることを確認
  - 下記の手順で、デモ環境用データの入ったsupabase環境を作成できることを確認
    - ./demo_start.sh を実行
    - UIを操作し、pteamへの招待URLを発行 
    - ./demo_stop.sh を実行
    - (必要ならば)supabase用の環境変数を設定 (cp .env.supabase.example .env および cp .env.supabase.example .env)
    - docker compose -f docker-compose-supabase-local.yml up -d --build
    - http://localhost:8000/にアクセスして、AuthenticaitonメニューからAdd userでユーザを作成
    - 作成したユーザでログインした後、事前にはこうしておいた招待URLを用いてデモ環境用のpteamに入る
