### PR TITLE
topic/add a preview function for uploaded images

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
@@ -7,8 +7,16 @@ import DialogTitle from "@mui/material/DialogTitle";
 import PropTypes from "prop-types";
 import React from "react";
 
+const noImageAvailableUrl = "images/720x480.png";
+
 export function DeleteServiceImageAlertDialog(props) {
-  const { isDeleteDialogOpen, setIsDeleteDialogOpen, setImageFileData, setImageDeleteFlag } = props;
+  const {
+    isDeleteDialogOpen,
+    setIsDeleteDialogOpen,
+    setImageFileData,
+    setImageDeleteFlag,
+    setImagePreview,
+  } = props;
 
   const handleCloseCancel = () => {
     setIsDeleteDialogOpen(false);
@@ -18,6 +26,7 @@ export function DeleteServiceImageAlertDialog(props) {
     setIsDeleteDialogOpen(false);
     setImageFileData(null);
     setImageDeleteFlag(true);
+    setImagePreview(noImageAvailableUrl);
   };
 
   return (
@@ -43,4 +52,5 @@ DeleteServiceImageAlertDialog.propTypes = {
   setIsDeleteDialogOpen: PropTypes.func,
   setImageFileData: PropTypes.func,
   setImageDeleteFlag: PropTypes.func,
+  setImagePreview: PropTypes.func,
 };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
@@ -5,9 +5,12 @@ import {
   useUpdatePTeamServiceMutation,
   useUpdatePTeamServiceThumbnailMutation,
   useDeletePTeamServiceThumbnailMutation,
+  useGetPTeamServiceThumbnailQuery,
 } from "../../../services/tcApi";
 
 import { PTeamServiceDetailsSettingsView } from "./PTeamServiceDetailsSettingsView";
+
+const noImageAvailableUrl = "images/720x480.png";
 
 export function PTeamServiceDetailsSettings(props) {
   const { pteamId, service } = props;
@@ -39,12 +42,25 @@ export function PTeamServiceDetailsSettings(props) {
     }).unwrap();
   };
 
+  const {
+    data: thumbnail,
+    isError: thumbnailIsError,
+    isLoading: thumbnailIsLoading,
+  } = useGetPTeamServiceThumbnailQuery({
+    pteamId,
+    serviceId: service.service_id,
+  });
+
+  const image =
+    thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageAvailableUrl : thumbnail;
+
   return (
     <PTeamServiceDetailsSettingsView
       service={service}
       updatePTeamServiceFunc={updatePTeamServiceFunc}
       updatePTeamServiceThumbnailFunc={updatePTeamServiceThumbnailFunc}
       deletePTeamServiceThumbnailFunc={deletePTeamServiceThumbnailFunc}
+      image={image}
     />
   );
 }

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -16,7 +16,7 @@ import {
 } from "@mui/material";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { errorToString } from "../../../utils/func";
 
@@ -28,11 +28,13 @@ export function PTeamServiceDetailsSettingsView(props) {
     updatePTeamServiceFunc,
     updatePTeamServiceThumbnailFunc,
     deletePTeamServiceThumbnailFunc,
+    image,
   } = props;
 
   const [serviceName, setServiceName] = useState(service.service_name);
   const [imageFileData, setImageFileData] = useState(null);
   const [imageDeleteFalg, setImageDeleteFlag] = useState(false);
+  const [imagePreview, setImagePreview] = useState(null);
   const [currentKeywordsList, setCurrentKeywordsList] = useState(service.keywords);
   const [keywordText, setKeywordText] = useState("");
   const [open, setOpen] = useState(false);
@@ -44,6 +46,17 @@ export function PTeamServiceDetailsSettingsView(props) {
   );
 
   const { enqueueSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    // Reset the state when switching services
+    setServiceName(service.service_name);
+    setImageFileData(null);
+    setImageDeleteFlag(false);
+    setImagePreview(null);
+    setCurrentKeywordsList(service.keywords);
+    setCurrentDescription(service.description);
+    setDefaultSafetyImpactValue(service.service_safety_impact);
+  }, [service]);
 
   const handleClose = () => {
     setOpen(false);
@@ -59,11 +72,11 @@ export function PTeamServiceDetailsSettingsView(props) {
   const handleUpdatePTeamService = async () => {
     const promiseList = [];
     if (imageFileData !== null) {
-      promiseList.push(updatePTeamServiceThumbnailFunc(imageFileData));
+      promiseList.push(() => updatePTeamServiceThumbnailFunc(imageFileData));
     }
 
     if (imageDeleteFalg) {
-      promiseList.push(deletePTeamServiceThumbnailFunc());
+      promiseList.push(() => deletePTeamServiceThumbnailFunc());
     }
 
     const requestData = {
@@ -72,7 +85,7 @@ export function PTeamServiceDetailsSettingsView(props) {
       description: currentDescription,
       service_safety_impact: defaultSafetyImpactValue,
     };
-    promiseList.push(updatePTeamServiceFunc(requestData));
+    promiseList.push(() => updatePTeamServiceFunc(requestData));
 
     Promise.all(promiseList.map((apiFunc) => apiFunc()))
       .then(() => {
@@ -109,7 +122,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 <Box
                   component="img"
                   sx={{ height: 200, aspectRatio: "4/3" }}
-                  src="/images/720x480.png"
+                  src={imagePreview ? imagePreview : image}
                   alt=""
                 />
               </Box>
@@ -117,6 +130,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 <PTeamServiceImageUploadDeleteButton
                   setImageFileData={setImageFileData}
                   setImageDeleteFlag={setImageDeleteFlag}
+                  setImagePreview={setImagePreview}
                 />
               </Box>
             </Box>
@@ -220,4 +234,5 @@ PTeamServiceDetailsSettingsView.propTypes = {
   updatePTeamServiceFunc: PropTypes.func.isRequired,
   updatePTeamServiceThumbnailFunc: PropTypes.func.isRequired,
   deletePTeamServiceThumbnailFunc: PropTypes.func.isRequired,
+  image: PropTypes.string.isRequired,
 };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -13,7 +13,7 @@ import React, { useState } from "react";
 import { DeleteServiceImageAlertDialog } from "./DeleteServiceImageAlertDialog";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
-  const { setImageFileData, setImageDeleteFlag } = props;
+  const { setImageFileData, setImageDeleteFlag, setImagePreview } = props;
 
   const [anchorEl, setAnchorEl] = useState(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -28,14 +28,33 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setAnchorEl(null);
   };
   const handleUploadImage = (event) => {
-    const max_size = 512 * 1024;
+    const widthSize = 720;
+    const heightSize = 480;
+    const maxSize = 512 * 1024;
 
-    if (event.target.files[0].size < max_size) {
-      setImageFileData(event.target.files[0]);
-      setImageDeleteFlag(false);
-    } else {
+    if (event.target.files[0].size >= maxSize) {
       enqueueSnackbar("Filesize exceeds max(512KiB)", { variant: "error" });
+      return;
     }
+
+    const reader = new FileReader();
+    const image = new Image();
+    reader.onload = (e) => {
+      image.src = e.target?.result;
+      image.onload = () => {
+        if (image.naturalWidth === widthSize && image.naturalHeight === heightSize) {
+          setImageFileData(event.target.files[0]);
+          setImageDeleteFlag(false);
+          setImagePreview(e.target?.result);
+        } else {
+          enqueueSnackbar(`Dimensions must be ${widthSize}px ${heightSize} px`, {
+            variant: "error",
+          });
+          return;
+        }
+      };
+    };
+    reader.readAsDataURL(event.target.files[0]);
   };
 
   const VisuallyHiddenInput = styled("input")({
@@ -83,6 +102,7 @@ export function PTeamServiceImageUploadDeleteButton(props) {
         setIsDeleteDialogOpen={setIsDeleteDialogOpen}
         setImageFileData={setImageFileData}
         setImageDeleteFlag={setImageDeleteFlag}
+        setImagePreview={setImagePreview}
       />
     </>
   );
@@ -91,4 +111,5 @@ export function PTeamServiceImageUploadDeleteButton(props) {
 PTeamServiceImageUploadDeleteButton.propTypes = {
   setImageFileData: PropTypes.func.isRequired,
   setImageDeleteFlag: PropTypes.func.isRequired,
+  setImagePreview: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- アップロードした画像をプレビューで表示できるようにしました

## 経緯・意図・意思決定
- プレビューの仕様
   - サービス詳細変更画面を開いとき、DB上にサムネイル画像があればサムネイル画像を表示します。なかった場合720x480.pngを表示します。
   - 画像をアップロードしたら、アプロードした画像を表示します。画像サイズが512 * 1024以上または縦720、横480ではないものに関してはアップロードできないようにしています。
   - Deleteボタンを押したら720x480.pngを表示します。
- web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
  - サムネイル画像を取得するため、useGetPTeamServiceThumbnailQueryを追加しました
- web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
   - サービスタブを切り替えた際にサービス詳細変更画面の内容がリセットされるようにuseEffectを追加しました
   - promiseListに追加するときに関数が実行されていたので、修正しました
- web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
  - `new Image()`を使用しアップロードした画像の縦横のpxを取得しました
  - 縦720、横480以外の画像がアップロードされた時、スナックバーでエラーを表示するようにしました
- web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
  - Deleteボタンが押された時、720x480.pngが表示されるようにしました