### PR TITLE
change ticket default state to open

### DIFF
--- a/web/src/pages/Tag/TopicTables/TopicTableRowView.jsx
+++ b/web/src/pages/Tag/TopicTables/TopicTableRowView.jsx
@@ -24,7 +24,7 @@ export function TopicTableRowView(props) {
     topicActions,
     tickets,
   } = props;
-  const [ticketOpen, setTicketOpen] = useState(false);
+  const [ticketOpen, setTicketOpen] = useState(true);
   const [topicDrawerOpen, setTopicDrawerOpen] = useState(false);
   const currentTagDict = allTags.find((tag) => tag.tag_id === tagId);
 


### PR DESCRIPTION
## PR の目的
- Statusページから1件Tagを選んだページにおいて、Ticketテーブルのアコーディオンをデフォルトで開いた状態にする

