### PR TITLE
ToDoページの作成

### DIFF
--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -25,6 +25,7 @@ import {
   TopicDetail,
   TopicManagement,
   PTeam,
+  ToDo,
   Vulnerability,
 } from "./pages";
 import { AuthProvider } from "./providers/auth/AuthContext";
@@ -78,6 +79,9 @@ root.render(
                   <Route path="topics">
                     <Route index element={<TopicManagement />} />
                     <Route path=":topicId" element={<TopicDetail />} />
+                  </Route>
+                  <Route path="todo">
+                    <Route index element={<ToDo />} />
                   </Route>
                   <Route path="vulnerabilities">
                     <Route index element={<Vulnerability />} />

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -4,6 +4,7 @@ import {
   Home as HomeIcon,
   Topic as TopicIcon,
 } from "@mui/icons-material";
+import FormatListBulletedIcon from "@mui/icons-material/FormatListBulleted";
 import {
   Drawer as MuiDrawer,
   List,
@@ -124,6 +125,16 @@ export function Drawer() {
             <AccountCircleIcon />
           </StyledListItemIcon>
           <ListItemText>Account</ListItemText>
+        </StyledListItemButton>
+        {/* ToDo */}
+        <StyledListItemButton
+          onClick={() => navigate("/todo")}
+          selected={locationReader.isToDoPage()}
+        >
+          <StyledListItemIcon>
+            <FormatListBulletedIcon />
+          </StyledListItemIcon>
+          <ListItemText>ToDo</ListItemText>
         </StyledListItemButton>
       </List>
     </MuiDrawer>

--- a/web/src/pages/ToDo/ToDoPage.jsx
+++ b/web/src/pages/ToDo/ToDoPage.jsx
@@ -1,0 +1,224 @@
+import { Button, Typography } from "@mui/material";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TablePagination from "@mui/material/TablePagination";
+import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import { amber, grey, orange, red } from "@mui/material/colors";
+import PropTypes from "prop-types";
+import React, { useState, useMemo } from "react";
+
+import { Android12Switch } from "../../components/Android12Switch";
+
+function createData(cve, team, service, dueDate, assignee, ssvc) {
+  return {
+    cve,
+    team,
+    service,
+    dueDate,
+    assignee,
+    ssvc,
+  };
+}
+
+const rows = [
+  createData("CVE-XXXX-XXXX", "team_name", "service_name", "2024/12/12 10:00", "test_user1", 0),
+  createData("CVE-XXXX-XXXX", "team_name", "service_name", "2024/12/12 10:00", "test_user2", 1),
+  createData("CVE-XXXX-XXXX", "team_name", "service_name", "2024/12/12 10:00", "test_user3", 2),
+  createData("CVE-XXXX-XXXX", "team_name", "service_name", "2024/12/12 10:00", "test_user4", 0),
+  createData("CVE-XXXX-XXXX", "team_name", "service_name", "2024/12/12 10:00", "test_user5", 3),
+];
+
+function descendingComparator(a, b, orderBy) {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+function getComparator(order, orderBy) {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+const headCells = [
+  {
+    id: "cve",
+    label: "CVE-ID",
+  },
+  {
+    id: "team",
+    label: "Team",
+  },
+  {
+    id: "service",
+    label: "Service",
+  },
+  {
+    id: "dueDate",
+    label: "Due date",
+  },
+  {
+    id: "assignee",
+    label: "Assignee",
+  },
+  {
+    id: "ssvc",
+    label: "SSVC",
+  },
+];
+
+function EnhancedTableHead(props) {
+  const { order, orderBy, onRequestSort } = props;
+  const createSortHandler = (property) => (event) => {
+    onRequestSort(event, property);
+  };
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <TableCell key={headCell.id} sortDirection={orderBy === headCell.id ? order : false}>
+            <TableSortLabel
+              active={orderBy === headCell.id}
+              direction={orderBy === headCell.id ? order : "asc"}
+              onClick={createSortHandler(headCell.id)}
+            >
+              {headCell.label}
+            </TableSortLabel>
+          </TableCell>
+        ))}
+        <TableCell />
+      </TableRow>
+    </TableHead>
+  );
+}
+
+EnhancedTableHead.propTypes = {
+  onRequestSort: PropTypes.func.isRequired,
+  order: PropTypes.oneOf(["asc", "desc"]).isRequired,
+  orderBy: PropTypes.string.isRequired,
+};
+
+export function ToDo() {
+  const [order, setOrder] = useState("asc");
+  const [orderBy, setOrderBy] = useState("ssvc");
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const handleRequestSort = (event, property) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const visibleRows = useMemo(
+    () =>
+      rows
+        .slice()
+        .sort(getComparator(order, orderBy))
+        .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [order, orderBy, page, rowsPerPage],
+  );
+
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+        <Android12Switch />
+        <Typography>My tasks</Typography>
+      </Box>
+      <Paper sx={{ width: "100%" }} variant="outlined">
+        <TableContainer>
+          <Table size="small">
+            <EnhancedTableHead order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
+            <TableBody>
+              {visibleRows.map((row) => {
+                let ssvc;
+                switch (row.ssvc) {
+                  case 0:
+                    ssvc = "Immediate";
+                    break;
+                  case 1:
+                    ssvc = "Out-of-Cycle";
+                    break;
+                  case 2:
+                    ssvc = "Scheduled";
+                    break;
+                  case 3:
+                    ssvc = "Defer";
+                    break;
+                }
+
+                let ssvcBgcolor;
+                switch (ssvc) {
+                  case "Immediate":
+                    ssvcBgcolor = red[600];
+                    break;
+                  case "Out-of-Cycle":
+                    ssvcBgcolor = orange[600];
+                    break;
+                  case "Scheduled":
+                    ssvcBgcolor = amber[600];
+                    break;
+                  case "Defer":
+                    ssvcBgcolor = grey[600];
+                    break;
+                }
+
+                return (
+                  <TableRow key={row}>
+                    <TableCell>{row.cve}</TableCell>
+                    <TableCell>{row.team}</TableCell>
+                    <TableCell>{row.service}</TableCell>
+                    <TableCell>{row.dueDate}</TableCell>
+                    <TableCell>{row.assignee}</TableCell>
+                    <TableCell
+                      sx={{
+                        bgcolor: ssvcBgcolor,
+                        color: "white",
+                      }}
+                    >
+                      {ssvc}
+                    </TableCell>
+                    <TableCell align="right">
+                      <Button variant="contained" size="small">
+                        Details
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[5, 10, 25]}
+          component="div"
+          count={rows.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </Paper>
+    </>
+  );
+}

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -9,6 +9,7 @@ import { ResetPassword } from "./ResetPassword/ResetPasswordPage";
 import { SignUp } from "./SignUp/SignUpPage";
 import { Status } from "./Status/StatusPage";
 import { Tag } from "./Tag/TagPage";
+import { ToDo } from "./ToDo/ToDoPage";
 import { TopicDetail } from "./TopicDetail/TopicDetailPage";
 import { TopicManagement } from "./TopicManagement/TopicManagementPage";
 import { Vulnerability } from "./Vulnerability/VulnerabilityPage";
@@ -27,5 +28,6 @@ export {
   Tag,
   TopicDetail,
   TopicManagement,
+  ToDo,
   Vulnerability,
 };

--- a/web/src/utils/LocationReader.js
+++ b/web/src/utils/LocationReader.js
@@ -31,6 +31,10 @@ export class LocationReader {
     return this.location.pathname === "/account";
   }
 
+  isToDoPage() {
+    return this.location.pathname === "/todo";
+  }
+
   getPTeamId() {
     const params = new URLSearchParams(this.location.search);
     return params.get("pteamId");


### PR DESCRIPTION
## PR の目的

チーム横断でチケットの確認ができるToDoページを作成する。

## 経緯・意図・意思決定

- チーム横断でチケットの確認ができるToDoページを作成し、サイドバーから遷移可能にする。
- 画面上部のMy tasksのスイッチから、自分にアサインされたチケットのみを閲覧可能にする。
- 各チケットの詳細ページに遷移するボタンを、各行の右端に配置する。（どこに遷移するかは現在未定）
- 各ヘッダーセルを押下で、テーブルのソートを可能にする。

## 補足事項
- 現在はモックデータを使用
- My tasksボタンはモックのため、現在機能しない。