### PR TITLE
set textOverflow in TicketTable

### DIFF
--- a/web/src/pages/Tag/TopicTables/TicketTableRow.jsx
+++ b/web/src/pages/Tag/TopicTables/TicketTableRow.jsx
@@ -1,4 +1,4 @@
-import { Box, TableCell, TableRow } from "@mui/material";
+import { Box, TableCell, TableRow, Tooltip } from "@mui/material";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -18,7 +18,18 @@ export function TicketTableRow(props) {
 
   return (
     <TableRow>
-      <TableCell>{target}</TableCell>
+      <Tooltip arrow placement="bottom-end" title={target}>
+        <TableCell
+          sx={{
+            maxWidth: 200,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {target}
+        </TableCell>
+      </Tooltip>
       <TableCell>
         <SafetyImpactSelector threatId={ticket.threat.threat_id} />
       </TableCell>


### PR DESCRIPTION
## PR の目的
- Statusページから1件Tagを選んだページにおいて、TicketテーブルのTarget列の値が長い場合に、スクロールバーがTicketテーブルでなくTopicテーブルに出るため、見づらく分かりにくいため、下記対策とする
  - Target列の最大幅を200pxに固定
  - Target列の値が最大幅を超える場合は「Target文字列...」のように最後...を付ける
  - Target列のセルマウスホバーでツールチップにより全文表示