### PR TITLE
Remove unused rtk query hook

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -506,7 +506,6 @@ export const {
   useUpdateActionMutation,
   useDeleteActionMutation,
   useCreateActionLogMutation,
-  useRemoveWatchingPTeamMutation,
   useGetDependenciesQuery,
   useGetPTeamQuery,
   useCreatePTeamMutation,


### PR DESCRIPTION
## PR の目的
なぜか残っていたRTK Queryのhook useRemoveWatchingPTeamMutationを削除
- useRemoveWatchingPTeamMutationはateam側の機能であり、その消し忘れ
- tcapi.js上のエンドポイントは削除済みであり、hookだけがなぜか残っていた