### PR TITLE
move logic from view

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
@@ -1,3 +1,4 @@
+import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -7,6 +8,7 @@ import {
   useDeletePTeamServiceThumbnailMutation,
   useGetPTeamServiceThumbnailQuery,
 } from "../../../services/tcApi";
+import { errorToString } from "../../../utils/func";
 
 import { PTeamServiceDetailsSettingsView } from "./PTeamServiceDetailsSettingsView";
 
@@ -15,31 +17,62 @@ const noImageAvailableUrl = "images/720x480.png";
 export function PTeamServiceDetailsSettings(props) {
   const { pteamId, service } = props;
 
+  const { enqueueSnackbar } = useSnackbar();
+
   const [updatePTeamService] = useUpdatePTeamServiceMutation();
   const [updatePTeamServiceThumbnail] = useUpdatePTeamServiceThumbnailMutation();
   const [deletePTeamServiceThumbnail] = useDeletePTeamServiceThumbnailMutation();
 
-  const updatePTeamServiceFunc = async (requestData) => {
-    await updatePTeamService({
-      pteamId: pteamId,
-      serviceId: service.service_id,
-      data: requestData,
-    }).unwrap();
-  };
+  const handleSave = async (
+    serviceName,
+    imageFileData,
+    imageDeleteFalg,
+    keywordsList,
+    description,
+    defaultSafetyImpactValue,
+  ) => {
+    const promiseList = [];
 
-  const updatePTeamServiceThumbnailFunc = async (imageFileData) => {
-    await updatePTeamServiceThumbnail({
-      pteamId: pteamId,
-      serviceId: service.service_id,
-      imageFile: imageFileData,
-    }).unwrap();
-  };
+    if (imageFileData !== null) {
+      promiseList.push(() =>
+        updatePTeamServiceThumbnail({
+          pteamId: pteamId,
+          serviceId: service.service_id,
+          imageFile: imageFileData,
+        }).unwrap(),
+      );
+    }
 
-  const deletePTeamServiceThumbnailFunc = async () => {
-    await deletePTeamServiceThumbnail({
-      pteamId: pteamId,
-      serviceId: service.service_id,
-    }).unwrap();
+    if (imageDeleteFalg) {
+      promiseList.push(() =>
+        deletePTeamServiceThumbnail({
+          pteamId: pteamId,
+          serviceId: service.service_id,
+        }).unwrap(),
+      );
+    }
+
+    const requestData = {
+      service_name: serviceName,
+      keywords: keywordsList,
+      description: description,
+      service_safety_impact: defaultSafetyImpactValue,
+    };
+    promiseList.push(() =>
+      updatePTeamService({
+        pteamId: pteamId,
+        serviceId: service.service_id,
+        data: requestData,
+      }).unwrap(),
+    );
+
+    Promise.all(promiseList.map((apiFunc) => apiFunc()))
+      .then(() => {
+        enqueueSnackbar("Update succeeded", { variant: "success" });
+      })
+      .catch((error) => {
+        enqueueSnackbar(`Update failed: ${errorToString(error)}`, { variant: "error" });
+      });
   };
 
   const {
@@ -54,15 +87,7 @@ export function PTeamServiceDetailsSettings(props) {
   const image =
     thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageAvailableUrl : thumbnail;
 
-  return (
-    <PTeamServiceDetailsSettingsView
-      service={service}
-      updatePTeamServiceFunc={updatePTeamServiceFunc}
-      updatePTeamServiceThumbnailFunc={updatePTeamServiceThumbnailFunc}
-      deletePTeamServiceThumbnailFunc={deletePTeamServiceThumbnailFunc}
-      image={image}
-    />
-  );
+  return <PTeamServiceDetailsSettingsView service={service} image={image} onSave={handleSave} />;
 }
 
 PTeamServiceDetailsSettings.propTypes = {

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -14,22 +14,13 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from "@mui/material";
-import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-
-import { errorToString } from "../../../utils/func";
 
 import { PTeamServiceImageUploadDeleteButton } from "./PTeamServiceImageUploadDeleteButton";
 
 export function PTeamServiceDetailsSettingsView(props) {
-  const {
-    service,
-    updatePTeamServiceFunc,
-    updatePTeamServiceThumbnailFunc,
-    deletePTeamServiceThumbnailFunc,
-    image,
-  } = props;
+  const { service, image, onSave } = props;
 
   const [serviceName, setServiceName] = useState(service.service_name);
   const [imageFileData, setImageFileData] = useState(null);
@@ -44,8 +35,6 @@ export function PTeamServiceDetailsSettingsView(props) {
   const [defaultSafetyImpactValue, setDefaultSafetyImpactValue] = useState(
     service.service_safety_impact,
   );
-
-  const { enqueueSnackbar } = useSnackbar();
 
   useEffect(() => {
     // Reset the state when switching services
@@ -64,37 +53,20 @@ export function PTeamServiceDetailsSettingsView(props) {
   const handleClickOpen = () => {
     setOpen(true);
   };
-  const handleDelete = (item) => {
+  const handleDeleteKeyword = (item) => {
     const keywordsListCopy = JSON.parse(JSON.stringify(currentKeywordsList));
     const filteredKeywordsList = keywordsListCopy.filter((keyword) => keyword !== item);
     setCurrentKeywordsList(filteredKeywordsList);
   };
-  const handleUpdatePTeamService = async () => {
-    const promiseList = [];
-    if (imageFileData !== null) {
-      promiseList.push(() => updatePTeamServiceThumbnailFunc(imageFileData));
-    }
-
-    if (imageDeleteFalg) {
-      promiseList.push(() => deletePTeamServiceThumbnailFunc());
-    }
-
-    const requestData = {
-      service_name: serviceName,
-      keywords: currentKeywordsList,
-      description: currentDescription,
-      service_safety_impact: defaultSafetyImpactValue,
-    };
-    promiseList.push(() => updatePTeamServiceFunc(requestData));
-
-    Promise.all(promiseList.map((apiFunc) => apiFunc()))
-      .then(() => {
-        enqueueSnackbar("Update succeeded", { variant: "success" });
-      })
-      .catch((error) => {
-        enqueueSnackbar(`Update failed: ${errorToString(error)}`, { variant: "error" });
-      });
-  };
+  const handleUpdatePTeamService = async () =>
+    onSave(
+      serviceName,
+      imageFileData,
+      imageDeleteFalg,
+      currentKeywordsList,
+      currentDescription,
+      defaultSafetyImpactValue,
+    );
 
   return (
     <>
@@ -139,7 +111,11 @@ export function PTeamServiceDetailsSettingsView(props) {
               <Box>
                 <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap" }}>
                   {currentKeywordsList.map((keyword) => (
-                    <Chip key={keyword} label={keyword} onDelete={() => handleDelete(keyword)} />
+                    <Chip
+                      key={keyword}
+                      label={keyword}
+                      onDelete={() => handleDeleteKeyword(keyword)}
+                    />
                   ))}
                 </Stack>
                 {keywordAddingMode ? (
@@ -231,8 +207,6 @@ export function PTeamServiceDetailsSettingsView(props) {
 
 PTeamServiceDetailsSettingsView.propTypes = {
   service: PropTypes.object.isRequired,
-  updatePTeamServiceFunc: PropTypes.func.isRequired,
-  updatePTeamServiceThumbnailFunc: PropTypes.func.isRequired,
-  deletePTeamServiceThumbnailFunc: PropTypes.func.isRequired,
   image: PropTypes.string.isRequired,
+  onSave: PropTypes.func.isRequired,
 };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -14,6 +14,7 @@ import {
   ToggleButton,
   ToggleButtonGroup,
 } from "@mui/material";
+import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
@@ -43,6 +44,8 @@ export function PTeamServiceDetailsSettingsView(props) {
   const [defaultSafetyImpactValue, setDefaultSafetyImpactValue] = useState(
     service.service_safety_impact,
   );
+
+  const { enqueueSnackbar } = useSnackbar();
 
   useEffect(() => {
     // Reset the state when switching services

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
@@ -1,6 +1,6 @@
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 
 import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
 import { useGetThreatQuery, useUpdateThreatMutation } from "../../../services/tcApi";
@@ -11,6 +11,9 @@ import { SafetyImpactSelectorView } from "./SafetyImpactSelectorView";
 
 export function SafetyImpactSelector(props) {
   const { threatId } = props;
+
+  const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
+  const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
 
   const skip = useSkipUntilAuthUserIsReady();
   const {
@@ -41,11 +44,47 @@ export function SafetyImpactSelector(props) {
       );
   };
 
+  const defaultSafetyImpactItem = "Default";
+
+  const handleSelectSafetyImpact = (selectedSafetyImpact) => {
+    if (selectedSafetyImpact === defaultSafetyImpactItem) {
+      setPendingSafetyImpact("");
+      setPendingReasonSafetyImpact("");
+      const requestData = {
+        threat_safety_impact: null,
+        reason_safety_impact: null,
+      };
+      updateThreatFunction(requestData);
+    } else {
+      setPendingSafetyImpact(selectedSafetyImpact);
+      setPendingReasonSafetyImpact(
+        threat.reason_safety_impact === null ? "" : threat.reason_safety_impact,
+      );
+    }
+  };
+
+  const handleChangeReason = (reasonSafetyImpact) => {
+    setPendingReasonSafetyImpact(reasonSafetyImpact);
+  };
+
+  const handleSaveReason = async () => {
+    const requestData = {
+      threat_safety_impact: pendingSafetyImpact,
+      reason_safety_impact: pendingReasonSafetyImpact,
+    };
+    updateThreatFunction(requestData);
+  };
+
   return (
     <SafetyImpactSelectorView
-      threatSafetyImpact={threat.threat_safety_impact}
-      reasonSafetyImpact={threat.reason_safety_impact}
-      updateThreatFunction={updateThreatFunction}
+      defaultSafetyImpactItem={defaultSafetyImpactItem}
+      fixedThreatSafetyImpact={threat.threat_safety_impact}
+      fixedReasonSafetyImpact={threat.reason_safety_impact}
+      pendingSafetyImpact={pendingSafetyImpact}
+      pendingReasonSafetyImpact={pendingReasonSafetyImpact}
+      onSelectSafetyImpact={handleSelectSafetyImpact}
+      onChangeReason={handleChangeReason}
+      onSaveReason={handleSaveReason}
     />
   );
 }

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
@@ -49,10 +49,10 @@ export function SafetyImpactSelector(props) {
     updateThreatFunction(requestData);
   };
 
-  const handleSave = async (pendingSafetyImpact, pendingReasonSafetyImpact) => {
+  const handleSave = async (safetyImpact, reasonSafetyImpact) => {
     const requestData = {
-      threat_safety_impact: pendingSafetyImpact,
-      reason_safety_impact: pendingReasonSafetyImpact,
+      threat_safety_impact: safetyImpact,
+      reason_safety_impact: reasonSafetyImpact,
     };
     updateThreatFunction(requestData);
   };

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
@@ -1,6 +1,6 @@
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React from "react";
 
 import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
 import { useGetThreatQuery, useUpdateThreatMutation } from "../../../services/tcApi";
@@ -11,9 +11,6 @@ import { SafetyImpactSelectorView } from "./SafetyImpactSelectorView";
 
 export function SafetyImpactSelector(props) {
   const { threatId } = props;
-
-  const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
-  const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
 
   const skip = useSkipUntilAuthUserIsReady();
   const {
@@ -44,47 +41,24 @@ export function SafetyImpactSelector(props) {
       );
   };
 
-  const defaultSafetyImpactItem = "Default";
-
-  const handleSelectSafetyImpact = (selectedSafetyImpact) => {
-    if (selectedSafetyImpact === defaultSafetyImpactItem) {
-      setPendingSafetyImpact("");
-      setPendingReasonSafetyImpact("");
-      const requestData = {
-        threat_safety_impact: null,
-        reason_safety_impact: null,
-      };
-      updateThreatFunction(requestData);
-    } else {
-      setPendingSafetyImpact(selectedSafetyImpact);
-      setPendingReasonSafetyImpact(
-        threat.reason_safety_impact === null ? "" : threat.reason_safety_impact,
-      );
-    }
-  };
-
-  const handleChangeReason = (reasonSafetyImpact) => {
-    setPendingReasonSafetyImpact(reasonSafetyImpact);
-  };
-
-  const handleSaveReason = async () => {
+  const handleRevertedToDefault = async () => {
     const requestData = {
-      threat_safety_impact: pendingSafetyImpact,
-      reason_safety_impact: pendingReasonSafetyImpact,
+      threat_safety_impact: null,
+      reason_safety_impact: null,
     };
+    updateThreatFunction(requestData);
+  };
+
+  const handleSave = async (requestData) => {
     updateThreatFunction(requestData);
   };
 
   return (
     <SafetyImpactSelectorView
-      defaultSafetyImpactItem={defaultSafetyImpactItem}
       fixedThreatSafetyImpact={threat.threat_safety_impact}
       fixedReasonSafetyImpact={threat.reason_safety_impact}
-      pendingSafetyImpact={pendingSafetyImpact}
-      pendingReasonSafetyImpact={pendingReasonSafetyImpact}
-      onSelectSafetyImpact={handleSelectSafetyImpact}
-      onChangeReason={handleChangeReason}
-      onSaveReason={handleSaveReason}
+      onRevertedToDefault={handleRevertedToDefault}
+      onSave={handleSave}
     />
   );
 }

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelector.jsx
@@ -49,7 +49,11 @@ export function SafetyImpactSelector(props) {
     updateThreatFunction(requestData);
   };
 
-  const handleSave = async (requestData) => {
+  const handleSave = async (pendingSafetyImpact, pendingReasonSafetyImpact) => {
+    const requestData = {
+      threat_safety_impact: pendingSafetyImpact,
+      reason_safety_impact: pendingReasonSafetyImpact,
+    };
     updateThreatFunction(requestData);
   };
 

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
@@ -48,11 +48,7 @@ export function SafetyImpactSelectorView(props) {
   };
 
   const handleSaveReason = async () => {
-    const requestData = {
-      threat_safety_impact: pendingSafetyImpact,
-      reason_safety_impact: pendingReasonSafetyImpact,
-    };
-    onSave(requestData);
+    onSave(pendingSafetyImpact, pendingReasonSafetyImpact);
     setOpenReasonDialog(false);
   };
 

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
@@ -23,41 +23,34 @@ import React, { useState } from "react";
 import { safetyImpactProps, sortedSafetyImpacts } from "../../../utils/const";
 
 export function SafetyImpactSelectorView(props) {
-  const { threatSafetyImpact, reasonSafetyImpact, updateThreatFunction } = props;
+  const {
+    defaultSafetyImpactItem,
+    fixedThreatSafetyImpact,
+    fixedReasonSafetyImpact,
+    pendingSafetyImpact,
+    pendingReasonSafetyImpact,
+    onSelectSafetyImpact,
+    onChangeReason,
+    onSaveReason,
+  } = props;
 
-  const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
-  const [open, setOpen] = useState(false);
-  const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
-
-  const defaultItem = "Default";
+  const [openReasonDialog, setOpenReasonDialog] = useState(false);
 
   const handleSelectSafetyImpact = (e) => {
-    if (e.target.value === defaultItem) {
-      setPendingSafetyImpact("");
-      setPendingReasonSafetyImpact("");
-      const requestData = {
-        threat_safety_impact: null,
-        reason_safety_impact: null,
-      };
-      updateThreatFunction(requestData);
-    } else {
-      setPendingSafetyImpact(e.target.value);
-      setPendingReasonSafetyImpact(reasonSafetyImpact === null ? "" : reasonSafetyImpact);
-      setOpen(true);
+    onSelectSafetyImpact(e.target.value);
+
+    if (e.target.value !== defaultSafetyImpactItem) {
+      setOpenReasonDialog(true);
     }
   };
 
   const handleClose = () => {
-    setOpen(false);
+    setOpenReasonDialog(false);
   };
 
-  const handleSave = async () => {
-    const requestData = {
-      threat_safety_impact: pendingSafetyImpact,
-      reason_safety_impact: pendingReasonSafetyImpact,
-    };
-    updateThreatFunction(requestData);
-    setOpen(false);
+  const handleSaveReason = async () => {
+    onSaveReason();
+    setOpenReasonDialog(false);
   };
 
   const StyledTooltip = styled(({ className, ...props }) => (
@@ -80,13 +73,13 @@ export function SafetyImpactSelectorView(props) {
     <Box sx={{ display: "flex", alignItems: "center" }}>
       <FormControl sx={{ width: 130 }} size="small" variant="standard">
         <Select
-          value={threatSafetyImpact ? threatSafetyImpact : defaultItem}
+          value={fixedThreatSafetyImpact ? fixedThreatSafetyImpact : defaultSafetyImpactItem}
           onChange={(e) => {
             handleSelectSafetyImpact(e);
           }}
         >
-          <MenuItem key={defaultItem} value={defaultItem}>
-            {defaultItem}
+          <MenuItem key={defaultSafetyImpactItem} value={defaultSafetyImpactItem}>
+            {defaultSafetyImpactItem}
           </MenuItem>
           {sortedSafetyImpacts.map((safetyImpact) => (
             <MenuItem key={safetyImpact} value={safetyImpact}>
@@ -95,7 +88,7 @@ export function SafetyImpactSelectorView(props) {
           ))}
         </Select>
       </FormControl>
-      {reasonSafetyImpact !== null && (
+      {fixedReasonSafetyImpact !== null && (
         <StyledTooltip
           arrow
           title={
@@ -104,7 +97,7 @@ export function SafetyImpactSelectorView(props) {
                 Why was it changed from the default safety impact?
               </Typography>
               <Box sx={{ p: 1 }}>
-                <Typography variant="body2">{reasonSafetyImpact}</Typography>
+                <Typography variant="body2">{fixedReasonSafetyImpact}</Typography>
               </Box>
             </>
           }
@@ -114,18 +107,20 @@ export function SafetyImpactSelectorView(props) {
           </IconButton>
         </StyledTooltip>
       )}
-      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <Dialog open={openReasonDialog} onClose={handleClose} maxWidth="sm" fullWidth>
         <DialogTitle>Safety Impact update</DialogTitle>
         <DialogContent>
           <Box sx={{ pb: 2 }}>
             <DialogContentText>
               Current:{" "}
-              {threatSafetyImpact ? safetyImpactProps[threatSafetyImpact].displayName : defaultItem}
+              {fixedThreatSafetyImpact
+                ? safetyImpactProps[fixedThreatSafetyImpact].displayName
+                : defaultSafetyImpactItem}
             </DialogContentText>
             <DialogContentText>
               Updated:{" "}
               {pendingSafetyImpact === ""
-                ? defaultItem
+                ? defaultSafetyImpactItem
                 : safetyImpactProps[pendingSafetyImpact].displayName}
             </DialogContentText>
           </Box>
@@ -138,12 +133,12 @@ export function SafetyImpactSelectorView(props) {
             rows={4}
             placeholder="Continue writing here"
             value={pendingReasonSafetyImpact}
-            onChange={(e) => setPendingReasonSafetyImpact(e.target.value)}
+            onChange={(e) => onChangeReason(e.target.value)}
           />
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Button onClick={handleSave} disabled={pendingReasonSafetyImpact === ""}>
+          <Button onClick={handleSaveReason} disabled={pendingReasonSafetyImpact === ""}>
             Save
           </Button>
         </DialogActions>
@@ -152,7 +147,12 @@ export function SafetyImpactSelectorView(props) {
   );
 }
 SafetyImpactSelectorView.propTypes = {
-  threatSafetyImpact: PropTypes.string.isRequired,
-  reasonSafetyImpact: PropTypes.string.isRequired,
-  updateThreatFunction: PropTypes.func.isRequired,
+  defaultSafetyImpactItem: PropTypes.string.isRequired,
+  fixedThreatSafetyImpact: PropTypes.string.isRequired,
+  fixedReasonSafetyImpact: PropTypes.string.isRequired,
+  pendingSafetyImpact: PropTypes.string.isRequired,
+  pendingReasonSafetyImpact: PropTypes.string.isRequired,
+  onSelectSafetyImpact: PropTypes.func.isRequired,
+  onChangeReason: PropTypes.func.isRequired,
+  onSaveReason: PropTypes.func.isRequired,
 };

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
@@ -23,23 +23,22 @@ import React, { useState } from "react";
 import { safetyImpactProps, sortedSafetyImpacts } from "../../../utils/const";
 
 export function SafetyImpactSelectorView(props) {
-  const {
-    defaultSafetyImpactItem,
-    fixedThreatSafetyImpact,
-    fixedReasonSafetyImpact,
-    pendingSafetyImpact,
-    pendingReasonSafetyImpact,
-    onSelectSafetyImpact,
-    onChangeReason,
-    onSaveReason,
-  } = props;
+  const { fixedThreatSafetyImpact, fixedReasonSafetyImpact, onRevertedToDefault, onSave } = props;
 
+  const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
+  const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
   const [openReasonDialog, setOpenReasonDialog] = useState(false);
 
-  const handleSelectSafetyImpact = (e) => {
-    onSelectSafetyImpact(e.target.value);
+  const defaultSafetyImpactItem = "Default";
 
-    if (e.target.value !== defaultSafetyImpactItem) {
+  const handleSelectSafetyImpact = (e) => {
+    if (e.target.value === defaultSafetyImpactItem) {
+      setPendingSafetyImpact("");
+      setPendingReasonSafetyImpact("");
+      onRevertedToDefault();
+    } else {
+      setPendingSafetyImpact(e.target.value);
+      setPendingReasonSafetyImpact(fixedReasonSafetyImpact === null ? "" : fixedReasonSafetyImpact);
       setOpenReasonDialog(true);
     }
   };
@@ -49,7 +48,11 @@ export function SafetyImpactSelectorView(props) {
   };
 
   const handleSaveReason = async () => {
-    onSaveReason();
+    const requestData = {
+      threat_safety_impact: pendingSafetyImpact,
+      reason_safety_impact: pendingReasonSafetyImpact,
+    };
+    onSave(requestData);
     setOpenReasonDialog(false);
   };
 
@@ -133,7 +136,7 @@ export function SafetyImpactSelectorView(props) {
             rows={4}
             placeholder="Continue writing here"
             value={pendingReasonSafetyImpact}
-            onChange={(e) => onChangeReason(e.target.value)}
+            onChange={(e) => setPendingReasonSafetyImpact(e.target.value)}
           />
         </DialogContent>
         <DialogActions>
@@ -147,12 +150,8 @@ export function SafetyImpactSelectorView(props) {
   );
 }
 SafetyImpactSelectorView.propTypes = {
-  defaultSafetyImpactItem: PropTypes.string.isRequired,
   fixedThreatSafetyImpact: PropTypes.string.isRequired,
   fixedReasonSafetyImpact: PropTypes.string.isRequired,
-  pendingSafetyImpact: PropTypes.string.isRequired,
-  pendingReasonSafetyImpact: PropTypes.string.isRequired,
-  onSelectSafetyImpact: PropTypes.func.isRequired,
-  onChangeReason: PropTypes.func.isRequired,
-  onSaveReason: PropTypes.func.isRequired,
+  onRevertedToDefault: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- SafetyImpactSelector、PTeamServiceDetailsSettingsにおいて、Viewからロジックを分離する
  - イベントを表す props には onSomething という名前を使い、それらのイベントを処理するハンドラ関数の定義には handleSomething という名前を使う
  - Viewコンポーネント内にはAPI側の変数名を持ち込まず、親コンポーネントでrequestDataを構築する

## 参考文献
onSomething, handleSomething の命名規則 
https://ja.react.dev/learn/tutorial-tic-tac-toe
