### PR TITLE
add Promise.all to handleDeleteService

### DIFF
--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -70,17 +70,19 @@ export function PTeamServiceDelete(props) {
         variant: "error",
       });
     }
-    checked.map(
-      async (service) =>
-        await deletePTeamService({ pteamId: pteamId, serviceName: service.service_name })
-          .unwrap()
-          .then((success) => onSuccess(success))
-          .catch((error) => onError(error)),
-    );
-    if (checked.find((service) => service.service_id === serviceId)) {
-      params.delete("serviceId"); // current selected serviceId is obsoleted!
-      navigate(location.pathname + "?" + params.toString()); // entrust to default behavior
-    }
+    await Promise.all(
+      checked.map((service) =>
+        deletePTeamService({ pteamId: pteamId, serviceName: service.service_name }).unwrap(),
+      ),
+    )
+      .then((success) => {
+        onSuccess(success);
+        if (checked.find((service) => service.service_id === serviceId)) {
+          params.delete("serviceId"); // current selected serviceId is obsoleted!
+          navigate(location.pathname + "?" + params.toString()); // entrust to default behavior
+        }
+      })
+      .catch((error) => onError(error));
   };
 
   return (


### PR DESCRIPTION
## PR の目的
- Delete Servicesでサービスを削除した際に登録してあるサービスが他に残っている場合はそのサービスの画面に遷移、そうでなければSBOMファイルのupload画面に遷移するように修正（エラー時の挙動も確認済み）

## 経緯・意図・意思決定
- Delete Servicesでサービスを削除した際に404 No such serviceエラーが発生
   - クエリパラメータ上に削除したはずのserviceIdが残ってしまっていた
      - web/src/pages/Status/PTeamServiceDelete.jsxのhandleDeleteService関数内において、map内でdeletePTeamServiceを非同期的に処理してしまっており、serviceIdの削除がすべて完了する前にnavigateしてしまっていたことが原因

