### PR TITLE
Topic/character count and keyword count check

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
@@ -7,7 +7,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import PropTypes from "prop-types";
 import React from "react";
 
-const noImageAvailableUrl = "images/720x480.png";
+const serviceDetailsSetttingNoImageUrl = "images/720x480.png";
 
 export function DeleteServiceImageAlertDialog(props) {
   const {
@@ -26,7 +26,7 @@ export function DeleteServiceImageAlertDialog(props) {
     setIsDeleteDialogOpen(false);
     setImageFileData(null);
     setImageDeleteFlag(true);
-    setImagePreview(noImageAvailableUrl);
+    setImagePreview(serviceDetailsSetttingNoImageUrl);
   };
 
   return (

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
@@ -10,7 +10,7 @@ import {
 
 import { PTeamServiceDetailsSettingsView } from "./PTeamServiceDetailsSettingsView";
 
-const noImageAvailableUrl = "images/720x480.png";
+const serviceDetailsSetttingNoImageUrl = "images/720x480.png";
 
 export function PTeamServiceDetailsSettings(props) {
   const { pteamId, service } = props;
@@ -52,7 +52,9 @@ export function PTeamServiceDetailsSettings(props) {
   });
 
   const image =
-    thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageAvailableUrl : thumbnail;
+    thumbnailIsError || thumbnailIsLoading || !thumbnail
+      ? serviceDetailsSetttingNoImageUrl
+      : thumbnail;
 
   return (
     <PTeamServiceDetailsSettingsView

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -102,7 +102,7 @@ export function PTeamServiceDetailsSettingsView(props) {
       });
   };
 
-  const handleServiceNameLengthCheck = (string) => {
+  const handleServiceNameSetting = (string) => {
     if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxServiceNameLengthInHalf) {
       enqueueSnackbar(
         `Too long service name. Max length is ${maxServiceNameLengthInHalf} in half-width or ${Math.floor(maxServiceNameLengthInHalf / 2)} in full-width`,
@@ -115,7 +115,7 @@ export function PTeamServiceDetailsSettingsView(props) {
     }
   };
 
-  const handleKeywordLengthCheck = (string) => {
+  const handleKeywordSetting = (string) => {
     if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxKeywordLengthInHalf) {
       enqueueSnackbar(
         `Too long description. Max length is ${maxKeywordLengthInHalf} in half-width or ${Math.floor(maxKeywordLengthInHalf / 2)} in full-width`,
@@ -128,7 +128,7 @@ export function PTeamServiceDetailsSettingsView(props) {
     }
   };
 
-  const handleDescriptionLengthCheck = (string) => {
+  const handleDescriptionSetting = (string) => {
     if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxDescriptionLengthInHalf) {
       enqueueSnackbar(
         `Too long keyword. Max length is ${maxDescriptionLengthInHalf} in half-width or ${Math.floor(maxDescriptionLengthInHalf / 2)} in full-width`,
@@ -165,7 +165,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 required
                 size="small"
                 value={serviceName}
-                onChange={(e) => handleServiceNameLengthCheck(e.target.value)}
+                onChange={(e) => handleServiceNameSetting(e.target.value)}
                 helperText={serviceName ? "" : "This field is required."}
                 error={!serviceName}
               />
@@ -202,7 +202,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                       variant="outlined"
                       size="small"
                       value={keywordText}
-                      onChange={(e) => handleKeywordLengthCheck(e.target.value)}
+                      onChange={(e) => handleKeywordSetting(e.target.value)}
                       sx={{ mr: 1 }}
                       error={currentKeywordsList.includes(keywordText)}
                       helperText={
@@ -245,7 +245,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 rows={3}
                 fullWidth
                 value={currentDescription}
-                onChange={(e) => handleDescriptionLengthCheck(e.target.value)}
+                onChange={(e) => handleDescriptionSetting(e.target.value)}
               />
             </Box>
             <Box sx={{ display: "flex", flexDirection: "column" }}>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -18,7 +18,13 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
 
-import { errorToString } from "../../../utils/func";
+import {
+  maxServiceNameLengthInHalf,
+  maxDescriptionLengthInHalf,
+  maxKeywordLengthInHalf,
+  maxKeywords,
+} from "../../../utils/const";
+import { errorToString, countFullWidthAndHalfWidthCharacters } from "../../../utils/func";
 
 import { PTeamServiceImageUploadDeleteButton } from "./PTeamServiceImageUploadDeleteButton";
 
@@ -96,6 +102,54 @@ export function PTeamServiceDetailsSettingsView(props) {
       });
   };
 
+  const handleServiceNameLengthCheck = (string) => {
+    if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxServiceNameLengthInHalf) {
+      enqueueSnackbar(
+        `Too long service name. Max length is ${maxServiceNameLengthInHalf} in half-width or ${Math.floor(maxServiceNameLengthInHalf / 2)} in full-width`,
+        {
+          variant: "error",
+        },
+      );
+    } else {
+      setServiceName(string);
+    }
+  };
+
+  const handleKeywordLengthCheck = (string) => {
+    if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxKeywordLengthInHalf) {
+      enqueueSnackbar(
+        `Too long description. Max length is ${maxKeywordLengthInHalf} in half-width or ${Math.floor(maxKeywordLengthInHalf / 2)} in full-width`,
+        {
+          variant: "error",
+        },
+      );
+    } else {
+      setKeywordText(string);
+    }
+  };
+
+  const handleDescriptionLengthCheck = (string) => {
+    if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxDescriptionLengthInHalf) {
+      enqueueSnackbar(
+        `Too long keyword. Max length is ${maxDescriptionLengthInHalf} in half-width or ${Math.floor(maxDescriptionLengthInHalf / 2)} in full-width`,
+        {
+          variant: "error",
+        },
+      );
+    } else {
+      setCurrentDescription(string);
+    }
+  };
+
+  const handleKeywordCountCheck = () => {
+    if (currentKeywordsList.length >= maxKeywords) {
+      setKeywordAddingMode(false);
+      enqueueSnackbar(`Too many keywords, max number: ${maxKeywords}`, { variant: "error" });
+    } else {
+      setKeywordAddingMode(!keywordAddingMode);
+    }
+  };
+
   return (
     <>
       <IconButton onClick={handleClickOpen} sx={{ position: "absolute", right: 0, top: 0 }}>
@@ -111,7 +165,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 required
                 size="small"
                 value={serviceName}
-                onChange={(e) => setServiceName(e.target.value)}
+                onChange={(e) => handleServiceNameLengthCheck(e.target.value)}
                 helperText={serviceName ? "" : "This field is required."}
                 error={!serviceName}
               />
@@ -148,7 +202,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                       variant="outlined"
                       size="small"
                       value={keywordText}
-                      onChange={(e) => setKeywordText(e.target.value)}
+                      onChange={(e) => handleKeywordLengthCheck(e.target.value)}
                       sx={{ mr: 1 }}
                       error={currentKeywordsList.includes(keywordText)}
                       helperText={
@@ -179,9 +233,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                   </Box>
                 ) : (
                   <Box>
-                    <Button onClick={() => setKeywordAddingMode(!keywordAddingMode)}>
-                      + Add a new keyword
-                    </Button>
+                    <Button onClick={handleKeywordCountCheck}>+ Add a new keyword</Button>
                   </Box>
                 )}
               </Box>
@@ -193,7 +245,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 rows={3}
                 fullWidth
                 value={currentDescription}
-                onChange={(e) => setCurrentDescription(e.target.value)}
+                onChange={(e) => handleDescriptionLengthCheck(e.target.value)}
               />
             </Box>
             <Box sx={{ display: "flex", flexDirection: "column" }}>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -10,7 +10,11 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
-import { imageHeightSize, imageWidthSize, imageMaxSize } from "../../../utils/const";
+import {
+  serviceImageHeightSize,
+  serviceImageWidthSize,
+  serviceImageMaxSize,
+} from "../../../utils/const";
 
 import { DeleteServiceImageAlertDialog } from "./DeleteServiceImageAlertDialog";
 
@@ -30,7 +34,7 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setAnchorEl(null);
   };
   const handleUploadImage = (event) => {
-    if (event.target.files[0].size >= imageMaxSize) {
+    if (event.target.files[0].size >= serviceImageMaxSize) {
       enqueueSnackbar("Filesize exceeds max(512KiB)", { variant: "error" });
       return;
     }
@@ -40,14 +44,20 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     reader.onload = (e) => {
       image.src = e.target?.result;
       image.onload = () => {
-        if (image.naturalWidth === imageWidthSize && image.naturalHeight === imageHeightSize) {
+        if (
+          image.naturalWidth === serviceImageWidthSize &&
+          image.naturalHeight === serviceImageHeightSize
+        ) {
           setImageFileData(event.target.files[0]);
           setImageDeleteFlag(false);
           setImagePreview(e.target?.result);
         } else {
-          enqueueSnackbar(`Dimensions must be ${imageWidthSize}px ${imageHeightSize} px`, {
-            variant: "error",
-          });
+          enqueueSnackbar(
+            `Dimensions must be ${serviceImageWidthSize}px ${serviceImageHeightSize} px`,
+            {
+              variant: "error",
+            },
+          );
           return;
         }
       };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -10,6 +10,8 @@ import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
+import { imageHeightSize, imageWidthSize, imageMaxSize } from "../../../utils/const";
+
 import { DeleteServiceImageAlertDialog } from "./DeleteServiceImageAlertDialog";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
@@ -28,11 +30,7 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setAnchorEl(null);
   };
   const handleUploadImage = (event) => {
-    const widthSize = 720;
-    const heightSize = 480;
-    const maxSize = 512 * 1024;
-
-    if (event.target.files[0].size >= maxSize) {
+    if (event.target.files[0].size >= imageMaxSize) {
       enqueueSnackbar("Filesize exceeds max(512KiB)", { variant: "error" });
       return;
     }
@@ -42,12 +40,12 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     reader.onload = (e) => {
       image.src = e.target?.result;
       image.onload = () => {
-        if (image.naturalWidth === widthSize && image.naturalHeight === heightSize) {
+        if (image.naturalWidth === imageWidthSize && image.naturalHeight === imageHeightSize) {
           setImageFileData(event.target.files[0]);
           setImageDeleteFlag(false);
           setImagePreview(e.target?.result);
         } else {
-          enqueueSnackbar(`Dimensions must be ${widthSize}px ${heightSize} px`, {
+          enqueueSnackbar(`Dimensions must be ${imageWidthSize}px ${imageHeightSize} px`, {
             variant: "error",
           });
           return;

--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
@@ -17,10 +17,16 @@ import {
 } from "@mui/material";
 import { tooltipClasses } from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
+import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
-import { safetyImpactProps, sortedSafetyImpacts } from "../../../utils/const";
+import {
+  safetyImpactProps,
+  sortedSafetyImpacts,
+  maxReasonSafetyImpactLengthInHalf,
+} from "../../../utils/const";
+import { countFullWidthAndHalfWidthCharacters } from "../../../utils/func";
 
 export function SafetyImpactSelectorView(props) {
   const { threatSafetyImpact, reasonSafetyImpact, updateThreatFunction } = props;
@@ -30,6 +36,8 @@ export function SafetyImpactSelectorView(props) {
   const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
 
   const defaultItem = "Default";
+
+  const { enqueueSnackbar } = useSnackbar();
 
   const handleSelectSafetyImpact = (e) => {
     if (e.target.value === defaultItem) {
@@ -58,6 +66,19 @@ export function SafetyImpactSelectorView(props) {
     };
     updateThreatFunction(requestData);
     setOpen(false);
+  };
+
+  const handleReasonSafetyImpactLengthCheck = (string) => {
+    if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxReasonSafetyImpactLengthInHalf) {
+      enqueueSnackbar(
+        `Too long reason_safety_impact. Max length is ${maxReasonSafetyImpactLengthInHalf} in half-width or ${Math.floor(maxReasonSafetyImpactLengthInHalf / 2)} in full-width`,
+        {
+          variant: "error",
+        },
+      );
+    } else {
+      setPendingReasonSafetyImpact(string);
+    }
   };
 
   const StyledTooltip = styled(({ className, ...props }) => (
@@ -138,7 +159,7 @@ export function SafetyImpactSelectorView(props) {
             rows={4}
             placeholder="Continue writing here"
             value={pendingReasonSafetyImpact}
-            onChange={(e) => setPendingReasonSafetyImpact(e.target.value)}
+            onChange={(e) => handleReasonSafetyImpactLengthCheck(e.target.value)}
           />
         </DialogContent>
         <DialogActions>

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -29,7 +29,7 @@ export const maxServiceNameLengthInHalf = 255;
 export const maxDescriptionLengthInHalf = 300;
 export const maxKeywordLengthInHalf = 20;
 export const maxKeywords = 5;
-export const  =serviceImageWidthSize 720;
+export const serviceImageWidthSize = 720;
 export const serviceImageHeightSize = 480;
 export const serviceImageMaxSize = 512 * 1024;
 

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -29,9 +29,9 @@ export const maxServiceNameLengthInHalf = 255;
 export const maxDescriptionLengthInHalf = 300;
 export const maxKeywordLengthInHalf = 20;
 export const maxKeywords = 5;
-export const imageWidthSize = 720;
-export const imageHeightSize = 480;
-export const imageMaxSize = 512 * 1024;
+export const  =serviceImageWidthSize 720;
+export const serviceImageHeightSize = 480;
+export const serviceImageMaxSize = 512 * 1024;
 
 export const actionTypeChipColors = {
   elimination: "error",

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -24,6 +24,15 @@ export const drawerWidth = 200;
 
 export const mainMaxWidth = 1100;
 
+export const maxReasonSafetyImpactLengthInHalf = 500;
+export const maxServiceNameLengthInHalf = 255;
+export const maxDescriptionLengthInHalf = 300;
+export const maxKeywordLengthInHalf = 20;
+export const maxKeywords = 5;
+export const imageWidthSize = 720;
+export const imageHeightSize = 480;
+export const imageMaxSize = 512 * 1024;
+
 export const actionTypeChipColors = {
   elimination: "error",
   mitigation: "warning",

--- a/web/src/utils/func.js
+++ b/web/src/utils/func.js
@@ -129,3 +129,19 @@ export const checkAdmin = (member, pteamId) => {
     (pteam_role) => pteam_role.pteam.pteam_id === pteamId && pteam_role.is_admin,
   );
 };
+
+export const countFullWidthAndHalfWidthCharacters = (string) => {
+  let count = 0;
+  for (let i = 0; i < string.length; i++) {
+    const char = string[i];
+    if (string[i].match(/[ -~｡-ﾟ]/)) {
+      // half-width characters
+      count += 1;
+    } else {
+      // full-width characters
+      count += 2;
+    }
+  }
+
+  return count;
+};


### PR DESCRIPTION
## PR の目的
- サービス詳細編集についてキーワード個数と文字数のチェックをUI層に追加しました
- Status詳細画面でticketにあるsafety_impactを変更した際に表示される変更理由を入力する画面においても文字数制限を行いました
- [このPR](https://github.com/nttcom/threatconnectome/pull/537)でわかりずらくなっていた変数名を修正しました

## 経緯・意図・意思決定
###文字数制限
- web/src/utils/const.js
   - エラー判定に使用する閾値についてconst.jsに定義しました
- web/src/utils/func.js
  - 全角、半角を判定する関数をfunc.jsに定義しました
  - pythonみたいな全角、半角を判定するライブラリーが見当たらなかったため、正規表現で判定しました
- web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
  - keyword, description, service_nameの文字数制限を追加しました
- web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
  - safety_impact変更理由についても文字数制限を追加しました

###keyword個数制限
- web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
  - 6つ目追加しようとした時、ボタンを押せないようにしました
  - またスナックバーでエラー通知を出すようにしました

### 変数名の変更
- 以下のファイルにあった`noImageAvailableUrl`について変更しました
  - web/src/pages/Status/ServiceDetailsSettings/DeleteServiceImageAlertDialog.jsx
  - web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettings.jsx
- エラー判定に使用する閾値をconst.jsに定義したため、以下のファイルにあった`widthSize`, `heightSize`, `maxSize`についてもconst.jsに移動させました
  - web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx


## 参考文献
全角判定に使用する正規表現
https://qiita.com/SZR/items/837574ffe887a7556fa6
https://tabibitojin.com/regular-expression-symbols-alphanumeric/
https://fuuno.net/web02/hankaku/hankaku.html
