### PR TITLE
Add CloseIcon to PTeamServiceDetailsSettingsView

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -1,4 +1,4 @@
-import SettingsIcon from "@mui/icons-material/Settings";
+import { Close as CloseIcon, Settings as SettingsIcon } from "@mui/icons-material";
 import {
   Box,
   Button,
@@ -13,10 +13,13 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
+  Typography,
 } from "@mui/material";
+import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
+import dialogStyle from "../../../cssModule/dialog.module.css";
 
 import {
   maxServiceNameLengthInHalf,
@@ -156,7 +159,16 @@ export function PTeamServiceDetailsSettingsView(props) {
         <SettingsIcon />
       </IconButton>
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
-        <DialogTitle>Service settings</DialogTitle>
+        <DialogTitle flexGrow={1}>
+          <Box alignItems="center" display="flex" flexDirection="row">
+            <Typography flexGrow={1} className={dialogStyle.dialog_title}>
+              Service settings
+            </Typography>
+            <IconButton onClick={handleClose} sx={{ color: grey[500] }}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
         <DialogContent dividers>
           <Stack spacing={2}>
             <Box sx={{ display: "flex", flexDirection: "column" }}>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -19,8 +19,8 @@ import { grey } from "@mui/material/colors";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
 import React, { useEffect, useState } from "react";
-import dialogStyle from "../../../cssModule/dialog.module.css";
 
+import dialogStyle from "../../../cssModule/dialog.module.css";
 import {
   maxServiceNameLengthInHalf,
   maxDescriptionLengthInHalf,


### PR DESCRIPTION
## PR の目的
- Service settingsダイアログに×ボタン（CLoseIcon）を追加
   - Team settingsダイアログのDialog Titleコンポーネントと同じコードを追加
      - https://github.com/nttcom/threatconnectome/blob/main/web/src/components/PTeamSettingsModal.jsx#L51-L61

## 経緯・意図・意思決定
- Service settingsダイアログにダイアログを閉じるボタンが存在しなかったため
