### PR TITLE
topic/fix warning on tag screen

### DIFF
--- a/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Tag/TopicTables/SafetyImpactSelectorView.jsx
@@ -167,8 +167,8 @@ export function SafetyImpactSelectorView(props) {
   );
 }
 SafetyImpactSelectorView.propTypes = {
-  fixedThreatSafetyImpact: PropTypes.string.isRequired,
-  fixedReasonSafetyImpact: PropTypes.string.isRequired,
+  fixedThreatSafetyImpact: PropTypes.string,
+  fixedReasonSafetyImpact: PropTypes.string,
   onRevertedToDefault: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- Tag画面を開いた時にWebコンソールに表示される警告文について対応しました
- 警告文
  - `Warning: Failed prop type: The prop fixedThreatSafetyImpact is marked as required in SafetyImpactSelectorView, but its value is null.`
  - `Warning: Failed prop type: The prop fixedReasonSafetyImpact is marked as required in SafetyImpactSelectorView, but its value is null.`

## 経緯・意図・意思決定
- 警告の原因
  - SafetyImpactSelectorView.jsxのpropsとして渡されている`fixedThreatSafetyImpact`と`fixedReasonSafetyImpact`について、仕様としてstring型かnullのどちらかが入ります。
  - しかしpropsの型定義で`PropTypes.string.isRequired`となっており、string型必須となっていました。
- 対策
  - `isRequired`を削除し、string型必須の設定をやめました