### PR TITLE
Topic/recalculate ssvc priority

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -358,7 +358,12 @@ export const tcApi = createApi({
         method: "GET",
       }),
       providesTags: (result, error, arg) => [
-        ...(result ? result.map((ticket) => ({ type: "TicketStatus", id: ticket.ticket_id })) : []),
+        ...(result
+          ? result.flatMap((ticket) => [
+              { type: "TicketStatus", id: ticket.ticket_id },
+              { type: "Threat", id: ticket.threat_id },
+            ])
+          : []),
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
         { type: "Service", id: "ALL" },

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -348,7 +348,10 @@ export const tcApi = createApi({
         method: "PUT",
         body: data,
       }),
-      invalidatesTags: (result, error, arg) => [{ type: "Threat", id: arg.threatId }],
+      invalidatesTags: (result, error, arg) => [
+        { type: "Threat", id: arg.threatId },
+        { type: "Ticket", id: "ALL" },
+      ],
     }),
 
     /* Ticket */
@@ -358,12 +361,7 @@ export const tcApi = createApi({
         method: "GET",
       }),
       providesTags: (result, error, arg) => [
-        ...(result
-          ? result.flatMap((ticket) => [
-              { type: "TicketStatus", id: ticket.ticket_id },
-              { type: "Threat", id: ticket.threat_id },
-            ])
-          : []),
+        ...(result ? result.map((ticket) => ({ type: "TicketStatus", id: ticket.ticket_id })) : []),
         { type: "Ticket", id: "ALL" },
         { type: "Threat", id: "ALL" },
         { type: "Service", id: "ALL" },


### PR DESCRIPTION
## PR の目的

- threat の safety impact の変更時に ticket の ssvc_deployer_priority を再計算するように修正
  - api 側で再計算していなかったため、再計算するように修正
  - ui 側で threat 更新時に ticket のキャッシュを破棄するように改修
