### PR TITLE
change deletePTeamService

### DIFF
--- a/scripts/upload_tags_file.py
+++ b/scripts/upload_tags_file.py
@@ -104,10 +104,6 @@ class ThreatconnectomeClient:
         response = self.retry_call(requests.post, url, params=params, files=files)
         return response.json()
 
-    def remove_pteamtags_by_group(self, pteam_id: UUID | str):
-        url = f"{self.api_url}/pteams/{pteam_id}/tags"
-        self.retry_call(requests.delete, url)
-
 
 ARGUMENTS: list[tuple[str, dict]] = [
     (
@@ -195,9 +191,6 @@ def main(args: argparse.Namespace) -> None:
         all_lines = list(args.infile)
         all_lines_length = len(all_lines)
         limit = args.gradual if args.gradual < all_lines_length else all_lines_length
-        trace_message(f"removing all artifact tags for {args.service}...", end="")
-        tc_client.remove_pteamtags_by_group(args.pteam_id)
-        trace_message("done")
         while True:
             if limit > all_lines_length:
                 limit = all_lines_length

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -72,7 +72,7 @@ export function PTeamServiceDelete(props) {
     }
     await Promise.all(
       checked.map((service) =>
-        deletePTeamService({ pteamId: pteamId, serviceName: service.service_name }).unwrap(),
+        deletePTeamService({ pteamId: pteamId, serviceId: service.service_id }).unwrap(),
       ),
     )
       .then((success) => {

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -208,9 +208,8 @@ export const tcApi = createApi({
       ],
     }),
     deletePTeamService: builder.mutation({
-      query: ({ pteamId, serviceName }) => ({
-        url: `pteams/${pteamId}/tags`,
-        params: { service: serviceName },
+      query: ({ pteamId, serviceId }) => ({
+        url: `pteams/${pteamId}/services/${serviceId}`,
         method: "DELETE",
       }),
       invalidatesTags: (result, error, arg) => [{ type: "Service", id: "ALL" }],


### PR DESCRIPTION
## PR の目的
- サービス削除API
[DELETE /pteams/{pteam_id}/tags]
は現状、サービス名を指定するが、これをservice_idを指定するよう変更する
- 上記URLが分かりにくいと指摘を受けており、下記に変更する
[DELETE /pteams/{pteam_id}/services/{service_id}]
- upload_tags_file.py remove_pteamtags_by_group()はサービス削除APIにサービス名を指定しておらず、常にエラーとなる状態であった。
不要な処理のため削除する。

## 経緯・意図・意思決定
サービス名指定からservice_id指定に変える理由
・UIから簡単にservice_idを取得できるようになっている
・サービス名の変更をサポートした
