### PR TITLE
Topic/gray out save button before any changes are made in service settings

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -65,15 +65,14 @@ export function PTeamServiceDetailsSettingsView(props) {
   }, [service]);
 
   useEffect(() => {
-    const isServiceChanged =
+    setIsChanged(
       serviceName !== service.service_name ||
-      imageFileData !== null ||
-      currentKeywordsList.length !== service.keywords.length ||
-      currentKeywordsList.some((keyword, index) => keyword !== service.keywords[index]) ||
-      currentDescription !== service.description ||
-      defaultSafetyImpactValue !== service.service_safety_impact;
-
-    setIsChanged(isServiceChanged);
+        imageFileData !== null ||
+        currentKeywordsList.length !== service.keywords.length ||
+        currentKeywordsList.some((keyword, index) => keyword !== service.keywords[index]) ||
+        currentDescription !== service.description ||
+        defaultSafetyImpactValue !== service.service_safety_impact,
+    );
   }, [
     serviceName,
     imageFileData,
@@ -82,7 +81,6 @@ export function PTeamServiceDetailsSettingsView(props) {
     defaultSafetyImpactValue,
     service,
   ]);
-
   const handleClose = () => {
     setOpen(false);
   };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -70,6 +70,24 @@ export function PTeamServiceDetailsSettingsView(props) {
     setIsChanged(false);
   }, [service]);
 
+  useEffect(() => {
+    const isServiceChanged =
+      serviceName !== service.service_name ||
+      imageFileData !== null ||
+      currentKeywordsList !== service.keywords ||
+      currentDescription !== service.description ||
+      defaultSafetyImpactValue !== service.service_safety_impact;
+
+    setIsChanged(isServiceChanged);
+  }, [
+    serviceName,
+    imageFileData,
+    currentKeywordsList,
+    currentDescription,
+    defaultSafetyImpactValue,
+    service,
+  ]);
+
   const handleClose = () => {
     setOpen(false);
   };
@@ -95,11 +113,6 @@ export function PTeamServiceDetailsSettingsView(props) {
       );
     } else {
       setServiceName(string);
-      if (string !== service.service_name) {
-        setIsChanged(true);
-      } else {
-        setIsChanged(false);
-      }
     }
   };
 
@@ -113,11 +126,6 @@ export function PTeamServiceDetailsSettingsView(props) {
       );
     } else {
       setKeywordText(string);
-      if (string !== service.keywords) {
-        setIsChanged(true);
-      } else {
-        setIsChanged(false);
-      }
     }
   };
 
@@ -131,13 +139,6 @@ export function PTeamServiceDetailsSettingsView(props) {
       );
     } else {
       setCurrentDescription(string);
-      if (string === "" && service.description === null) {
-        setIsChanged(false);
-      } else if (string !== service.description) {
-        setIsChanged(true);
-      } else {
-        setIsChanged(false);
-      }
     }
   };
 

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -113,7 +113,6 @@ export function PTeamServiceDetailsSettingsView(props) {
     } else {
       setKeywordText(string);
       if (string !== service.keywords) {
-        console.log("service.keywords", service.keywords);
         setIsChanged(true);
       } else {
         setIsChanged(false);

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -68,7 +68,8 @@ export function PTeamServiceDetailsSettingsView(props) {
     const isServiceChanged =
       serviceName !== service.service_name ||
       imageFileData !== null ||
-      currentKeywordsList !== service.keywords ||
+      currentKeywordsList.length !== service.keywords.length ||
+      currentKeywordsList.some((keyword, index) => keyword !== service.keywords[index]) ||
       currentDescription !== service.description ||
       defaultSafetyImpactValue !== service.service_safety_impact;
 

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -266,9 +266,6 @@ export function PTeamServiceDetailsSettingsView(props) {
                       onClick={() => {
                         setKeywordAddingMode(false);
                         setKeywordText("");
-                        const isKeywordsChanged =
-                          JSON.stringify(currentKeywordsList) !== JSON.stringify(service.keywords);
-                        setIsChanged(isKeywordsChanged);
                       }}
                     >
                       Cancel

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -145,16 +145,6 @@ export function PTeamServiceDetailsSettingsView(props) {
     }
   };
 
-  const handleSafetyImpactChange = (value) => {
-    setDefaultSafetyImpactValue(value);
-
-    if (value !== service.service_safety_impact) {
-      setIsChanged(true);
-    } else {
-      setIsChanged(false);
-    }
-  };
-
   const handleUpdatePTeamService = async () =>
     onSave(
       serviceName,
@@ -289,7 +279,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                   <ToggleButton
                     key={value}
                     value={value}
-                    onClick={() => handleSafetyImpactChange(value)}
+                    onClick={() => setDefaultSafetyImpactValue(value)}
                   >
                     {value}
                   </ToggleButton>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -68,7 +68,6 @@ export function PTeamServiceDetailsSettingsView(props) {
   useEffect(() => {
     setIsChanged(
       serviceName !== service.service_name ||
-        imageFileData !== null ||
         currentKeywordsList.length !== service.keywords.length ||
         currentKeywordsList.some((keyword, index) => keyword !== service.keywords[index]) ||
         currentDescription !== service.description ||

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -38,6 +38,7 @@ export function PTeamServiceDetailsSettingsView(props) {
   const [imageFileData, setImageFileData] = useState(null);
   const [imageDeleteFalg, setImageDeleteFlag] = useState(false);
   const [imagePreview, setImagePreview] = useState(null);
+  const [originalImage, setOriginalImage] = useState(image);
   const [currentKeywordsList, setCurrentKeywordsList] = useState(service.keywords);
   const [originalKeywordsList, setOriginalKeywordsList] = useState(service.keywords);
   const [keywordText, setKeywordText] = useState("");
@@ -214,6 +215,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                   setImageDeleteFlag={setImageDeleteFlag}
                   setImagePreview={setImagePreview}
                   setIsChanged={setIsChanged}
+                  originalImage={originalImage}
                 />
               </Box>
             </Box>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -38,19 +38,13 @@ export function PTeamServiceDetailsSettingsView(props) {
   const [imageFileData, setImageFileData] = useState(null);
   const [imageDeleteFalg, setImageDeleteFlag] = useState(false);
   const [imagePreview, setImagePreview] = useState(null);
-  const [originalImage, setOriginalImage] = useState(image);
   const [currentKeywordsList, setCurrentKeywordsList] = useState(service.keywords);
-  const [originalKeywordsList, setOriginalKeywordsList] = useState(service.keywords);
   const [keywordText, setKeywordText] = useState("");
   const [open, setOpen] = useState(false);
   const [keywordAddingMode, setKeywordAddingMode] = useState(false);
   const [currentDescription, setCurrentDescription] = useState(service.description);
-  const [originalDescription, setOriginalDescription] = useState(service.description);
   const safetyImpactList = ["negligible", "marginal", "critical", "catastrophic"];
   const [defaultSafetyImpactValue, setDefaultSafetyImpactValue] = useState(
-    service.service_safety_impact,
-  );
-  const [originalSafetyImpactValue, setOriginalSafetyImpactValue] = useState(
     service.service_safety_impact,
   );
 
@@ -154,7 +148,7 @@ export function PTeamServiceDetailsSettingsView(props) {
   const handleSafetyImpactChange = (value) => {
     setDefaultSafetyImpactValue(value);
 
-    if (value !== originalSafetyImpactValue) {
+    if (value !== service.service_safety_impact) {
       setIsChanged(true);
     } else {
       setIsChanged(false);
@@ -216,7 +210,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                   setImageDeleteFlag={setImageDeleteFlag}
                   setImagePreview={setImagePreview}
                   setIsChanged={setIsChanged}
-                  originalImage={originalImage}
+                  originalImage={image}
                 />
               </Box>
             </Box>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -154,9 +154,9 @@ export function PTeamServiceDetailsSettingsView(props) {
     setDefaultSafetyImpactValue(value);
 
     if (value !== originalSafetyImpactValue) {
-      setIsChanged(true); // 変更があった場合は isChanged を true に
+      setIsChanged(true);
     } else {
-      setIsChanged(false); // 元の値に戻った場合は isChanged を false に
+      setIsChanged(false);
     }
   };
 
@@ -226,7 +226,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                     <Chip
                       key={keyword}
                       label={keyword}
-                      onDelete={() => handleDeleteKeyword(keyword)} // 削除処理
+                      onDelete={() => handleDeleteKeyword(keyword)}
                     />
                   ))}
                 </Stack>
@@ -236,7 +236,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                       variant="outlined"
                       size="small"
                       value={keywordText}
-                      onChange={(e) => handleKeywordSetting(e.target.value)} // キーワード入力処理
+                      onChange={(e) => handleKeywordSetting(e.target.value)}
                       sx={{ mr: 1 }}
                       error={currentKeywordsList.includes(keywordText)}
                       helperText={

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -49,6 +49,7 @@ export function PTeamServiceDetailsSettingsView(props) {
   );
 
   const [isChanged, setIsChanged] = useState(false);
+  const [isImageChanged, setIsImageChanged] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -71,7 +72,8 @@ export function PTeamServiceDetailsSettingsView(props) {
         currentKeywordsList.length !== service.keywords.length ||
         currentKeywordsList.some((keyword, index) => keyword !== service.keywords[index]) ||
         currentDescription !== service.description ||
-        defaultSafetyImpactValue !== service.service_safety_impact,
+        defaultSafetyImpactValue !== service.service_safety_impact ||
+        isImageChanged,
     );
   }, [
     serviceName,
@@ -80,6 +82,7 @@ export function PTeamServiceDetailsSettingsView(props) {
     currentDescription,
     defaultSafetyImpactValue,
     service,
+    isImageChanged,
   ]);
   const handleClose = () => {
     setOpen(false);
@@ -91,9 +94,6 @@ export function PTeamServiceDetailsSettingsView(props) {
     const keywordsListCopy = JSON.parse(JSON.stringify(currentKeywordsList));
     const filteredKeywordsList = keywordsListCopy.filter((keyword) => keyword !== item);
     setCurrentKeywordsList(filteredKeywordsList);
-    const isKeywordsChanged =
-      JSON.stringify(filteredKeywordsList) !== JSON.stringify(service.keywords);
-    setIsChanged(isKeywordsChanged);
   };
 
   const handleServiceNameSetting = (string) => {
@@ -198,7 +198,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                   setImageFileData={setImageFileData}
                   setImageDeleteFlag={setImageDeleteFlag}
                   setImagePreview={setImagePreview}
-                  setIsChanged={setIsChanged}
+                  setIsImageChanged={setIsImageChanged}
                   originalImage={image}
                 />
               </Box>
@@ -235,9 +235,6 @@ export function PTeamServiceDetailsSettingsView(props) {
                       onClick={() => {
                         const updatedKeywordsList = [...currentKeywordsList, keywordText];
                         setCurrentKeywordsList(updatedKeywordsList);
-                        const isKeywordsChanged =
-                          JSON.stringify(updatedKeywordsList) !== JSON.stringify(service.keywords);
-                        setIsChanged(isKeywordsChanged);
                         setKeywordText("");
                         setKeywordAddingMode(false);
                       }}

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -8,7 +8,7 @@ import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import {
   serviceImageHeightSize,

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -8,7 +8,7 @@ import MenuItem from "@mui/material/MenuItem";
 import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import {
   serviceImageHeightSize,
@@ -17,7 +17,7 @@ import {
 } from "../../../utils/const";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
-  const { setImageFileData, setImageDeleteFlag, setImagePreview } = props;
+  const { setImageFileData, setImageDeleteFlag, setImagePreview, setIsChanged } = props;
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -49,6 +49,7 @@ export function PTeamServiceImageUploadDeleteButton(props) {
           setImageFileData(event.target.files[0]);
           setImageDeleteFlag(false);
           setImagePreview(e.target?.result);
+          setIsChanged(true);
         } else {
           enqueueSnackbar(
             `Dimensions must be ${serviceImageWidthSize}px ${serviceImageHeightSize} px`,
@@ -67,6 +68,7 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setImageFileData(null);
     setImageDeleteFlag(true);
     setImagePreview(serviceDetailsSetttingNoImageUrl);
+    setIsChanged(true);
   };
 
   const VisuallyHiddenInput = styled("input")({

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -17,8 +17,13 @@ import {
 } from "../../../utils/const";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
-  const { setImageFileData, setImageDeleteFlag, setImagePreview, setIsChanged, originalImage } =
-    props;
+  const {
+    setImageFileData,
+    setImageDeleteFlag,
+    setImagePreview,
+    setIsImageChanged,
+    originalImage,
+  } = props;
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -51,9 +56,9 @@ export function PTeamServiceImageUploadDeleteButton(props) {
           setImageDeleteFlag(false);
           setImagePreview(e.target?.result);
           if (originalImage === e.target?.result) {
-            setIsChanged(false);
+            setIsImageChanged(false);
           } else {
-            setIsChanged(true);
+            setIsImageChanged(true);
           }
         } else {
           enqueueSnackbar(
@@ -74,9 +79,9 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setImageDeleteFlag(true);
     setImagePreview(serviceDetailsSetttingNoImageUrl);
     if (originalImage === "images/720x480.png") {
-      setIsChanged(false);
+      setIsImageChanged(false);
     } else {
-      setIsChanged(true);
+      setIsImageChanged(true);
     }
   };
 
@@ -128,6 +133,6 @@ PTeamServiceImageUploadDeleteButton.propTypes = {
   setImageFileData: PropTypes.func.isRequired,
   setImageDeleteFlag: PropTypes.func.isRequired,
   setImagePreview: PropTypes.func.isRequired,
-  setIsChanged: PropTypes.func.isRequired,
+  setIsImageChanged: PropTypes.func.isRequired,
   originalImage: PropTypes.string.isRequired,
 };

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -17,7 +17,8 @@ import {
 } from "../../../utils/const";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
-  const { setImageFileData, setImageDeleteFlag, setImagePreview, setIsChanged } = props;
+  const { setImageFileData, setImageDeleteFlag, setImagePreview, setIsChanged, originalImage } =
+    props;
 
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -49,7 +50,11 @@ export function PTeamServiceImageUploadDeleteButton(props) {
           setImageFileData(event.target.files[0]);
           setImageDeleteFlag(false);
           setImagePreview(e.target?.result);
-          setIsChanged(true);
+          if (originalImage === e.target?.result) {
+            setIsChanged(false);
+          } else {
+            setIsChanged(true);
+          }
         } else {
           enqueueSnackbar(
             `Dimensions must be ${serviceImageWidthSize}px ${serviceImageHeightSize} px`,
@@ -68,7 +73,11 @@ export function PTeamServiceImageUploadDeleteButton(props) {
     setImageFileData(null);
     setImageDeleteFlag(true);
     setImagePreview(serviceDetailsSetttingNoImageUrl);
-    setIsChanged(true);
+    if (originalImage === "images/720x480.png") {
+      setIsChanged(false);
+    } else {
+      setIsChanged(true);
+    }
   };
 
   const VisuallyHiddenInput = styled("input")({

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -128,4 +128,6 @@ PTeamServiceImageUploadDeleteButton.propTypes = {
   setImageFileData: PropTypes.func.isRequired,
   setImageDeleteFlag: PropTypes.func.isRequired,
   setImagePreview: PropTypes.func.isRequired,
+  setIsChanged: PropTypes.func.isRequired,
+  originalImage: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- Service編集ダイアログ（Service settings）にて設定が変更されたときのみSAVEボタンが有効になるように修正
   - 現在の設定が元の設定と異なるかどうかを示すフラグ **isChanged** を用いて実装（以下は全て動作検証済み）
      - **Name**
         - 【SAVE有効】
            - 入力したサービス名と元のサービス名が異なっている場合
         - 【SAVE無効】
            - 何も変更を加えていない状態
            - 一度変更したのちにもう一度（ダイアログを閉じないで）元と同じ名前を付けた場合
      - **Image**
         - 【SAVE有効】
            - デフォルト（"images/720x480.png"）の状態で新しい画像を追加した場合
            - 何らかの画像が設定してある状態で画像削除した場合
         - 【SAVE無効】
            - 何の変更も加えていない状態
            - デフォルト画像に新しい画像を追加したのちに画像削除をしてデフォルト画像に戻した場合
            - 何らかの画像が設定してある状態で画像削除したのちに削除前と同じ画像を追加した場合
               - ※画像削除したのちに削除前と違う画像を追加した場合は元の状態と変化があるのでSAVEは有効化
      - **Keywords**
         - 【SAVE有効】
            - 新しいキーワードを追加した場合あるいは既存のキーワードを削除した場合
         - 【SAVE無効】
            - キーワードを追加したのちに追加したキーワードを削除した場合
            - 既存のキーワードを削除したのちに、同じキーワードを追加した場合
      - **Description**
         - 【SAVE有効】
            - サービスの説明文を変更した場合
         - 【SAVE無効】
            - 何も変更を加えていない状態
            - 一度変更したのちにもう一度文を削除、あるいは追加して変更前の文と同じになった場合
      - **Default Safety Impact**
         - 【SAVE有効】
            - Default Safety Impactを変更した場合
         - 【SAVE無効】
            - 何も変更を加えていない状態
            - 一度変更したのちにもう一度元の値に戻した場合         

## 経緯・意図・意思決定
- Service編集ダイアログ（Service settings）にて設定が変更されなくてもSAVEボタンが押せるようになっていたためsettings）にて設定が変更されなくてもSAVEボタンが押せるようになっていたため
