### PR TITLE
Implement the user deletion API in users.py

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -157,7 +157,9 @@ class PTeamAccountRole(Base):
     )
     is_admin: Mapped[bool] = mapped_column(default=False)
 
-    pteam = relationship("PTeam", back_populates="pteam_role", uselist=False, cascade="all, delete")
+    pteam = relationship(
+        "PTeam", back_populates="pteam_roles", uselist=False, cascade="all, delete"
+    )
     account = relationship(
         "Account", back_populates="pteam_roles", uselist=False, cascade="all, delete"
     )
@@ -442,9 +444,7 @@ class PTeam(Base):
         cascade="all, delete-orphan",
     )
     members = relationship("Account", secondary=PTeamAccountRole.__tablename__)
-    pteam_role = relationship(
-        "PTeamAccountRole", back_populates="pteam", uselist=False, cascade="all, delete"
-    )
+    pteam_roles = relationship("PTeamAccountRole", back_populates="pteam", cascade="all, delete")
     invitations = relationship("PTeamInvitation", back_populates="pteam")
     alert_slack: Mapped["PTeamSlack"] = relationship(
         back_populates="pteam", cascade="all, delete-orphan"

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -157,12 +157,8 @@ class PTeamAccountRole(Base):
     )
     is_admin: Mapped[bool] = mapped_column(default=False)
 
-    pteam = relationship(
-        "PTeam", back_populates="pteam_roles", uselist=False, cascade="all, delete"
-    )
-    account = relationship(
-        "Account", back_populates="pteam_roles", uselist=False, cascade="all, delete"
-    )
+    pteam = relationship("PTeam", back_populates="pteam_roles", uselist=False)
+    account = relationship("Account", back_populates="pteam_roles", uselist=False)
 
 
 class TopicTag(Base):

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -96,7 +96,7 @@ def update_user(
     return user
 
 
-@router.delete("", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
 def delete_user(
     current_user: models.Account = Depends(get_current_user), db: Session = Depends(get_db)
 ):

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -101,12 +101,24 @@ def delete_user(
     current_user: models.Account = Depends(get_current_user), db: Session = Depends(get_db)
 ):
     """
-    Delete current user.
+    Delete current user and left admin-less pteams.
     """
 
     for log in current_user.action_logs:
         # actoin logs shoud not be deleted, but should be anonymized
-        log.user_id = None
+        log.user_id = (
+            None  # Current_user.user_id should be removed from the assignees of the ticket status.
+        )
+
+    def having_only_one_admin(pteam: models.PTeam):
+        return len(list(filter(lambda x: x.is_admin is True, pteam.pteam_roles))) == 1
+
+    for delete_target in [
+        role.pteam
+        for role in current_user.pteam_roles
+        if role.is_admin and having_only_one_admin(role.pteam)
+    ]:
+        persistence.delete_pteam(db, delete_target)
 
     persistence.delete_account(db, current_user)
     db.commit()

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -106,9 +106,9 @@ def delete_user(
 
     for log in current_user.action_logs:
         # actoin logs shoud not be deleted, but should be anonymized
-        log.user_id = (
-            None  # Current_user.user_id should be removed from the assignees of the ticket status.
-        )
+        log.user_id = None
+
+    # Current_user.user_id should be removed from the assignees of the ticket status.
 
     def having_only_one_admin(pteam: models.PTeam):
         return len(list(filter(lambda x: x.is_admin is True, pteam.pteam_roles))) == 1

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -9,7 +9,6 @@ from app.tests.medium.constants import (
     PTEAM1,
     USER1,
     USER2,
-    USER3,
 )
 from app.tests.medium.utils import (
     accept_pteam_invitation,
@@ -57,68 +56,6 @@ class TestDeleteUser:
         )
         for log in action_logs:
             assert log.user_id is None
-
-        deleted_pteam = testdb.execute(
-            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
-        ).scalar_one_or_none()
-        assert deleted_pteam is None
-
-    def test_delete_user_if_not_last_admin(self, user_setup, testdb: Session):
-        user1 = user_setup["user1"]
-        user2 = user_setup["user2"]
-        pteam1 = user_setup["pteam1"]
-
-        user3 = create_user(USER3)
-        pteam_role = models.PTeamAccountRole(
-            account_id=user3["user_id"], pteam_id=pteam1.pteam_id, is_admin=True
-        )
-        testdb.add(pteam_role)
-        testdb.commit()
-
-        delete_response = client.delete("/me", headers=headers(USER1))
-        assert delete_response.status_code == 204
-
-        deleted_user = testdb.execute(
-            select(models.Account).where(models.Account.user_id == str(user1.user_id))
-        ).scalar_one_or_none()
-        assert deleted_user is None
-
-        deleted_pteam = testdb.execute(
-            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
-        ).scalar_one_or_none()
-        assert deleted_pteam is not None
-
-    def test_delete_user_if_not_admin(self, user_setup, testdb: Session):
-        user1 = user_setup["user1"]
-        pteam1 = user_setup["pteam1"]
-
-        pteam_role = models.PTeamAccountRole(
-            account_id=user1.user_id,
-            pteam_id=pteam1.pteam_id,
-            is_admin=False,
-        )
-        testdb.add(pteam_role)
-        testdb.commit()
-
-        delete_response = client.delete("/me", headers=headers(USER1))
-        assert delete_response.status_code == 204
-
-        deleted_user = testdb.execute(
-            select(models.Account).where(models.Account.user_id == str(user1.user_id))
-        ).scalar_one_or_none()
-        assert deleted_user is None
-
-        deleted_pteam = testdb.execute(
-            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
-        ).scalar_one_or_none()
-        assert deleted_pteam is not None
-
-    def test_delete_user_if_last_admin(self, user_setup, testdb: Session):
-        user1 = user_setup["user1"]
-        pteam1 = user_setup["pteam1"]
-
-        delete_response = client.delete("/me", headers=headers(USER1))
-        assert delete_response.status_code == 204
 
         deleted_pteam = testdb.execute(
             select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -1,0 +1,126 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app import models
+from app.main import app
+from app.tests.medium.constants import (
+    PTEAM1,
+    USER1,
+    USER2,
+    USER3,
+)
+from app.tests.medium.utils import (
+    accept_pteam_invitation,
+    create_pteam,
+    create_user,
+    headers,
+    invite_to_pteam,
+)
+
+client = TestClient(app)
+
+
+class TestDeleteUser:
+    @pytest.fixture(scope="function")
+    def user_setup(self, testdb: Session):
+        user1 = create_user(USER1)
+        user2 = create_user(USER2)
+
+        pteam_data = PTEAM1
+        pteam1 = create_pteam(USER1, pteam_data)
+
+        invite = invite_to_pteam(USER1, pteam1.pteam_id)
+        accept_pteam_invitation(USER2, invite.invitation_id)
+
+        return {"user1": user1, "user2": user2, "pteam1": pteam1}
+
+    def test_delete_user_success(self, user_setup, testdb: Session):
+        user1 = user_setup["user1"]
+        pteam1 = user_setup["pteam1"]
+
+        delete_response = client.delete("/users/me", headers=headers(USER1))
+        assert delete_response.status_code == 204
+
+        deleted_user = testdb.execute(
+            select(models.Account).where(models.Account.user_id == str(user1.user_id))
+        ).scalar_one_or_none()
+        assert deleted_user is None
+
+        action_logs = (
+            testdb.execute(
+                select(models.ActionLog).where(models.ActionLog.user_id == str(user1.user_id))
+            )
+            .scalars()
+            .all()
+        )
+        for log in action_logs:
+            assert log.user_id is None
+
+        deleted_pteam = testdb.execute(
+            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
+        ).scalar_one_or_none()
+        assert deleted_pteam is None
+
+    def test_delete_user_if_not_last_admin(self, user_setup, testdb: Session):
+        user1 = user_setup["user1"]
+        user2 = user_setup["user2"]
+        pteam1 = user_setup["pteam1"]
+
+        user3 = create_user(USER3)
+        pteam_role = models.PTeamAccountRole(
+            account_id=user3["user_id"], pteam_id=pteam1.pteam_id, is_admin=True
+        )
+        testdb.add(pteam_role)
+        testdb.commit()
+
+        delete_response = client.delete("/me", headers=headers(USER1))
+        assert delete_response.status_code == 204
+
+        deleted_user = testdb.execute(
+            select(models.Account).where(models.Account.user_id == str(user1.user_id))
+        ).scalar_one_or_none()
+        assert deleted_user is None
+
+        deleted_pteam = testdb.execute(
+            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
+        ).scalar_one_or_none()
+        assert deleted_pteam is not None
+
+    def test_delete_user_if_not_admin(self, user_setup, testdb: Session):
+        user1 = user_setup["user1"]
+        pteam1 = user_setup["pteam1"]
+
+        pteam_role = models.PTeamAccountRole(
+            account_id=user1.user_id,
+            pteam_id=pteam1.pteam_id,
+            is_admin=False,
+        )
+        testdb.add(pteam_role)
+        testdb.commit()
+
+        delete_response = client.delete("/me", headers=headers(USER1))
+        assert delete_response.status_code == 204
+
+        deleted_user = testdb.execute(
+            select(models.Account).where(models.Account.user_id == str(user1.user_id))
+        ).scalar_one_or_none()
+        assert deleted_user is None
+
+        deleted_pteam = testdb.execute(
+            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
+        ).scalar_one_or_none()
+        assert deleted_pteam is not None
+
+    def test_delete_user_if_last_admin(self, user_setup, testdb: Session):
+        user1 = user_setup["user1"]
+        pteam1 = user_setup["pteam1"]
+
+        delete_response = client.delete("/me", headers=headers(USER1))
+        assert delete_response.status_code == 204
+
+        deleted_pteam = testdb.execute(
+            select(models.PTeam).where(models.PTeam.pteam_id == str(pteam1.pteam_id))
+        ).scalar_one_or_none()
+        assert deleted_pteam is None


### PR DESCRIPTION
## PR の目的
- ユーザ削除APIの実装
   - api/app/routers/users.pyの@router.deleteに以下の処理を追加
      - ユーザーを削除した際に、そのユーザーのみがadminとなっているPTeamが存在する場合、そのPTeamも削除する
         - having_only_one_admin関数の実装
            - 特定のPTeamにおいて、is_adminがTrueであるメンバーが1人だけであるかをチェック
         - persistence.delete_pteamにより該当pteamを削除

## 経緯・意図・意思決定
- ユーザ削除機能の実装に向け、APIにユーザ削除処理を追加するため
