### PR TITLE
Topic/add pteam delete api

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -445,7 +445,9 @@ class PTeam(Base):
     pteam_role = relationship(
         "PTeamAccountRole", back_populates="pteam", uselist=False, cascade="all, delete"
     )
-    invitations = relationship("PTeamInvitation", back_populates="pteam")
+    invitations = relationship(
+        "PTeamInvitation", back_populates="pteam", cascade="all, delete-orphan"
+    )
     alert_slack: Mapped["PTeamSlack"] = relationship(
         back_populates="pteam", cascade="all, delete-orphan"
     )

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1368,3 +1368,21 @@ def delete_invitation(
     db.commit()  # commit not only deleted but also expired
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)  # avoid Content-Length Header
+
+
+@router.delete("/{pteam_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_pteam(
+    pteam_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_admin_authority(db, pteam, current_user):
+        raise NOT_HAVE_AUTH
+
+    persistence.delete_pteam(db, pteam)
+
+    db.commit()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4131,8 +4131,9 @@ class TestDeletePteam:
 
     def test_raise_403_if_user_is_not_pteam_admin(self, testdb: Session, pteam_setup):
         create_user(USER2)
-
         pteam_id = pteam_setup["pteam_id"]
+
+        # delete pteam
         delete_pteam_response = client.delete(
             f"/pteams/{pteam_id}",
             headers=headers(USER2),
@@ -4142,11 +4143,9 @@ class TestDeletePteam:
         assert delete_pteam_response.json()["detail"] == "You do not have authority"
 
     def test_raise_404_if_invalid_pteam_id(self, testdb: Session, pteam_setup):
+        wrong_pteam_id = str(uuid4())
+
         # delete pteam
-        while True:
-            wrong_pteam_id = str(uuid4())
-            if wrong_pteam_id != pteam_setup["pteam_id"]:
-                break
         delete_pteam_response = client.delete(
             f"/pteams/{wrong_pteam_id}",
             headers=headers(USER1),


### PR DESCRIPTION
## PR の目的
PTeam削除APIの追加
- APIエンドポイントの追加
- PTeamとPTeamInvitationの間のrelationshipにcascade設定を追加
