### PR TITLE
Fix/sa warning at deleting pteamaccountrole

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -148,6 +148,10 @@ class Base(DeclarativeBase):
 
 class PTeamAccountRole(Base):
     __tablename__ = "pteamaccountrole"
+    # deleting PTeamAccountRole via relationship may cause SAWarning,
+    #   "DELETE statement on table 'pteamaccountrole' expected to delete 2 row(s); 1 were matched."
+    # set False to confirm_deleted_rows to prevent this warning.
+    __mapper_args__ = {"confirm_deleted_rows": False}
 
     pteam_id = mapped_column(
         ForeignKey("pteam.pteam_id", ondelete="CASCADE"), primary_key=True, index=True
@@ -439,8 +443,12 @@ class PTeam(Base):
         back_populates="pteam",
         cascade="all, delete-orphan",
     )
-    members = relationship("Account", secondary=PTeamAccountRole.__tablename__)
-    pteam_roles = relationship("PTeamAccountRole", back_populates="pteam", cascade="all, delete")
+    # set members viewonly to prevent confliction with pream_roles.
+    # to update members, update pteam_foles instead.
+    members = relationship("Account", secondary=PTeamAccountRole.__tablename__, viewonly=True)
+    pteam_roles = relationship(
+        "PTeamAccountRole", back_populates="pteam", cascade="all, delete-orphan"
+    )
     invitations = relationship(
         "PTeamInvitation", back_populates="pteam", cascade="all, delete-orphan"
     )


### PR DESCRIPTION
## PR の目的

- PTeamAccountRole テーブル周りの不整合を修正
  - PTeamAccountRole テーブルに `confirm_deleted_rolws=False` を設定
    - Account および PTeam から relationship が張られているため、Account 削除時に account.pteams[x].pteam_roles と account.pteam_roles の二重削除が発生する
    - delete_pteam した際に db.refresh(current_user) しないと current_user の削除で pteam_roles の二重削除が発生しうるが、db.refresh() は現実的なアプローチとは言えない（因果関係が直感的に分かり難い）
  - PTeam.members に `viewonly=True` を設定
    - PTeam.pteam_roles と競合するため
    - members の増減処理を pteam_roles で処理するように改修

## 参考

- https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.Mapper.params.confirm_deleted_rows