### PR TITLE
Topic/add test code user delete api

### DIFF
--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -3,19 +3,29 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app import models
+from app import models, schemas
 from app.main import app
 from app.tests.medium.constants import (
     PTEAM1,
+    PTEAM2,
+    TOPIC1,
+    TOPIC2,
     USER1,
     USER2,
 )
+from app.tests.medium.exceptions import HTTPError
 from app.tests.medium.utils import (
     accept_pteam_invitation,
     create_pteam,
+    create_tag,
+    create_topic,
     create_user,
+    get_service_by_service_name,
+    get_tickets_related_to_topic_tag,
     headers,
     invite_to_pteam,
+    set_ticket_status,
+    upload_pteam_tags,
 )
 
 client = TestClient(app)
@@ -159,3 +169,216 @@ class TestDeleteUser:
         # adminではないため、PTeamは削除されていないことを確認
         existing_pteam = self._get_pteam_not_deleted(pteam1, testdb)
         assert existing_pteam is not None
+
+
+class TestDeleteUserSideEffects:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        # Setup user, pteam, service, and topic
+        self.user1 = create_user(USER1)
+        self.user2 = create_user(USER2)
+        self.pteam1 = create_pteam(USER1, PTEAM1)
+        self.pteam2 = create_pteam(USER2, PTEAM2)
+        self.tag1 = create_tag(USER1, "foobar:ubuntu-24.04:")
+
+        action1 = {
+            "action": "test action1",
+            "action_type": models.ActionType.elimination,
+            "recommended": True,
+            "ext": {
+                "tags": [self.tag1.tag_name],
+                "vulnerable_versions": {self.tag1.tag_name: ["< 9999.99.99"]},
+            },
+        }
+
+        self.topic1 = create_topic(
+            USER1, {**TOPIC1, "tags": [self.tag1.tag_name], "actions": [action1]}
+        )
+        self.topic2 = create_topic(
+            USER2, {**TOPIC2, "tags": [self.tag1.tag_name], "actions": [action1]}
+        )
+
+        refs0 = {self.tag1.tag_name: [("test target", "1.2.3"), ("noise target", "1.2.3")]}
+        service_name1 = "test service1"
+        service_name2 = "test service2"
+
+        upload_pteam_tags(USER1, self.pteam1.pteam_id, service_name1, refs0)
+        upload_pteam_tags(USER2, self.pteam2.pteam_id, service_name2, refs0)
+
+        self.service1 = get_service_by_service_name(USER1, self.pteam1.pteam_id, service_name1)
+        self.service2 = get_service_by_service_name(USER2, self.pteam2.pteam_id, service_name2)
+
+        invitation1 = invite_to_pteam(USER1, self.pteam1.pteam_id)
+        invitation2 = invite_to_pteam(USER2, self.pteam2.pteam_id)
+
+        accept_pteam_invitation(USER2, invitation1.invitation_id)
+        accept_pteam_invitation(USER1, invitation2.invitation_id)
+
+        # Setup ticket status with actionlog
+        tickets1 = get_tickets_related_to_topic_tag(
+            USER1,
+            self.pteam1.pteam_id,
+            self.service1["service_id"],
+            self.topic1.topic_id,
+            self.tag1.tag_id,
+        )
+        self.ticket1 = tickets1[0]
+
+        tickets2 = get_tickets_related_to_topic_tag(
+            USER2,
+            self.pteam2.pteam_id,
+            self.service2["service_id"],
+            self.topic2.topic_id,
+            self.tag1.tag_id,
+        )
+        self.ticket2 = tickets2[0]
+
+        # Action logs for tickets
+        log_request1 = {
+            "action_id": str(self.topic1.actions[0].action_id),
+            "topic_id": str(self.topic1.topic_id),
+            "user_id": str(self.user1.user_id),
+            "pteam_id": str(self.pteam1.pteam_id),
+            "service_id": self.service1["service_id"],
+            "ticket_id": self.ticket1["ticket_id"],
+            "executed_at": None,
+        }
+
+        log_response1 = client.post("/actionlogs", headers=headers(USER1), json=log_request1)
+        self.actionlog1 = log_response1.json()
+
+        log_request2 = {
+            "action_id": str(self.topic2.actions[0].action_id),
+            "topic_id": str(self.topic2.topic_id),
+            "user_id": str(self.user2.user_id),
+            "pteam_id": str(self.pteam2.pteam_id),
+            "service_id": self.service2["service_id"],
+            "ticket_id": self.ticket2["ticket_id"],
+            "executed_at": None,
+        }
+
+        log_response2 = client.post("/actionlogs", headers=headers(USER2), json=log_request2)
+        self.actionlog2 = log_response2.json()
+
+        # Set ticket status
+        status_request1 = {
+            "topic_status": models.TopicStatusType.completed.value,
+            "assignees": [str(self.user1.user_id)],
+            "logging_ids": [self.actionlog1["logging_id"]],
+        }
+        set_ticket_status(
+            USER1,
+            self.pteam1.pteam_id,
+            self.service1["service_id"],
+            self.ticket1["ticket_id"],
+            status_request1,
+        )
+
+        status_request2 = {
+            "topic_status": models.TopicStatusType.completed.value,
+            "assignees": [str(self.user2.user_id)],
+            "logging_ids": [self.actionlog2["logging_id"]],
+        }
+        set_ticket_status(
+            USER2,
+            self.pteam2.pteam_id,
+            self.service2["service_id"],
+            self.ticket2["ticket_id"],
+            status_request2,
+        )
+
+    @staticmethod
+    def delete_user_me(user) -> None:
+        response = client.delete("/users/me", headers=headers(user))
+        if response.status_code != 204:
+            raise HTTPError(response)
+
+    @staticmethod
+    def get_users_me(user) -> schemas.UserResponse:
+        response = client.get("/users/me", headers=headers(user))
+        if response.status_code != 200:
+            raise HTTPError(response)
+        return schemas.UserResponse(**response.json())
+
+    @staticmethod
+    def update_pteam_member(
+        operate_user, user_id, pteam_id, is_admin: bool
+    ) -> schemas.PTeamMemberResponse:
+        request = {"is_admin": is_admin}
+        response = client.put(
+            f"/pteams/{pteam_id}/members/{user_id}", headers=headers(operate_user), json=request
+        )
+        if response.status_code != 200:
+            raise HTTPError(response)
+        return schemas.PTeamMemberResponse(**response.json())
+
+    def test_cannot_get_user_after_deleted(self, testdb):
+        self.delete_user_me(USER1)
+        with pytest.raises(HTTPError, match="404: Not Found: No such user"):
+            self.get_users_me(USER1)
+
+    def test_user_id_of_deleted_users_actionlog_should_be_none(self, testdb):
+        # Make user2 admin to prevent deletion of pteam1
+        self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
+        self.delete_user_me(USER1)
+
+        # Check user_id of deleted user's actionlog
+        db_actionlog1 = testdb.scalars(
+            select(models.ActionLog).where(
+                models.ActionLog.logging_id == str(self.actionlog1["logging_id"])
+            )
+        ).one()
+        assert db_actionlog1.user_id is None
+
+    def test_user_id_of_not_deleted_users_actionlog_should_be_kept(self, testdb):
+        self.delete_user_me(USER1)
+
+        # Check user_id of non-deleted user's actionlog
+        db_actionlog2 = testdb.scalars(
+            select(models.ActionLog).where(
+                models.ActionLog.logging_id == str(self.actionlog2["logging_id"])
+            )
+        ).one()
+        assert db_actionlog2.user_id == str(self.user2.user_id)
+
+    def test_created_by_of_deleted_users_action_should_be_none(self, testdb):
+        action1 = self.topic1.actions[0]
+        # Make user2 admin to prevent deletion of pteam1
+        self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
+        self.delete_user_me(USER1)
+
+        # Check created_by of deleted user's action
+        db_action1 = testdb.scalars(
+            select(models.TopicAction).where(models.TopicAction.action_id == str(action1.action_id))
+        ).one()
+        assert db_action1.created_by is None
+
+    def test_created_by_of_not_deleted_users_action_should_be_kept(self, testdb):
+        action2 = self.topic2.actions[0]
+        self.delete_user_me(USER1)
+
+        # Check created_by of non-deleted user's action
+        db_action2 = testdb.scalars(
+            select(models.TopicAction).where(models.TopicAction.action_id == str(action2.action_id))
+        ).one()
+        assert db_action2.created_by == str(self.user2.user_id)
+
+    def test_created_by_of_deleted_users_topic_should_be_none(self, testdb):
+        # Make user2 admin to prevent deletion of pteam1
+        self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
+        self.delete_user_me(USER1)
+
+        # Check created_by of deleted user's topic
+        db_topic1 = testdb.scalars(
+            select(models.Topic).where(models.Topic.topic_id == str(self.topic1.topic_id))
+        ).one()
+        assert db_topic1.created_by is None
+
+    def test_created_by_of_not_deleted_users_topic_should_be_kept(self, testdb):
+        self.delete_user_me(USER1)
+
+        # Check created_by of non-deleted user's topic
+        db_topic2 = testdb.scalars(
+            select(models.Topic).where(models.Topic.topic_id == str(self.topic2.topic_id))
+        ).one()
+        assert db_topic2.created_by == str(self.topic2.created_by)

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -79,18 +79,18 @@ class TestDeleteUser:
         user2 = user_setup["user2"]
         pteam1 = user_setup["pteam1"]
 
-        # user2をadminに設定(use1以外にadminがいる状態に設定)
+        # Set user2 as admin (set it so that there is an admin other than user1)
         client.put(
             f"/pteams/{pteam1.pteam_id}/members/{user2.user_id}",
             headers=headers(USER1),
             json={"is_admin": True},
         )
 
-        # ユーザーが自分を削除できるかを確認
+        # Check if the user can delete themselves.
         delete_response = client.delete("/users/me", headers=headers(USER1))
         assert delete_response.status_code == 204
 
-        # ユーザー削除後の確認
+        # Confirmation after user deletion.
         deleted_user, action_logs = self._get_user_deleted(user1, testdb)
         assert deleted_user is None
         for log in action_logs:
@@ -101,23 +101,23 @@ class TestDeleteUser:
         user2 = user_setup["user2"]
         pteam1 = user_setup["pteam1"]
 
-        # user1が最後のadminであることを確認(adminではないuser2を追加)
+        # set user2, who is not an admin(user1 is the last admin)
         client.put(
             f"/pteams/{pteam1.pteam_id}/members/{user2.user_id}",
             headers=headers(USER1),
         )
 
-        # user1が自分を削除
+        # Check if the user can delete themselves.
         delete_response = client.delete("/users/me", headers=headers(USER1))
         assert delete_response.status_code == 204
 
-        # ユーザー削除後の確認
+        # Confirmation after user deletion.
         deleted_user, action_logs = self._get_user_deleted(user1, testdb)
         assert deleted_user is None
         for log in action_logs:
             assert log.user_id is None
 
-        # PTeamは削除されていることを確認
+        # Confirm that the PTeam has been deleted.
         deleted_pteam = self._get_pteam_deleted(pteam1, testdb)
         assert deleted_pteam is None
 
@@ -126,7 +126,7 @@ class TestDeleteUser:
         user2 = user_setup["user2"]
         pteam1 = user_setup["pteam1"]
 
-        # user2をadmin=Trueとして追加
+        # Set user2 as admin (set it so that there is an admin other than user1)
         client.put(
             f"/pteams/{pteam1.pteam_id}/members/{user2.user_id}",
             headers=headers(USER1),
@@ -136,13 +136,13 @@ class TestDeleteUser:
         delete_response = client.delete("/users/me", headers=headers(USER1))
         assert delete_response.status_code == 204
 
-        # ユーザー削除後の確認
+        # Confirmation after user deletion.
         deleted_user, action_logs = self._get_user_deleted(user1, testdb)
         assert deleted_user is None
         for log in action_logs:
             assert log.user_id is None
 
-        # 最後のadminではないためPTeamは削除されていないことを確認
+        # Confirm that the PTeam has not been deleted because it is not the last admin.
         existing_pteam = self._get_pteam_not_deleted(pteam1, testdb)
         assert existing_pteam is not None
 
@@ -150,7 +150,7 @@ class TestDeleteUser:
         user2 = user_setup["user2"]
         pteam1 = user_setup["pteam1"]
 
-        # user2をadminでない状態でPTeamに参加させる
+        # set user2, who is not an admin(user1 is the last admin)
         client.put(
             f"/pteams/{pteam1.pteam_id}/members/{user2.user_id}",
             headers=headers(USER1),
@@ -160,13 +160,13 @@ class TestDeleteUser:
         delete_response = client.delete("/users/me", headers=headers(USER2))
         assert delete_response.status_code == 204
 
-        # adminでないuser2を削除後の確認
+        # Confirmation after deleting user2, who is not an admin.
         deleted_user, action_logs = self._get_user_deleted(user2, testdb)
         assert deleted_user is None
         for log in action_logs:
             assert log.user_id is None
 
-        # adminではないため、PTeamは削除されていないことを確認
+        # Confirm that the PTeam has not been deleted because user2 is not an admin.
         existing_pteam = self._get_pteam_not_deleted(pteam1, testdb)
         assert existing_pteam is not None
 

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -86,10 +86,6 @@ class TestDeleteUser:
         for log in action_logs:
             assert log.user_id is None
 
-        # チームは削除されていないことを確認
-        existing_pteam = self._get_pteam_not_deleted(pteam1, testdb)
-        assert existing_pteam is not None
-
     def test_user_deletes_last_admin_and_pteam_is_deleted(self, user_setup, testdb: Session):
         user1 = user_setup["user1"]
         user2 = user_setup["user2"]


### PR DESCRIPTION
## PR の目的
- 以下のテストコードの実装
   - class TestDeleteUser
      - ユーザーが削除されたかの検証
      - adminユーザーが削除されたときにそのユーザーが最後のadminだったpteamがあった場合、そのpteamも削除する
      - adminユーザーが削除されたときにそのユーザーが最後のadminではないpteamの場合、そのpteamは削除しない
      - そもそもユーザーがadminではなかった場合、所属しているpteamは削除されない
   - class TestDeleteUserSideEffects（副作用的なテストコードの実装）
      - 削除されたユーザーは取得できない
      - 削除されたユーザーのactionlogにおけるユーザーIDはnull
      - 削除されていないユーザーのactionlogにおけるユーザーIDは保持される
      - 削除されたユーザーのactionにおけるcreated_byはnull
      - 削除されていないユーザーのactionにおけるcreated_byは保持される
      - 削除されたユーザーのtopicにおけるcreated_byはnull
      - 削除されていないユーザーのtopicにおけるcreated_byは保持される

## 経緯・意図・意思決定
- ユーザー削除に関わるAPIテストの実装
