### PR TITLE
topic/fix service settings dialog

### DIFF
--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -134,15 +134,6 @@ export function PTeamServiceDetailsSettingsView(props) {
     }
   };
 
-  const handleKeywordCountCheck = () => {
-    if (currentKeywordsList.length >= maxKeywords) {
-      setKeywordAddingMode(false);
-      enqueueSnackbar(`Too many keywords, max number: ${maxKeywords}`, { variant: "error" });
-    } else {
-      setKeywordAddingMode(!keywordAddingMode);
-    }
-  };
-
   const handleUpdatePTeamService = async () =>
     onSave(
       serviceName,

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -177,6 +177,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 required
                 size="small"
                 value={serviceName}
+                placeholder={`Max length is ${maxServiceNameLengthInHalf} in half-width or ${Math.floor(maxServiceNameLengthInHalf / 2)} in full-width`}
                 onChange={(e) => handleServiceNameSetting(e.target.value)}
                 helperText={serviceName ? "" : "This field is required."}
                 error={!serviceName}
@@ -203,7 +204,7 @@ export function PTeamServiceDetailsSettingsView(props) {
               </Box>
             </Box>
             <Box sx={{ display: "flex", flexDirection: "column" }}>
-              <FormLabel>Keywords</FormLabel>
+              <FormLabel>Keywords (Max 5)</FormLabel>
               <Box>
                 <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: "wrap" }}>
                   {currentKeywordsList.map((keyword) => (
@@ -252,7 +253,12 @@ export function PTeamServiceDetailsSettingsView(props) {
                   </Box>
                 ) : (
                   <Box>
-                    <Button onClick={handleKeywordCountCheck}>+ Add a new keyword</Button>
+                    <Button
+                      onClick={() => setKeywordAddingMode(!keywordAddingMode)}
+                      disabled={currentKeywordsList.length >= maxKeywords}
+                    >
+                      + Add a new keyword
+                    </Button>
                   </Box>
                 )}
               </Box>
@@ -263,6 +269,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                 multiline
                 rows={3}
                 fullWidth
+                placeholder={`Max length is ${maxDescriptionLengthInHalf} in half-width or ${Math.floor(maxDescriptionLengthInHalf / 2)} in full-width`}
                 value={currentDescription}
                 onChange={(e) => handleDescriptionSetting(e.target.value)}
               />


### PR DESCRIPTION
## PR の目的
- servce setttings ダイアログ画面の修正を行いました

## 経緯・意図・意思決定
- プレースホルダーをNameとDescriptionのTextFiledに追加しました
- 「Keywords」の横に「(Max 5)」を追加しました
- keywordが6個目から追加できないようにdisabledを追加しました
- handleKeywordCountCheckが必要なくなったため、削除しました
