### PR TITLE
Topic/delete action log.emai

### DIFF
--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -105,8 +105,9 @@ def delete_user(
     """
 
     for log in current_user.action_logs:
-        # actoin logs shoud not be deleted, but should be anonymized
+        # action logs should not be deleted, but should be anonymized
         log.user_id = None
+        log.email = ""
 
     # Current_user.user_id should be removed from the assignees of the ticket status.
 

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -430,7 +430,8 @@ class TestDeleteUserSideEffects:
         assert db_ticketstatus is not None
 
     @pytest.mark.skip(
-        reason="process of excluding deleted users' user_id from TicketStatus assignees is not implemented."
+        reason="process of excluding deleted users' user_id from TicketStatus "
+        "assignees is not implemented."
     )
     def test_ticketstatus_assignees_should_not_include_deleted_user(self, testdb):
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -329,6 +329,7 @@ class TestDeleteUserSideEffects:
             )
         ).one()
         assert db_actionlog.user_id is None
+        assert db_actionlog.email == ""
 
     def test_user_id_of_not_deleted_users_actionlog_should_be_kept(self, testdb):
         self.delete_user_me(USER1)


### PR DESCRIPTION
## PR の目的
- api/app/routers/users.py
  - ユーザ削除時、ActionLogテーブルにあるemailを空文字するように修正しました
  - コメントがtypoしていたため修正しました
- api/app/tests/integrations/test_users.py
- test_users.pyでフォーマットエラーになっていたため修正しました

