### PR TITLE
fix password reset function name

### DIFF
--- a/web/src/providers/auth/AuthContext.jsx
+++ b/web/src/providers/auth/AuthContext.jsx
@@ -19,7 +19,7 @@ export function AuthProvider(props) {
   const sendEmailVerification = authProvider.sendEmailVerification;
   const sendPasswordResetEmail = authProvider.sendPasswordResetEmail;
   const verifyPasswordResetCode = authProvider.verifyPasswordResetCode;
-  const confirmPassword = authProvider.confirmPassword;
+  const confirmPassword = authProvider.confirmPasswordReset;
   const applyActionCode = authProvider.applyActionCode;
 
   return (
@@ -34,7 +34,7 @@ export function AuthProvider(props) {
         sendEmailVerification,
         sendPasswordResetEmail,
         verifyPasswordResetCode,
-        confirmPassword,
+        confirmPasswordReset,
         applyActionCode,
       }}
     >

--- a/web/src/providers/auth/AuthContext.jsx
+++ b/web/src/providers/auth/AuthContext.jsx
@@ -19,7 +19,7 @@ export function AuthProvider(props) {
   const sendEmailVerification = authProvider.sendEmailVerification;
   const sendPasswordResetEmail = authProvider.sendPasswordResetEmail;
   const verifyPasswordResetCode = authProvider.verifyPasswordResetCode;
-  const confirmPassword = authProvider.confirmPasswordReset;
+  const confirmPasswordReset = authProvider.confirmPasswordReset;
   const applyActionCode = authProvider.applyActionCode;
 
   return (


### PR DESCRIPTION
## PR の目的

confirmPasswordResetの関数名が誤っていたため、パスワードリセットができない問題に対応

## 経緯・意図・意思決定

パスワードリセットができないという問題が発生。
原因を調査したところ、 confirmPasssordReset の実行部分で `is not a function` とコンソールに表示されていたことが判明。

調査したところ、 AuthProviderの名前が confirmPasswordReset ではなく confirmPassword となっていたことが原因 (変更漏れ)
そのため関数名を修正する

## 参考文献
