### PR TITLE
Topic/fix upload SBOM file

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -206,6 +206,7 @@ class PackageVersion(Base):
         ForeignKey("package.package_id", ondelete="CASCADE"), index=True
     )
 
+    package = relationship("Package")
     dependencies = relationship(
         "Dependency", back_populates="package_version", cascade="all, delete-orphan"
     )

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 from app import models
@@ -172,6 +172,41 @@ def get_pteam_account_role(
 
 def create_pteam_account_role(db: Session, account_role: models.PTeamAccountRole) -> None:
     db.add(account_role)
+    db.flush()
+
+
+### Package
+def get_package_by_name_and_ecosystem(
+    db: Session, name: str, ecosystem: str
+) -> models.Package | None:
+    return db.scalars(
+        select(models.Package).where(
+            and_(models.Package.name == name, models.Package.ecosystem == ecosystem)
+        )
+    ).one_or_none()
+
+
+def create_package(db: Session, package: models.Package) -> None:
+    db.add(package)
+    db.flush()
+
+
+### PackageVersion
+def get_package_version_by_package_id_and_version(
+    db: Session, package_id: UUID | str, version: str
+) -> models.PackageVersion | None:
+    return db.scalars(
+        select(models.PackageVersion).where(
+            and_(
+                models.PackageVersion.package_id == str(package_id),
+                models.PackageVersion.version == version,
+            )
+        )
+    ).one_or_none()
+
+
+def create_package_version(db: Session, package_version: models.PackageVersion) -> None:
+    db.add(package_version)
     db.flush()
 
 

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1081,12 +1081,11 @@ def apply_service_packages(
             raise ValueError("Missing  package name")
         if not (ecosystem := str(line.get("ecosystem"))):
             raise ValueError("Missing ecosystem")
-        if not (package_manager := str(line.get("package_manager"))):
-            raise ValueError("Missing package_manager")
         if not (_refs := line.get("references")):
             raise ValueError("Missing references")
         if any(None in {_ref.get("target"), _ref.get("version")} for _ref in _refs):
             raise ValueError("Missing target and|or version")
+        package_manager = str(line.get("package_manager", ""))
         if not (
             _package := persistence.get_package_by_name_and_ecosystem(db, package_name, ecosystem)
         ):

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -948,7 +948,7 @@ def bg_create_tags_from_sbom_json(
 
         try:
             json_lines = sbom_json_to_artifact_json_lines(sbom_json)
-            apply_service_tags(db, service, json_lines, auto_create_tags=force_mode)
+            apply_service_packages(db, service, json_lines, auto_create_packages=force_mode)
         except ValueError:
             notify_sbom_upload_ended(service, filename, False)
             log.error(f"Failed uploading SBOM as a service: {service_name}")
@@ -1065,42 +1065,64 @@ def upload_pteam_tags_file(
     return []
 
 
-def apply_service_tags(
+def apply_service_packages(
     db: Session,
     service: models.Service,
     json_lines: list[dict],
-    auto_create_tags=False,
+    auto_create_packages=False,
 ) -> None:
     # Check file format and get tag_names
-    missing_tags = set()
-    new_dependencies_set: set[tuple[str, str, str]] = set()  # (tag_id, target, version)
+    missing_packages: set[str] = set()
+    new_dependencies_set: set[tuple[str, str, str]] = (
+        set()
+    )  # (package_version_id, target, package_manager)
     for line in json_lines:
-        if not (_tag_name := line.get("tag_name")):
-            raise ValueError("Missing tag_name")
+        if not (package_name := str(line.get("package_name"))):
+            raise ValueError("Missing  package name")
+        if not (ecosystem := str(line.get("ecosystem"))):
+            raise ValueError("Missing ecosystem")
+        if not (package_manager := str(line.get("package_manager"))):
+            raise ValueError("Missing package_manager")
         if not (_refs := line.get("references")):
             raise ValueError("Missing references")
         if any(None in {_ref.get("target"), _ref.get("version")} for _ref in _refs):
             raise ValueError("Missing target and|or version")
-        # TODO Provisional Processing
-        # if not (_tag := persistence.get_tag_by_name(db, _tag_name)):
-        #     if auto_create_tags:
-        #         _tag = create_topic_tag(db, _tag_name)
-        #     else:
-        #         missing_tags.add(_tag_name)
-        _tag = None
-        if _tag:
+        if not (
+            _package := persistence.get_package_by_name_and_ecosystem(db, package_name, ecosystem)
+        ):
+            if auto_create_packages:
+                # create new package
+                _package = models.Package(name=package_name, ecosystem=ecosystem)
+                persistence.create_package(db, _package)
+
+            else:
+                missing_packages.add(package_name + ":" + ecosystem)
+
+        if _package:
             for ref in line.get("references", [{}]):
+                if not (
+                    _package_version := persistence.get_package_version_by_package_id_and_version(
+                        db, _package.package_id, ref.get("version", "")
+                    )
+                ):
+                    # create new package version
+                    _package_version = models.PackageVersion(
+                        package_id=_package.package_id,
+                        version=ref.get("version", ""),
+                    )
+                    persistence.create_package_version(db, _package_version)
                 new_dependencies_set.add(
-                    (_tag.tag_id, ref.get("target", ""), ref.get("version", ""))
+                    (_package_version.package_version_id, ref.get("target", ""), package_manager)
                 )
-    if missing_tags:
-        raise ValueError(f"No such tags: {', '.join(sorted(missing_tags))}")
+
+    if missing_packages:
+        raise ValueError(f"No such packages: {', '.join(sorted(missing_packages))}")
 
     # separate dependencis to keep, delete or create
     obsoleted_dependencies = []
     for dependency in service.dependencies:
         if (
-            item := (dependency.tag_id, dependency.target, dependency.version)
+            item := (dependency.package_version_id, dependency.target, dependency.package_manager)
         ) in new_dependencies_set:
             new_dependencies_set.remove(item)  # already exists
             continue
@@ -1108,12 +1130,12 @@ def apply_service_tags(
     for obsoleted in obsoleted_dependencies:
         service.dependencies.remove(obsoleted)
     # create new dependencies
-    for [tag_id, target, version] in new_dependencies_set:
+    for [package_version_id, target, package_manager] in new_dependencies_set:
         new_dependency = models.Dependency(
             service_id=service.service_id,
-            tag_id=tag_id,
-            version=version,
+            package_version_id=package_version_id,
             target=target,
+            package_manager=package_manager,
         )
         service.dependencies.append(new_dependency)
         db.flush()

--- a/api/app/sbom/parser/artifact.py
+++ b/api/app/sbom/parser/artifact.py
@@ -3,14 +3,18 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Artifact:
-    tag: str
+    package_name: str
+    ecosystem: str
+    package_manager: str
     targets: set[tuple[str, str]] = field(init=False, repr=False, default_factory=set)
     versions: set[str] = field(init=False, repr=False, default_factory=set)  # for missing targets
 
     def to_json(self) -> dict:
         targets = self.targets if self.targets else {("", version) for version in self.versions}
         return {
-            "tag_name": self.tag,
+            "package_name": self.package_name,
+            "ecosystem": self.ecosystem,
+            "package_manager": self.package_manager,
             "references": sorted(
                 [
                     {

--- a/api/app/sbom/parser/trivy_cdx_parser.py
+++ b/api/app/sbom/parser/trivy_cdx_parser.py
@@ -75,7 +75,7 @@ class TrivyCDXParser(SBOMParser):
                     return mgr_candidate
             return components_map.get(refs[0])
 
-        def to_tag(self, components_map: dict[str, Any]) -> str | None:
+        def to_tag(self, components_map: dict[str, Any]) -> dict | None:
             if not self.purl:
                 return None
             pkg_name = (
@@ -96,7 +96,8 @@ class TrivyCDXParser(SBOMParser):
                     pkg_info = self._fix_distro(distro) if distro else ""
                 else:
                     pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
-            return f"{pkg_name}:{pkg_info}:{pkg_mgr}"
+
+            return {"pkg_name": pkg_name, "ecosystem": pkg_info, "pkg_mgr": pkg_mgr}
 
     @classmethod
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> list[Artifact]:
@@ -183,12 +184,20 @@ class TrivyCDXParser(SBOMParser):
                 continue  # maybe directory or image
             if not (tag := component.to_tag(components_map)):
                 continue  # omit not packages
-            artifact = artifacts_map.get(tag, Artifact(tag=tag))
-            artifacts_map[tag] = artifact
+            _tag = f"{tag['pkg_name']}:{tag['ecosystem']}:{tag['pkg_mgr']}"
+            artifact = artifacts_map.get(
+                _tag,
+                Artifact(
+                    package_name=tag["pkg_name"],
+                    ecosystem=tag["ecosystem"],
+                    package_manager=tag["pkg_mgr"],
+                ),
+            )
+            artifacts_map[_tag] = artifact
             for _target_ref, target_name in component.targets:
                 new_target = (target_name, component.version)
                 if new_target in artifact.targets:
-                    error_message("conflicted target:", tag, new_target)
+                    error_message("conflicted target:", _tag, new_target)
                 else:
                     artifact.targets.add(new_target)
             artifact.versions.add(component.version)

--- a/api/app/sbom/sbom_analyzer.py
+++ b/api/app/sbom/sbom_analyzer.py
@@ -70,4 +70,9 @@ def sbom_json_to_artifact_json_lines(jdata: dict) -> list[dict]:
         raise ValueError("Not supported file format")
 
     artifacts = sbom_parser.parse_sbom(sbom, sbom_info)
-    return [artifact.to_json() for artifact in sorted(artifacts, key=lambda a: a.tag)]
+    return [
+        artifact.to_json()
+        for artifact in sorted(
+            artifacts, key=lambda a: (a.package_name, a.ecosystem, a.package_manager)
+        )
+    ]

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -439,6 +439,7 @@ class ServiceTaggedTopicsSolvedUnsolved(ORMModel):
 class DependencyResponse(ORMModel):
     dependency_id: UUID
     service_id: UUID
-    tag_id: UUID
-    version: str
+    package_version_id: UUID
+    package_manager: str
     target: str
+    dependency_mission_impact: str | None

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -828,7 +828,7 @@ class TestPostUploadSBOMFileCycloneDX:
             }
             sbom_json = self.gen_sbom_json(self.gen_base_json(target_name), components_dict)
 
-            bg_create_tags_from_sbom_json(sbom_json, self.pteam1.pteam_id, service_name, True, None)
+            bg_create_tags_from_sbom_json(sbom_json, self.pteam1.pteam_id, service_name, None)
 
             services = self.get_services()
             service1 = next(filter(lambda x: x["service_name"] == service_name, services), None)
@@ -1134,7 +1134,7 @@ class TestPostUploadSBOMFileCycloneDX:
             }
             sbom_json = self.gen_sbom_json(self.gen_base_json(target_name), components_dict)
 
-            bg_create_tags_from_sbom_json(sbom_json, self.pteam1.pteam_id, service_name, True, None)
+            bg_create_tags_from_sbom_json(sbom_json, self.pteam1.pteam_id, service_name, None)
 
             services = self.get_services()
             service1 = next(filter(lambda x: x["service_name"] == service_name, services), None)
@@ -1207,7 +1207,7 @@ class TestPostUploadSBOMFileCycloneDX:
             sbom_json = self.gen_sbom_json(self.gen_base_json(target_name), {})
 
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
 
             services = self.get_services()
@@ -1255,7 +1255,7 @@ class TestPostUploadSBOMFileCycloneDX:
             sbom_json = self.gen_broken_sbom_json(self.gen_base_json(target_name))
 
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
 
             services = self.get_services()
@@ -1299,7 +1299,7 @@ class TestPostUploadSBOMFileCycloneDX:
             sbom_json = self.gen_sbom_json(self.gen_base_json(target_name), {})
 
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
 
             services = self.get_services()
@@ -1351,7 +1351,7 @@ class TestPostUploadSBOMFileCycloneDX:
             sbom_json = self.gen_broken_sbom_json(self.gen_base_json(target_name))
 
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
 
             services = self.get_services()
@@ -1379,7 +1379,7 @@ class TestPostUploadSBOMFileCycloneDX:
 
             caplog.set_level(INFO)
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
             assert [
                 ("app.routers.pteams", INFO, f"Start SBOM uploade as a service: {service_name}"),
@@ -1396,7 +1396,7 @@ class TestPostUploadSBOMFileCycloneDX:
 
             caplog.set_level(INFO)
             bg_create_tags_from_sbom_json(
-                sbom_json, self.pteam1.pteam_id, service_name, True, upload_filename
+                sbom_json, self.pteam1.pteam_id, service_name, upload_filename
             )
             assert [
                 ("app.routers.pteams", INFO, f"Start SBOM uploade as a service: {service_name}"),

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1883,128 +1883,114 @@ def test_remove_pteam_by_service_id(testdb):
     assert response.status_code == 204
 
 
-def test_upload_pteam_sbom_file_with_syft():
-    create_user(USER1)
-    pteam1 = create_pteam(USER1, PTEAM1)
-    # To avoid multiple rows error, pteam2 is created for test
-    create_pteam(USER1, PTEAM2)
+class TestPostUploadPTeamSbomFile:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        self.user1 = create_user(USER1)
+        self.pteam1 = create_pteam(USER1, PTEAM1)
 
-    params = {"service": "threatconnectome", "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
-    with open(sbom_file, "rb") as tags:
-        response = client.post(
-            f"/pteams/{pteam1.pteam_id}/upload_sbom_file",
-            headers=file_upload_headers(USER1),
-            params=params,
-            files={"file": tags},
-        )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["pteam_id"] == str(pteam1.pteam_id)
-    assert data["service_name"] == params["service"]
-    assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
+    def test_upload_pteam_sbom_file_with_syft(self):
+        # To avoid multiple rows error, pteam2 is created for test
+        create_pteam(USER1, PTEAM2)
 
-
-def test_upload_pteam_sbom_file_with_trivy():
-    create_user(USER1)
-    pteam1 = create_pteam(USER1, PTEAM1)
-    # To avoid multiple rows error, pteam2 is created for test
-    create_pteam(USER1, PTEAM2)
-
-    params = {"service": "threatconnectome", "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
-    with open(sbom_file, "rb") as tags:
-        response = client.post(
-            f"/pteams/{pteam1.pteam_id}/upload_sbom_file",
-            headers=file_upload_headers(USER1),
-            params=params,
-            files={"file": tags},
-        )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert data["pteam_id"] == str(pteam1.pteam_id)
-    assert data["service_name"] == params["service"]
-    assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
-
-
-def test_upload_pteam_sbom_file_with_empty_file():
-    create_user(USER1)
-    pteam = create_pteam(USER1, PTEAM1)
-
-    params = {"service": "threatconnectome", "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "empty.json"
-    with open(sbom_file, "rb") as tags:
-        response = client.post(
-            f"/pteams/{pteam.pteam_id}/upload_sbom_file",
-            headers=file_upload_headers(USER1),
-            params=params,
-            files={"file": tags},
-        )
-
-    assert response.status_code == 400
-    data = response.json()
-    assert data["detail"] == "Upload file is empty"
-
-
-def test_upload_pteam_sbom_file_with_wrong_filename():
-    create_user(USER1)
-    pteam = create_pteam(USER1, PTEAM1)
-
-    params = {"service": "threatconnectome", "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag.txt"
-    with open(sbom_file, "rb") as tags:
-        response = client.post(
-            f"/pteams/{pteam.pteam_id}/upload_sbom_file",
-            headers=file_upload_headers(USER1),
-            params=params,
-            files={"file": tags},
-        )
-
-    assert response.status_code == 400
-    data = response.json()
-    assert data["detail"] == "Please upload a file with .json as extension"
-
-
-def test_it_should_return_422_when_upload_sbom_with_over_255_char_servicename():
-    create_user(USER1)
-    pteam = create_pteam(USER1, PTEAM1)
-
-    # create 256 alphanumeric characters
-    service_name = "a" * 256
-
-    params = {"service": service_name, "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
-    with open(sbom_file, "rb") as tags:
-        response = client.post(
-            f"/pteams/{pteam.pteam_id}/upload_sbom_file",
-            headers=file_upload_headers(USER1),
-            params=params,
-            files={"file": tags},
-        )
-
-    assert response.status_code == 422
-    data = response.json()
-    assert data["detail"] == "Length of Service name exceeds 255 characters"
-
-
-@pytest.mark.skip(reason="TODO: need api to get background task status")
-def test_upload_pteam_sbom_file_wrong_content_format():
-    create_user(USER1)
-    pteam = create_pteam(USER1, PTEAM1)
-
-    params = {"service": "threatconnectome", "force_mode": True}
-    sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag_with_wrong_format.json"
-    with open(sbom_file, "rb") as tags:
-        with pytest.raises(HTTPError, match=r"400: Bad Request: Not supported file format"):
-            assert_200(
-                client.post(
-                    f"/pteams/{pteam.pteam_id}/upload_sbom_file",
-                    headers=file_upload_headers(USER1),
-                    params=params,
-                    files={"file": tags},
-                )
+        params = {"service": "threatconnectome", "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
             )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pteam_id"] == str(self.pteam1.pteam_id)
+        assert data["service_name"] == params["service"]
+        assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
+
+    def test_upload_pteam_sbom_file_with_trivy(self):
+        # To avoid multiple rows error, pteam2 is created for test
+        create_pteam(USER1, PTEAM2)
+
+        params = {"service": "threatconnectome", "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pteam_id"] == str(self.pteam1.pteam_id)
+        assert data["service_name"] == params["service"]
+        assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
+
+    def test_upload_pteam_sbom_file_with_empty_file(self):
+        params = {"service": "threatconnectome", "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "empty.json"
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Upload file is empty"
+
+    def test_upload_pteam_sbom_file_with_wrong_filename(self):
+        params = {"service": "threatconnectome", "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag.txt"
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Please upload a file with .json as extension"
+
+    def test_it_should_return_422_when_upload_sbom_with_over_255_char_servicename(self):
+        # create 256 alphanumeric characters
+        service_name = "a" * 256
+
+        params = {"service": service_name, "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["detail"] == "Length of Service name exceeds 255 characters"
+
+    @pytest.mark.skip(reason="TODO: need api to get background task status")
+    def test_upload_pteam_sbom_file_wrong_content_format(self):
+        params = {"service": "threatconnectome", "force_mode": True}
+        sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag_with_wrong_format.json"
+        with open(sbom_file, "rb") as tags:
+            with pytest.raises(HTTPError, match=r"400: Bad Request: Not supported file format"):
+                assert_200(
+                    client.post(
+                        f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                        headers=file_upload_headers(USER1),
+                        params=params,
+                        files={"file": tags},
+                    )
+                )
 
 
 class TestGetPTeamServiceTagsSummary:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1893,7 +1893,7 @@ class TestPostUploadPTeamSbomFile:
         # To avoid multiple rows error, pteam2 is created for test
         create_pteam(USER1, PTEAM2)
 
-        params = {"service": "threatconnectome", "force_mode": True}
+        params = {"service": "threatconnectome"}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_syft_cyclonedx.json"
         with open(sbom_file, "rb") as tags:
             response = client.post(
@@ -1913,7 +1913,7 @@ class TestPostUploadPTeamSbomFile:
         # To avoid multiple rows error, pteam2 is created for test
         create_pteam(USER1, PTEAM2)
 
-        params = {"service": "threatconnectome", "force_mode": True}
+        params = {"service": "threatconnectome"}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
         with open(sbom_file, "rb") as tags:
             response = client.post(
@@ -1930,7 +1930,7 @@ class TestPostUploadPTeamSbomFile:
         assert data["sbom_file_sha256"] == calc_file_sha256(sbom_file)
 
     def test_upload_pteam_sbom_file_with_empty_file(self):
-        params = {"service": "threatconnectome", "force_mode": True}
+        params = {"service": "threatconnectome"}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "empty.json"
         with open(sbom_file, "rb") as tags:
             response = client.post(
@@ -1945,7 +1945,7 @@ class TestPostUploadPTeamSbomFile:
         assert data["detail"] == "Upload file is empty"
 
     def test_upload_pteam_sbom_file_with_wrong_filename(self):
-        params = {"service": "threatconnectome", "force_mode": True}
+        params = {"service": "threatconnectome"}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag.txt"
         with open(sbom_file, "rb") as tags:
             response = client.post(
@@ -1963,7 +1963,7 @@ class TestPostUploadPTeamSbomFile:
         # create 256 alphanumeric characters
         service_name = "a" * 256
 
-        params = {"service": service_name, "force_mode": True}
+        params = {"service": service_name}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "test_trivy_cyclonedx.json"
         with open(sbom_file, "rb") as tags:
             response = client.post(
@@ -1979,7 +1979,7 @@ class TestPostUploadPTeamSbomFile:
 
     @pytest.mark.skip(reason="TODO: need api to get background task status")
     def test_upload_pteam_sbom_file_wrong_content_format(self):
-        params = {"service": "threatconnectome", "force_mode": True}
+        params = {"service": "threatconnectome"}
         sbom_file = Path(__file__).resolve().parent / "upload_test" / "tag_with_wrong_format.json"
         with open(sbom_file, "rb") as tags:
             with pytest.raises(HTTPError, match=r"400: Bad Request: Not supported file format"):


### PR DESCRIPTION
## PR の目的
- tagテーブルをpackage, packgeVersionテーブルへ変更するのに伴いsbom upload fileについて修正しました

## 経緯・意図・意思決定
- sbom paserの変更(commit: fix sbom parser)
  -  今までsbom_json_to_artifact_json_lines関数の返り値が
  `{ "tag_name": "cryptography:pypi:pipenv",  "references":  [ { "target": "api/Pipfile.lock",  "version": "42.0.5" } ] }`となっていました。
  - `{ "package_name": "cryptography",  "ecosystem": "pypi",  "package_manager": "pipenv",  "references":  [ { "target": "api/Pipfile.lock",  "version": "42.0.5" } ] }`と返すように変更しました
- upload sbom file apiの変更(commit: fix upload sbom file)
  - apply_service_packagesについてtag, dependencyテーブルへデータ登録したいた部分をpackge, packgeVersion, dependencyテーブルへデータ登録するように変更しました
  - dependencyテーブルへpackage_version_id, package_managerを登録するように変更しました
- persistence.pyにpackge, packgeVersionテーブルのget, createのsqlalchemyを追加(commit: add package and packageVersion sql)
