### PR TITLE
add delete vuln api

### DIFF
--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -313,6 +313,11 @@ def create_vuln(db: Session, vuln: models.Vuln):
     db.flush()
 
 
+def delete_vuln(db: Session, vuln: models.Vuln) -> None:
+    db.delete(vuln)
+    db.flush()
+
+
 ### Service
 
 

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app import command, models, persistence, schemas
@@ -117,7 +117,7 @@ def delete_vuln(
     # Delete the vuln and its associated affects
     persistence.delete_vuln(db, vuln)
     db.commit()
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{vuln_id}", response_model=schemas.VulnReponse)

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -102,6 +102,24 @@ def update_vuln(
     return schemas.VulnReponse(**response)
 
 
+@router.delete("/{vuln_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_vuln(
+    vuln_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a vuln.
+    """
+    if not (vuln := persistence.get_vuln_by_id(db, vuln_id)):
+        raise NO_SUCH_VULN
+
+    # Delete the vuln and its associated affects
+    persistence.delete_vuln(db, vuln)
+    db.commit()
+    return None
+
+
 @router.get("/{vuln_id}", response_model=schemas.VulnReponse)
 def get_vuln(
     vuln_id: UUID,

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -370,7 +370,7 @@ class TestDeleteVuln:
         # Create a vuln to delete
         client.put(f"/vulns/{self.new_vuln_id}", headers=headers(USER1), json=self.request1)
 
-    def test_it_should_return_204_when_vuln_is_deleted_successfully(self):
+    def test_it_should_delete_vuln_when_vuln_id_exists(self):
         # When
         response = client.delete(f"/vulns/{self.new_vuln_id}", headers=headers(USER1))
 

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -356,7 +356,7 @@ class TestDeleteVuln:
             "detail": "This vuln is example.",
             "exploitation": "active",
             "automatable": "yes",
-            "cvss_v3_score": 7.8,
+            "cvss_v3_score": 7.5,
             "vulnerable_packages": [
                 {
                     "name": "example-lib",

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -376,6 +376,9 @@ class TestDeleteVuln:
 
         # Then
         assert response.status_code == 204  # No Content
+        get_response = client.get(f"/vulns/{self.new_vuln_id}", headers=headers(USER1))
+        assert get_response.status_code == 404  # Not Found
+        assert get_response.json()["detail"] == "No such vuln"
 
     def test_it_should_return_404_when_vuln_id_does_not_exist(self):
         # Given

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -342,3 +342,48 @@ class TestGetVulns:
         assert response_data[0]["vulnerable_packages"][0]["ecosystem"] == "pypi"
         assert response_data[0]["vulnerable_packages"][0]["affected_versions"] == ["<2.0.0"]
         assert response_data[0]["vulnerable_packages"][0]["fixed_versions"] == ["2.0.0"]
+
+
+class TestDeleteVuln:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self):
+        # Given
+        self.user1 = create_user(USER1)
+        self.new_vuln_id = uuid4()
+        self.request1 = {
+            "title": "Example vuln",
+            "cve_id": "CVE-0000-0001",
+            "detail": "This vuln is example.",
+            "exploitation": "active",
+            "automatable": "yes",
+            "cvss_v3_score": 7.8,
+            "vulnerable_packages": [
+                {
+                    "name": "example-lib",
+                    "ecosystem": "pypi",
+                    "affected_versions": ["<2.0.0"],
+                    "fixed_versions": ["2.0.0"],
+                }
+            ],
+        }
+
+        # Create a vuln to delete
+        client.put(f"/vulns/{self.new_vuln_id}", headers=headers(USER1), json=self.request1)
+
+    def test_it_should_return_204_when_vuln_is_deleted_successfully(self):
+        # When
+        response = client.delete(f"/vulns/{self.new_vuln_id}", headers=headers(USER1))
+
+        # Then
+        assert response.status_code == 204  # No Content
+
+    def test_it_should_return_404_when_vuln_id_does_not_exist(self):
+        # Given
+        non_existent_vuln_id = uuid4()
+
+        # When
+        response = client.delete(f"/vulns/{non_existent_vuln_id}", headers=headers(USER1))
+
+        # Then
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No such vuln"


### PR DESCRIPTION
## PR の目的
- データモデルの修正
   - api/app/routers/vulns.pyにdelete vulnsルーター関数の実装
   - api/app/persistence.pyにdelete_vuln関数の実装

- テストコードの実装
   - 脆弱性が正常に削除された場合
      - 事前に作成した脆弱性を削除するリクエストを送信し、レスポンスのステータスコードが204となっていることの確認
      - get_vulnを用いて、deleteしたvulnが取得できなくなったことの確認
   - 存在しない脆弱性を削除しようとした場合
      - 存在しない脆弱性IDを指定して削除リクエストを送信し、以下を確認
         - レスポンスのステータスコードが404 Not Found 
         - エラーメッセージ"No such vuln"を出力