### PR TITLE
Topic/add get tickets

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -70,7 +70,7 @@ def expire_pteam_invitations(db: Session) -> None:
     db.flush()
 
 
-def get_sorted_tickets_related_to_service_and_pakaget_and_vuln(
+def get_sorted_tickets_related_to_service_and_package_and_vuln(
     db: Session,
     service_id: UUID | str | None,
     package_id: UUID | str | None,
@@ -108,7 +108,9 @@ def get_sorted_tickets_related_to_service_and_pakaget_and_vuln(
             ),
         )
 
-    select_stmt = select_stmt.order_by(models.Ticket.ssvc_deployer_priority)
+    select_stmt = select_stmt.order_by(
+        models.Ticket.ssvc_deployer_priority, models.Ticket.created_at
+    )
 
     # https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#joined-eager-loading
     return db.scalars(select_stmt).unique().all()

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -336,7 +336,7 @@ class Threat(Base):
         ForeignKey("vuln.vuln_id", ondelete="CASCADE"), index=True
     )
 
-    vuln = relationship("Vuln")
+    vuln = relationship("Vuln", back_populates="threats")
     package_version = relationship("PackageVersion")
     tickets = relationship("Ticket", back_populates="threat", cascade="all, delete")
 
@@ -494,7 +494,7 @@ class Vuln(Base):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         if not self.vuln_id:
-            self.vulun_id = str(uuid.uuid4())
+            self.vuln_id = str(uuid.uuid4())
         if not self.exploitation:
             self.exploitation = ExploitationEnum.NONE
         if not self.automatable:
@@ -516,7 +516,7 @@ class Vuln(Base):
 
     vuln_actions = relationship("VulnAction", cascade="all, delete-orphan")
     affects = relationship("Affect", back_populates="vuln", cascade="all, delete-orphan")
-    threats = relationship("Threat", cascade="all, delete-orphan")
+    threats = relationship("Threat", back_populates="vuln", cascade="all, delete-orphan")
 
 
 class VulnAction(Base):

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -188,6 +188,12 @@ def create_pteam_account_role(db: Session, account_role: models.PTeamAccountRole
 
 
 ### Package
+def get_package_by_id(db: Session, package_id: UUID | str) -> models.Package | None:
+    return db.scalars(
+        select(models.Package).where(models.Package.package_id == str(package_id))
+    ).one_or_none()
+
+
 def get_package_by_name_and_ecosystem(
     db: Session, name: str, ecosystem: str
 ) -> models.Package | None:

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -807,7 +807,7 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
     if vuln_id and not (persistence.get_vuln_by_id(db, vuln_id)):
         raise NO_SUCH_VULN
 
-    tickets = command.get_sorted_tickets_related_to_service_and_pakaget_and_vuln(
+    tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
         db, service_id, package_id, vuln_id
     )
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -372,10 +372,8 @@ class ActionLogRequest(ORMModel):
 
 class ThreatResponse(ORMModel):
     threat_id: UUID
-    dependency_id: UUID
-    topic_id: UUID
-    threat_safety_impact: SafetyImpactEnum | None = None
-    reason_safety_impact: str | None = None
+    package_version_id: UUID
+    vuln_id: UUID
 
 
 class ThreatUpdateRequest(ORMModel):
@@ -408,6 +406,8 @@ class TicketResponse(ORMModel):
     threat_id: UUID
     created_at: datetime
     ssvc_deployer_priority: SSVCDeployerPriorityEnum | None
+    ticket_safety_impact: SafetyImpactEnum | None
+    reason_safety_impact: str | None
     threat: ThreatResponse
     ticket_status: TicketStatusResponse
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -404,6 +404,7 @@ class TicketStatusResponse(ORMModel):
 class TicketResponse(ORMModel):
     ticket_id: UUID
     threat_id: UUID
+    dependency_id: UUID
     created_at: datetime
     ssvc_deployer_priority: SSVCDeployerPriorityEnum | None
     ticket_safety_impact: SafetyImpactEnum | None

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app import models, persistence, schemas
+from app.business import ticket_business
 from app.constants import (
     DEFAULT_ALERT_SSVC_PRIORITY,
     ZERO_FILLED_UUID,
@@ -2980,121 +2981,93 @@ class TestTicketStatus:
 class TestGetTickets:
 
     @pytest.fixture(scope="function", autouse=True)
-    def common_setup(self):
+    def common_setup(self, testdb):
+        # Given
         self.user1 = create_user(USER1)
-        self.user2 = create_user(USER2)
         self.pteam1 = create_pteam(USER1, PTEAM1)
-        invitation1 = invite_to_pteam(USER1, self.pteam1.pteam_id)
-        accept_pteam_invitation(USER2, invitation1.invitation_id)
 
-        self.tag1 = create_tag(USER1, TAG1)
-        # add test_service to pteam1
         test_service = "test_service"
         test_target = "test target"
-        test_version = "1.2.3"
-        refs0 = {self.tag1.tag_name: [(test_target, test_version)]}
-        upload_pteam_tags(USER1, self.pteam1.pteam_id, test_service, refs0)
-        self.service_id1 = self._get_service_id_by_service_name(
-            USER1, self.pteam1.pteam_id, test_service
+        test_version = "1.0.0"
+
+        # Todo: Replace when API is created.
+        self.service1 = models.Service(
+            service_name=test_service,
+            pteam_id=str(self.pteam1.pteam_id),
         )
+        testdb.add(self.service1)
+        testdb.flush()
 
-    @pytest.fixture(scope="function", autouse=False)
-    def actionable_topic1(self):
-        action1 = self._gen_action([self.tag1.tag_name])
-        self.topic1 = create_topic(
-            USER1, {**TOPIC1, "tags": [self.tag1.tag_name], "actions": [action1]}
+        self.package1 = models.Package(
+            name="TestPackage",
+            ecosystem="npm",
         )
+        persistence.create_package(testdb, self.package1)
 
-    @pytest.fixture(scope="function", autouse=False)
-    def not_actionable_topic1(self):
-        self.topic1 = create_topic(USER1, {**TOPIC1, "tags": [self.tag1.tag_name], "actions": []})
-
-    @staticmethod
-    def _get_access_token(user: dict) -> str:
-        body = {
-            "username": user["email"],
-            "password": user["pass"],
-        }
-        response = client.post("/auth/token", data=body)
-        if response.status_code != 200:
-            raise HTTPError(response)
-        data = response.json()
-        return data["access_token"]
-
-    @staticmethod
-    def _get_service_id_by_service_name(user: dict, pteam_id: UUID | str, service_name: str) -> str:
-        response = client.get(f"/pteams/{pteam_id}/services", headers=headers(user))
-        if response.status_code != 200:
-            raise HTTPError(response)
-        data = response.json()
-        service = next(filter(lambda x: x["service_name"] == service_name, data))
-        return service["service_id"]
-
-    @staticmethod
-    def _gen_action(tag_names: list[str]) -> dict:
-        return {
-            "action": f"sample action for {str(tag_names)}",
-            "action_type": models.ActionType.elimination,
-            "recommended": True,
-            "ext": {
-                "tags": tag_names,
-                "vulnerable_versions": {tag_name: ["<999.99.9"] for tag_name in tag_names},
-            },
-        }
-
-    def _set_ticket_status(
-        self, pteam_id: str, service_id: str, ticket_id: str, request: dict
-    ) -> dict:
-        url = f"/pteams/{pteam_id}/services/{service_id}/ticketstatus/{ticket_id}"
-        user1_access_token = self._get_access_token(USER1)
-        _headers = {
-            "Authorization": f"Bearer {user1_access_token}",
-            "Content-Type": "application/json",
-            "accept": "application/json",
-        }
-        return client.put(url, headers=_headers, json=request).json()
-
-    def test_returns_empty_if_no_tickets(self, not_actionable_topic1):
-        url = (
-            f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
+        self.package_version1 = models.PackageVersion(
+            package_id=self.package1.package_id,
+            version=test_version,
         )
-        user1_access_token = self._get_access_token(USER1)
-        _headers = {
-            "Authorization": f"Bearer {user1_access_token}",
-            "Content-Type": "application/json",
-            "accept": "application/json",
-        }
-        response = client.get(url, headers=_headers)
-        assert response.status_code == 200
-        assert response.json() == []
+        persistence.create_package_version(testdb, self.package_version1)
 
-    def test_returns_ticket_with_initial_status_if_no_status_created(
-        self, testdb, actionable_topic1
-    ):
-        db_dependency1 = testdb.scalars(select(models.Dependency)).one()
-        db_threat1 = testdb.scalars(select(models.Threat)).one()
+        dependency1 = models.Dependency(
+            target=test_target,
+            package_manager="npm",
+            package_version_id=self.package_version1.package_version_id,
+            service=self.service1,
+        )
+        testdb.add(dependency1)
+        testdb.flush()
+
+        self.vuln1 = models.Vuln(
+            title="Test Vulnerability",
+            detail="This is a test vulnerability.",
+            cvss_v3_score=7.5,
+            created_by=self.user1.user_id,
+            created_at="2023-10-01T00:00:00Z",
+            updated_at="2023-10-01T00:00:00Z",
+            content_fingerprint="dummy_fingerprint",
+        )
+        persistence.create_vuln(testdb, self.vuln1)
+
+        affect1 = models.Affect(
+            vuln_id=self.vuln1.vuln_id,
+            package_id=self.package1.package_id,
+            affected_versions=["<=1.0.0"],
+            fixed_versions=["2.0.0"],
+        )
+        persistence.create_affect(testdb, affect1)
+
+        self.threat1 = models.Threat(
+            package_version_id=self.package_version1.package_version_id, vuln_id=self.vuln1.vuln_id
+        )
+        persistence.create_threat(testdb, self.threat1)
+
+        ticket_business.fix_ticket_by_threat(testdb, self.threat1)
+
+    def test_it_should_return_200_when_ticket_exists(self, testdb):
+        # Given
         db_ticket1 = testdb.scalars(select(models.Ticket)).one()
         db_status1 = testdb.scalars(select(models.TicketStatus)).one()
         expected_ticket_response1 = {
             "ticket_id": str(db_ticket1.ticket_id),
-            "threat_id": str(db_threat1.threat_id),
+            "threat_id": str(self.threat1.threat_id),
             "created_at": datetime.isoformat(db_ticket1.created_at),
             "ssvc_deployer_priority": (
                 None
                 if db_ticket1.ssvc_deployer_priority is None
                 else db_ticket1.ssvc_deployer_priority.value
             ),
+            "ticket_safety_impact": (
+                None
+                if db_ticket1.ticket_safety_impact is None
+                else db_ticket1.ticket_safety_impact.value
+            ),
+            "reason_safety_impact": None,
             "threat": {
-                "threat_id": str(db_threat1.threat_id),
-                "topic_id": str(self.topic1.topic_id),
-                "dependency_id": str(db_dependency1.dependency_id),
-                "threat_safety_impact": (
-                    str(db_threat1.threat_safety_impact.value)
-                    if db_threat1.threat_safety_impact
-                    else db_threat1.threat_safety_impact
-                ),
-                "reason_safety_impact": None,
+                "threat_id": str(self.threat1.threat_id),
+                "package_version_id": str(self.package_version1.package_version_id),
+                "vuln_id": str(self.vuln1.vuln_id),
             },
             "ticket_status": {
                 "status_id": db_status1.status_id,  # do not check
@@ -3109,89 +3082,109 @@ class TestGetTickets:
             },
         }
 
-        url = (
-            f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
-        )
-        user1_access_token = self._get_access_token(USER1)
-        _headers = {
-            "Authorization": f"Bearer {user1_access_token}",
-            "Content-Type": "application/json",
-            "accept": "application/json",
-        }
-        response = client.get(url, headers=_headers)
+        # When
+        response = client.get(f"/pteams/{self.pteam1.pteam_id}/tickets", headers=headers(USER1))
+
+        # Then
         assert response.status_code == 200
 
-        now = datetime.now()
-        data = response.json()
-        assert len(data) == 1
-        ticket1 = data[0]
-        assert ticket1 == expected_ticket_response1
-        status1_created_at = datetime.fromisoformat(ticket1["ticket_status"]["created_at"])
-        assert now - timedelta(seconds=10) < status1_created_at < now
+        assert response.json()[0] == expected_ticket_response1
 
-    def test_returns_ticket_with_current_status_if_status_created(self, testdb, actionable_topic1):
-        db_dependency1 = testdb.scalars(select(models.Dependency)).one()
-        db_threat1 = testdb.scalars(select(models.Threat)).one()
+    def test_it_should_return_200_when_all_queries_are_specified(self, testdb):
+        # Given
         db_ticket1 = testdb.scalars(select(models.Ticket)).one()
-        status_request = {
-            "topic_status": models.TopicStatusType.scheduled.value,
-            "assignees": [str(self.user2.user_id)],
-            "note": "assign user2 and schedule at 2345/6/7",
-            "scheduled_at": "2345-06-07T08:09:10",
-        }
-        self._set_ticket_status(
-            self.pteam1.pteam_id, self.service_id1, db_ticket1.ticket_id, status_request
-        )
-
-        db_ticket_status1 = testdb.scalars(select(models.TicketStatus)).one()
+        db_status1 = testdb.scalars(select(models.TicketStatus)).one()
         expected_ticket_response1 = {
             "ticket_id": str(db_ticket1.ticket_id),
-            "threat_id": str(db_threat1.threat_id),
+            "threat_id": str(self.threat1.threat_id),
             "created_at": datetime.isoformat(db_ticket1.created_at),
             "ssvc_deployer_priority": (
                 None
                 if db_ticket1.ssvc_deployer_priority is None
                 else db_ticket1.ssvc_deployer_priority.value
             ),
+            "ticket_safety_impact": (
+                None
+                if db_ticket1.ticket_safety_impact is None
+                else db_ticket1.ticket_safety_impact.value
+            ),
+            "reason_safety_impact": None,
             "threat": {
-                "threat_id": str(db_threat1.threat_id),
-                "topic_id": str(self.topic1.topic_id),
-                "dependency_id": str(db_dependency1.dependency_id),
-                "threat_safety_impact": (
-                    str(db_threat1.threat_safety_impact.value)
-                    if db_threat1.threat_safety_impact
-                    else db_threat1.threat_safety_impact
-                ),
-                "reason_safety_impact": None,
+                "threat_id": str(self.threat1.threat_id),
+                "package_version_id": str(self.package_version1.package_version_id),
+                "vuln_id": str(self.vuln1.vuln_id),
             },
             "ticket_status": {
-                "status_id": str(db_ticket_status1.status_id),
+                "status_id": db_status1.status_id,  # do not check
                 "ticket_id": str(db_ticket1.ticket_id),
-                "user_id": str(self.user1.user_id),
-                "created_at": datetime.isoformat(db_ticket_status1.created_at),
+                "topic_status": models.TopicStatusType.alerted.value,
+                "user_id": None,
+                "created_at": datetime.isoformat(db_status1.created_at),  # check later
+                "assignees": [],
+                "note": None,
+                "scheduled_at": None,
                 "action_logs": [],
-                **status_request,
             },
         }
 
-        url = (
-            f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}"
-            f"/topics/{self.topic1.topic_id}/tags/{self.tag1.tag_id}/tickets"
+        # When
+        response = client.get(
+            f"/pteams/{self.pteam1.pteam_id}/tickets?service_id={self.service1.service_id}"
+            f"&package_id={self.package1.package_id}&vuln_id={self.vuln1.vuln_id}",
+            headers=headers(USER1),
         )
-        user1_access_token = self._get_access_token(USER1)
-        _headers = {
-            "Authorization": f"Bearer {user1_access_token}",
-            "Content-Type": "application/json",
-            "accept": "application/json",
-        }
-        response = client.get(url, headers=_headers)
-        assert response.status_code == 200
 
-        data = response.json()
-        assert len(data) == 1
-        ticket1 = data[0]
-        assert ticket1 == expected_ticket_response1
+        # Then
+        assert response.status_code == 200
+        assert response.json()[0] == expected_ticket_response1
+
+    def test_it_should_return_404_when_pteam_id_does_not_exist(self):
+        # When
+        pteam_id = str(uuid4())
+        response = client.get(
+            f"/pteams/{pteam_id}/tickets",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No such pteam"
+
+    def test_it_should_return_404_when_service_id_does_not_exist(self):
+        # When
+        setvice_id = str(uuid4())
+        response = client.get(
+            f"/pteams/{self.pteam1.pteam_id}/tickets?service_id={setvice_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No such service"
+
+    def test_it_should_return_404_when_vuln_id_does_not_exist(self):
+        # When
+        vuln_id = str(uuid4())
+        response = client.get(
+            f"/pteams/{self.pteam1.pteam_id}/tickets?vuln_id={vuln_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No such vuln"
+
+    def test_it_should_return_404_when_package_id_does_not_exist(self):
+        # When
+        package_id = str(uuid4())
+        response = client.get(
+            f"/pteams/{self.pteam1.pteam_id}/tickets?package_id={package_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No such package"
 
 
 class TestUpdatePTeamService:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -3046,7 +3046,7 @@ class TestGetTickets:
 
             ticket_business.fix_ticket_by_threat(testdb, self.threat1)
 
-    class TestQueryRarameter(Common):
+    class TestQueryParameter(Common):
         @pytest.fixture(scope="function", autouse=True)
         def common_setup_for_test_query_parameter(self, testdb):
             # Given


### PR DESCRIPTION
## PR の目的
- get ticket api(Get /pteams/{preat_id}/tickets?service_id&pacakge_id,&vuln_id)
について追加しました
- 既存のget ticket api(Get /pteams/{pteam_id}/services/{service_id}/topics/{topic_id}/tags/{tag_id}/tickets)
について削除しました

## 経緯・意図・意思決定
### API
- pteams.py
  - service_id, package_id, vuln_idをそれぞれクエリパラメータで指定するようにしました
  - service_id, package_id, vuln_idについてそれぞれチェックする機能を追加しました
- command.py
  - 条件に応じてjoin句, where句を追加するようにしました
  - Threatをjoinedloadを使用してjoinしようとすると、PackageVersion, Dependencyテーブルのjoinより後に行われるためエラーが出ます。そのためThreatテーブルのjoinはjoinedloadを使用せず、joinしています。
- schemas.py
  - データモデルの変更に伴いスキーマも変更しました
- persistence.py
  -  idチェックで使用するためget_package_by_idを追加しました

### テスト
- 既存のTestGetTicketsからテストを削除し、新たにテストを6個追加しました
- def common_setupについて
   - ticketを作成するAPIがまだないため、sqlalchemyを用いて直接データをinsertしています


### models.pyのエラー
- Vulnテーブルのdef _init()_でself.vuln_idがself.vulun_idとtypoしていたため修正しました
- ThreatテーブルとVulnテーブルのrelationshipにback_populatesがなかったため追加しました
             