### PR TITLE
bugfix/delete colon in ecosystem

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -301,8 +301,8 @@ def create_os_tag_info(os_repos):
 def get_package_info(repos):
     if b"::" in repos:  # lang-pkgs
         lang_pkg_raw_data = repos.decode().split("::", 1)[0]
-        lang_tag_info = lang_families[lang_pkg_raw_data]
-        return f"{lang_tag_info}:"
+        lang_ecosystem_info = lang_families[lang_pkg_raw_data]
+        return f"{lang_ecosystem_info}"
     # os-pkgs
     os_tag_info = create_os_tag_info(repos)
     return f"{os_tag_info}"


### PR DESCRIPTION
## PR の目的
- ecosystemを生成した時に「:」がついていた部分を削除しました
  - 「:」がついた状態でecosystemをput vulne のRequestに入れていたため、pacakgeテーブルにある情報と一致しない状態になっていました
- 変数名をlang_tag_infoからlang_ecosystem_infoに変更しました



