### PR TITLE
Bugfix/add cascade

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -337,7 +337,7 @@ class Threat(Base):
 
     vuln = relationship("Vuln", back_populates="threats")
     package_version = relationship("PackageVersion")
-    tickets = relationship("Ticket", back_populates="threat", cascade="all, delete")
+    tickets = relationship("Ticket", back_populates="threat", cascade="all, delete-orphan")
 
 
 class Ticket(Base):

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -259,7 +259,7 @@ class Dependency(Base):
 
     service = relationship("Service", back_populates="dependencies")
     package_version = relationship("PackageVersion", uselist=False, back_populates="dependencies")
-    tickets = relationship("Ticket", back_populates="dependency")
+    tickets = relationship("Ticket", back_populates="dependency", cascade="all, delete-orphan")
 
 
 class Service(Base):


### PR DESCRIPTION
## PR の目的

- バグ改修
  - 現象
    - サービス削除時にエラーとなる
      - 条件：削除するDependencyに紐づくTicketが複数存在する
  - 原因
    - sqlalchemyのSQLログを確認したところ、サービスに紐づくDependencyを削除する前に、そのDependencyに紐づくTicketを検索し、各Ticketが持つdependency_idにNULLをセットしようとして、非NULL制約でエラーとなっていた
    - 詳しい原因は分からないが、Dependency.tickets のrelationshipにおけるcascade属性の指定値によって、sqlalchemyが必要なSQLを発行する、という知識はある
  - 対策
    - Dependency.tickets のrelationshipにおけるcascade属性を指定していなかったが、"all, delete-orphan"を指定する
- 周辺見直し
  - 問題箇所と同様な1対多のrelationshipを見直したところ、Threat.tickets において、データモデル変更によって1対多になったにも関わらずcascade="all, delete"としていたため、"all, delete-orphan"に修正する

## 参考文献
https://docs.sqlalchemy.org/en/20/orm/cascades.html