### PR TITLE
add Get /pteams/{pteam_id}/tickets/{ticket_id}

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -821,7 +821,7 @@ def get_ticket(
 
     service = ticket.dependency.service
     if str(service.pteam_id) != str(pteam_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
 
     # vuln_idはthreatから取得
     vuln_id = ticket.threat.vuln_id if ticket.threat else None

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -811,17 +811,19 @@ def get_ticket(
     """
     Get a ticket.
     """
+
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
     if not (ticket := persistence.get_ticket_by_id(db, ticket_id)):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
+        raise NO_SUCH_TICKET
 
     service = ticket.dependency.service
     if str(service.pteam_id) != str(pteam_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
 
-    if check_pteam_membership(service, current_user):
-        return ticket
-    else:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a pteam member")
+    return ticket
 
 
 @router.post("", response_model=schemas.PTeamInfo)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -811,15 +811,15 @@ def get_ticket(
     """
     Get a ticket.
     """
-    if not (threat := persistence.get_ticket_by_id(db, ticket_id)):
+    if not (ticket := persistence.get_ticket_by_id(db, ticket_id)):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
 
-    pteam = threat.dependency.service.pteam
+    pteam = ticket.dependency.service.pteam
     if str(pteam.pteam_id) != str(pteam_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
 
     if check_pteam_membership(pteam, current_user):
-        return threat
+        return ticket
     else:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a pteam member")
 

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -802,21 +802,21 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
 
 
 @router.get("/{pteam_id}/tickets/{ticket_id}", response_model=schemas.TicketResponse)
-def get_threat(
+def get_ticket(
     pteam_id: UUID,
     ticket_id: UUID,
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """
-    Get a threat.
+    Get a ticket.
     """
     if not (threat := persistence.get_ticket_by_id(db, ticket_id)):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
 
     pteam = threat.dependency.service.pteam
     if str(pteam.pteam_id) != str(pteam_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such threat")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
 
     if check_pteam_membership(pteam, current_user):
         return threat

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -821,9 +821,8 @@ def get_ticket(
 
     service = ticket.dependency.service
     if str(service.pteam_id) != str(pteam_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
+        raise NO_SUCH_TICKET
 
-    # vuln_idはthreatから取得
     vuln_id = ticket.threat.vuln_id if ticket.threat else None
 
     return {

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -814,11 +814,11 @@ def get_ticket(
     if not (ticket := persistence.get_ticket_by_id(db, ticket_id)):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
 
-    pteam = ticket.dependency.service.pteam
-    if str(pteam.pteam_id) != str(pteam_id):
+    service = ticket.dependency.service
+    if str(service.pteam_id) != str(pteam_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
 
-    if check_pteam_membership(pteam, current_user):
+    if check_pteam_membership(service, current_user):
         return ticket
     else:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a pteam member")

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -823,7 +823,19 @@ def get_ticket(
     if str(service.pteam_id) != str(pteam_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such pteam")
 
-    return ticket
+    # vuln_idはthreatから取得
+    vuln_id = ticket.threat.vuln_id if ticket.threat else None
+
+    return {
+        "ticket_id": ticket.ticket_id,
+        "vuln_id": vuln_id,
+        "dependency_id": ticket.dependency_id,
+        "created_at": ticket.created_at,
+        "ssvc_deployer_priority": ticket.ssvc_deployer_priority,
+        "ticket_safety_impact": ticket.ticket_safety_impact,
+        "reason_safety_impact": ticket.reason_safety_impact,
+        "ticket_status": ticket.ticket_status,
+    }
 
 
 @router.post("", response_model=schemas.PTeamInfo)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4290,6 +4290,7 @@ class TestGetTicket:
             else self.ticket1.ssvc_deployer_priority.value
         )
         assert data["ticket_status"]["status_id"] == self.ticket_status1.status_id
+        assert data["created_at"] == self.ticket1.created_at.isoformat()
 
     def test_it_should_return_404_when_ticket_not_found(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4136,7 +4136,7 @@ class TestGetTicket:
         data = response.json()
         return data["access_token"]
 
-    def test_it_should_return_200_and_ticket_detail(self):
+    def test_it_should_return_correct_ticket_detail(self):
         user1_access_token = self._get_access_token(USER1)
         _headers = {
             "Authorization": f"Bearer {user1_access_token}",


### PR DESCRIPTION
## PR の目的
- API Get /pteams/{pteam_id}/tickets/{ticket_id}の実装
   - 既存[Get /threats/{threat_id}]に対し、threat_safety_impactがticketに移動したためURL変更

- TestGetTicketの実装（テストコード）
   - test_it_should_return_correct_ticket_detail
      - Ticketが存在し、かつPTeamのメンバーであれば、チケットの詳細情報が正しく取得できることの確認
   - test_it_should_return_404_when_ticket_not_found
      - 存在しないticket_idを指定した場合、404（No such ticket）が返ることの確認
   - test_it_should_return_404_when_pteam_not_found
      - 存在しないpteam_idを指定した場合、404（No such pteam）が返ることの確認
   - test_it_should_return_403_when_not_pteam_member
      - PTeamのメンバーでないユーザーがアクセスした場合、403（Not a pteam member）が返ることの確認