### PR TITLE
add resetKeys in ErrorBoundary

### DIFF
--- a/web/src/pages/App/AppPage.jsx
+++ b/web/src/pages/App/AppPage.jsx
@@ -49,7 +49,7 @@ export function App() {
       <Main open={system.drawerOpen}>
         <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" m={1}>
           <Box display="flex" flexDirection="column" flexGrow={1} maxWidth={mainMaxWidth}>
-            <ErrorBoundary FallbackComponent={AppFallback}>
+            <ErrorBoundary FallbackComponent={AppFallback} resetKeys={[location.pathname]}>
               <OutletWithCheckedParams />
             </ErrorBoundary>
           </Box>


### PR DESCRIPTION
## PR の目的

- バグ改修
  - 現象
    - 未実装のページを表示することでエラー表示となった後、Statusページをクリックしてもエラー表示のままとなる
  - 修正内容
    - ErrorBoundaryにresetKeys属性を追加し、location.pathnameが変わった場合にエラー状態をリセットする

