### PR TITLE
Topic/create get ticket counts

### DIFF
--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -75,3 +75,66 @@ def _update_vuln_ids_dict(
             "highest_ssvc_priority": ssvc_priority,
             "vuln_updated_at": ticket.threat.vuln.updated_at,
         }
+
+
+def get_ticket_counts_summary_by_service_id_and_package_id(
+    pteam: models.PTeam,
+    service: models.Service | None,
+    package_id: UUID | str | None,
+    related_ticket_status: str | None,
+):
+    immediate = models.SSVCDeployerPriorityEnum.IMMEDIATE.value
+    out_of_cycle = models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE.value
+    scheduled = models.SSVCDeployerPriorityEnum.SCHEDULED.value
+    defer = models.SSVCDeployerPriorityEnum.DEFER.value
+
+    ticket_counts_dict: dict = {
+        immediate: 0,
+        out_of_cycle: 0,
+        scheduled: 0,
+        defer: 0,
+    }
+
+    if service is None:
+        for _service in pteam.services:
+            _update_ticket_counts_from_dependencies(
+                _service, package_id, related_ticket_status, ticket_counts_dict
+            )
+    else:
+        _update_ticket_counts_from_dependencies(
+            service, package_id, related_ticket_status, ticket_counts_dict
+        )
+
+    # gen summary
+    ticket_counts_summary: dict[str, dict] = {
+        "ssvc_priority_count": ticket_counts_dict,
+    }
+    return ticket_counts_summary
+
+
+def _update_ticket_counts_from_dependencies(
+    service: models.Service,
+    package_id: UUID | str | None,
+    related_ticket_status: str | None,
+    ticket_counts_dict: dict,
+):
+    _completed = models.TopicStatusType.completed
+
+    for dependency in service.dependencies:
+        if package_id and dependency.package_version.package_id != str(package_id):
+            continue
+        for ticket in dependency.tickets:
+            ssvc_priority = ticket.ssvc_deployer_priority or models.SSVCDeployerPriorityEnum.DEFER
+
+            if (
+                related_ticket_status == "solved"
+                and ticket.ticket_status.topic_status != _completed
+            ):
+                continue
+            elif (
+                related_ticket_status == "unsolved"
+                and ticket.ticket_status.topic_status == _completed
+            ):
+                continue
+
+            ticket_counts_dict[ssvc_priority.value] += 1

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -548,7 +548,7 @@ def get_dependency(
     "/{pteam_id}/vuln_ids",
     response_model=schemas.ServicePackageVulnsSolvedUnsolved,
 )
-def get_vuln_ids_tied_to_service_packages(
+def get_vuln_ids_tied_to_service_package(
     pteam_id: UUID,
     service_id: UUID | None = Query(None),
     package_id: UUID | None = Query(None),
@@ -594,7 +594,7 @@ def get_vuln_ids_tied_to_service_packages(
     "/{pteam_id}/ticket_counts",
     response_model=schemas.ServicePackageTicketCountsSolvedUnsolved,
 )
-def get_ticket_counts_tied_to_service_packages(
+def get_ticket_counts_tied_to_service_package(
     pteam_id: UUID,
     service_id: UUID | None = Query(None),
     package_id: UUID | None = Query(None),

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -14,7 +14,10 @@ from sqlalchemy.orm import Session
 from app import command, models, persistence, schemas
 from app.auth.account import get_current_user
 from app.business import package_business, threat_business, ticket_business
-from app.business.ssvc_business import get_vuln_ids_summary_by_service_id_and_package_id
+from app.business.ssvc_business import (
+    get_ticket_counts_summary_by_service_id_and_package_id,
+    get_vuln_ids_summary_by_service_id_and_package_id,
+)
 from app.database import get_db, open_db_session
 from app.notification.alert import notify_sbom_upload_ended
 from app.notification.slack import validate_slack_webhook_url
@@ -584,6 +587,52 @@ def get_vuln_ids_tied_to_service_packages(
         "package_id": package_id,
         "related_ticket_status": related_ticket_status,
         **vuln_ids_summary,
+    }
+
+
+@router.get(
+    "/{pteam_id}/ticket_counts",
+    response_model=schemas.ServicePackageTicketCountsSolvedUnsolved,
+)
+def get_ticket_counts_tied_to_service_packages(
+    pteam_id: UUID,
+    service_id: UUID | None = Query(None),
+    package_id: UUID | None = Query(None),
+    related_ticket_status: schemas.RelatedTicketStatus | None = Query(None),
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
+        raise NO_SUCH_PTEAM
+    if not check_pteam_membership(pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    service = None
+    if service_id:
+        if not (service := persistence.get_service_by_id(db, service_id)):
+            raise NO_SUCH_SERVICE
+        if service.pteam_id != str(pteam_id):
+            raise NO_SUCH_SERVICE
+    if package_id and not persistence.get_package_by_id(db, package_id):
+        raise NO_SUCH_PACKAGE
+    if (
+        service_id
+        and package_id
+        and not persistence.get_dependency_from_service_id_and_package_id(
+            db, service_id, package_id
+        )
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such service package")
+
+    ticket_counts_summary = get_ticket_counts_summary_by_service_id_and_package_id(
+        pteam, service, package_id, related_ticket_status
+    )
+
+    return {
+        "pteam_id": pteam_id,
+        "service_id": service_id,
+        "package_id": package_id,
+        "related_ticket_status": related_ticket_status,
+        **ticket_counts_summary,
     }
 
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -348,6 +348,14 @@ class ServicePackageVulnsSolvedUnsolved(ORMModel):
     vuln_ids: list[UUID]
 
 
+class ServicePackageTicketCountsSolvedUnsolved(ORMModel):
+    pteam_id: UUID
+    service_id: UUID | None
+    package_id: UUID | None
+    related_ticket_status: str | None
+    ssvc_priority_count: dict[str, int]
+
+
 class DependencyResponse(ORMModel):
     dependency_id: UUID
     service_id: UUID

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -62,7 +62,7 @@ def test_sbom_uploaded_at_with_called_upload_tags_file():
     assert datetime.strptime(service1["sbom_uploaded_at"], datetime_format) < now
 
 
-class TestGetVulnIdsTiedToServicePackages:
+class TestGetVulnIdsTiedToServicePackage:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self, testdb):
         # Given
@@ -295,7 +295,7 @@ class TestGetVulnIdsTiedToServicePackages:
         assert response1.json()["vuln_ids"] == vuln_ids_sorted
 
 
-class TestGetTicketCountsTiedToServicePackages:
+class TestGetTicketCountsTiedToServicePackage:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self, testdb):
         # Given
@@ -538,8 +538,8 @@ class TestGetTicketCountsTiedToServicePackages:
         self,
         exploitation,
         automatable,
-        expected_ssvc_priority_count,
         service_mission_impact,
+        expected_ssvc_priority_count,
     ):
         # Given
         vuln = {

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -295,6 +295,282 @@ class TestGetVulnIdsTiedToServicePackages:
         assert response1.json()["vuln_ids"] == vuln_ids_sorted
 
 
+class TestGetTicketCountsTiedToServicePackages:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self, testdb):
+        # Given
+        # Create 1st ticket
+        service_name1 = "test_service1"
+        self.ticket_response1 = ticket_utils.create_ticket(
+            testdb, USER1, PTEAM1, service_name1, VULN1
+        )
+        json_data = {
+            "topic_status": "acknowledged",
+            "note": "string",
+            "assignees": [],
+            "scheduled_at": None,
+        }
+        set_ticket_status(
+            USER1,
+            self.ticket_response1["pteam_id"],
+            self.ticket_response1["ticket_id"],
+            json_data,
+        )
+
+        # Create 2st ticket
+        service_name2 = "test_service2"
+        upload_file_name = "test_trivy_cyclonedx_asynckit.json"
+        sbom_file = (
+            Path(__file__).resolve().parent.parent / "common" / "upload_test" / upload_file_name
+        )
+        with open(sbom_file, "r") as sbom:
+            sbom_json = json.load(sbom)
+
+        bg_create_tags_from_sbom_json(
+            sbom_json, self.ticket_response1["pteam_id"], service_name2, upload_file_name
+        )
+        self.vuln2 = create_vuln(USER1, VULN2)
+
+    def test_it_able_to_filter_when_service_id_is_specified_as_query_parameter(self):
+        # When
+        response1 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts",
+            headers=headers(USER1),
+        )
+        response2 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts?service_id={self.ticket_response1['service_id']}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response1.status_code == 200
+        assert response1.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response1.json()["service_id"] is None
+        assert response1.json()["package_id"] is None
+        assert response1.json()["related_ticket_status"] is None
+        assert response1.json()["ssvc_priority_count"] == {
+            "immediate": 2,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+        assert response2.status_code == 200
+        assert response2.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response2.json()["service_id"] == self.ticket_response1["service_id"]
+        assert response2.json()["package_id"] is None
+        assert response2.json()["related_ticket_status"] is None
+        assert response2.json()["ssvc_priority_count"] == {
+            "immediate": 1,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+    def test_it_able_to_filter_when_package_id_is_specified_as_query_parameter(self):
+        # When
+        response1 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts",
+            headers=headers(USER1),
+        )
+        response2 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts?package_id={self.ticket_response1['package_id']}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response1.status_code == 200
+        assert response1.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response1.json()["service_id"] is None
+        assert response1.json()["package_id"] is None
+        assert response1.json()["related_ticket_status"] is None
+        assert response1.json()["ssvc_priority_count"] == {
+            "immediate": 2,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+        assert response2.status_code == 200
+        assert response2.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response2.json()["service_id"] is None
+        assert response2.json()["package_id"] == self.ticket_response1["package_id"]
+        assert response2.json()["related_ticket_status"] is None
+        assert response2.json()["ssvc_priority_count"] == {
+            "immediate": 1,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+    def test_it_able_to_filter_when_solved_is_specified_as_query_parameter(self):
+        # Given
+        # Change status of ticket1
+        json_data = {
+            "topic_status": "completed",
+            "note": "string",
+            "assignees": [self.ticket_response1["user_id"]],
+            "scheduled_at": None,
+        }
+        set_ticket_status(
+            USER1,
+            self.ticket_response1["pteam_id"],
+            self.ticket_response1["ticket_id"],
+            json_data,
+        )
+
+        # When
+        response1 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts",
+            headers=headers(USER1),
+        )
+        response2 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts?related_ticket_status=solved",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response1.status_code == 200
+        assert response1.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response1.json()["service_id"] is None
+        assert response1.json()["package_id"] is None
+        assert response1.json()["related_ticket_status"] is None
+        assert response1.json()["ssvc_priority_count"] == {
+            "immediate": 2,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+        assert response2.status_code == 200
+        assert response2.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response2.json()["service_id"] is None
+        assert response2.json()["package_id"] is None
+        assert response2.json()["related_ticket_status"] == "solved"
+        assert response2.json()["ssvc_priority_count"] == {
+            "immediate": 1,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+    def test_it_able_to_filter_when_unsolved_is_specified_as_query_parameter(self):
+        # Given
+        # Change status of ticket1
+        json_data = {
+            "topic_status": "completed",
+            "note": "string",
+            "assignees": [self.ticket_response1["user_id"]],
+            "scheduled_at": None,
+        }
+        set_ticket_status(
+            USER1,
+            self.ticket_response1["pteam_id"],
+            self.ticket_response1["ticket_id"],
+            json_data,
+        )
+
+        # When
+        response1 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts",
+            headers=headers(USER1),
+        )
+        response2 = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts?related_ticket_status=unsolved",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response1.status_code == 200
+        assert response1.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response1.json()["service_id"] is None
+        assert response1.json()["package_id"] is None
+        assert response1.json()["related_ticket_status"] is None
+        assert response1.json()["ssvc_priority_count"] == {
+            "immediate": 2,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+        assert response2.status_code == 200
+        assert response2.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response2.json()["service_id"] is None
+        assert response2.json()["package_id"] is None
+        assert response2.json()["related_ticket_status"] == "unsolved"
+        assert response2.json()["ssvc_priority_count"] == {
+            "immediate": 1,
+            "out_of_cycle": 0,
+            "scheduled": 0,
+            "defer": 0,
+        }
+
+    @pytest.mark.parametrize(
+        "exploitation, automatable, service_mission_impact, expected_ssvc_priority_count",
+        [
+            (
+                "active",
+                "yes",
+                "mission_failure",
+                {"immediate": 1, "out_of_cycle": 0, "scheduled": 0, "defer": 0},
+            ),
+            (
+                "public_poc",
+                "yes",
+                "mission_failure",
+                {"immediate": 0, "out_of_cycle": 1, "scheduled": 0, "defer": 0},
+            ),
+            (
+                "none",
+                "no",
+                "mission_failure",
+                {"immediate": 0, "out_of_cycle": 0, "scheduled": 1, "defer": 0},
+            ),
+            (
+                "none",
+                "no",
+                "degraded",
+                {"immediate": 0, "out_of_cycle": 0, "scheduled": 0, "defer": 1},
+            ),
+        ],
+    )
+    def test_it_should_return_correct_ssvc_priority_count_when_ssvc_is_changed(
+        self,
+        exploitation,
+        automatable,
+        expected_ssvc_priority_count,
+        service_mission_impact,
+    ):
+        # Given
+        vuln = {
+            **VULN1,
+            "exploitation": exploitation,
+            "automatable": automatable,
+        }
+        data_service = {"service_mission_impact": service_mission_impact}
+
+        create_vuln(USER1, vuln)
+
+        client.put(
+            f"/pteams/{self.ticket_response1['pteam_id']}/services/{self.ticket_response1['service_id']}",
+            headers=headers(USER1),
+            json=data_service,
+        )
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response1['pteam_id']}/ticket_counts?service_id={self.ticket_response1['service_id']}&package_id={self.ticket_response1['package_id']}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 200
+        assert response.json()["pteam_id"] == self.ticket_response1["pteam_id"]
+        assert response.json()["service_id"] == self.ticket_response1["service_id"]
+        assert response.json()["package_id"] == self.ticket_response1["package_id"]
+        assert response.json()["ssvc_priority_count"] == expected_ssvc_priority_count
+
+
 class TestPostUploadSBOMFileCycloneDX:
 
     class Common:

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1961,6 +1961,138 @@ class TestGetVulnIdsTiedToServicePackages:
         assert response.json()["detail"][0]["msg"] == "Input should be 'solved' or 'unsolved'"
 
 
+class TestGetTicketCountsTiedToServicePackages:
+    @pytest.fixture(scope="function", autouse=True)
+    def common_setup(self, testdb):
+        # Given
+        service_name = "test_service1"
+        self.ticket_response = ticket_utils.create_ticket(
+            testdb, USER1, PTEAM1, service_name, VULN1
+        )
+
+        json_data = {
+            "topic_status": "acknowledged",
+            "note": "string",
+            "assignees": [],
+            "scheduled_at": None,
+        }
+        set_ticket_status(
+            USER1,
+            self.ticket_response["pteam_id"],
+            self.ticket_response["ticket_id"],
+            json_data,
+        )
+
+    def test_it_should_return_404_with_wrong_pteam_id(self):
+        # Given
+        wrong_pteam_id = str(uuid4())
+
+        # When
+        response = client.get(
+            f"/pteams/{wrong_pteam_id}/ticket_counts?service_id={self.ticket_response['service_id']}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No such pteam"}
+
+    def test_it_should_return_403_with_wrong_pteam_member(self):
+        # Given
+        create_user(USER2)  # with wrong pteam member
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?service_id={self.ticket_response['service_id']}",
+            headers=headers(USER2),
+        )
+
+        # Then
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Not a pteam member"}
+
+    def test_it_should_return_404_with_wrong_service_id(self):
+        # Given
+        wrong_service_id = str(uuid4())  # with wrong service_id
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?service_id={wrong_service_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No such service"}
+
+    def test_it_should_return_404_with_service_not_in_pteam(self, testdb):
+        # Given
+        pteam2 = create_pteam(USER1, PTEAM2)
+        service2 = models.Service(
+            service_name="test_service2",
+            pteam_id=str(pteam2.pteam_id),
+        )
+        testdb.add(service2)
+        testdb.flush()
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?service_id={service2.service_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No such service"}
+
+    def test_it_should_return_404_with_wrong_package_id(self):
+        # Given
+        wrong_package_id = str(uuid4())  # with wrong tag_id
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?service_id={self.ticket_response['service_id']}&package_id={wrong_package_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No such package"}
+
+    def test_it_should_return_404_with_valid_but_not_service_package(self, testdb):
+        # Given
+        # with valid but not service package
+        package = models.Package(
+            name="a1",
+            ecosystem="a2",
+        )
+        persistence.create_package(testdb, package)
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?service_id={self.ticket_response['service_id']}&package_id={package.package_id}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        assert response.json() == {"detail": "No such service package"}
+
+    def test_it_should_return_404_with_wrong_related_ticket_status(self, testdb):
+        # Given
+        related_ticket_status = "wrong_status"
+
+        # When
+        response = client.get(
+            f"/pteams/{self.ticket_response['pteam_id']}/ticket_counts?related_ticket_status={related_ticket_status}",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["msg"] == "Input should be 'solved' or 'unsolved'"
+
+
 class TestPostUploadPTeamSbomFile:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1829,7 +1829,7 @@ def test_remove_pteam_by_service_id(testdb):
     assert response.status_code == 204
 
 
-class TestGetVulnIdsTiedToServicePackages:
+class TestGetVulnIdsTiedToServicePackage:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self, testdb):
         # Given
@@ -1961,7 +1961,7 @@ class TestGetVulnIdsTiedToServicePackages:
         assert response.json()["detail"][0]["msg"] == "Input should be 'solved' or 'unsolved'"
 
 
-class TestGetTicketCountsTiedToServicePackages:
+class TestGetTicketCountsTiedToServicePackage:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self, testdb):
         # Given


### PR DESCRIPTION
## PR の目的
- API[Get /pteams/{pteam_id}/ticket_counts? sercice_id, package_id, related_ticket_status=[solved|unsolved]]を作成しました
- 旧[Get /pteams/{pteam_id}/services/{service_id}/tags/{tag_id}/topic_ids] の機能を2つに分割しました。

## 経緯・意図・意思決定
### API
- api/app/routers/pteams.py
  - get_vuln_ids_tied_to_service_packages()を参考に作成しました
- api/app/business/ssvc_business.py
  - get_vuln_ids_summary_by_service_id_and_package_id()では、service, package_id, related_ticket_statusがあった時、取ってくるssvc_priority_countを絞れるように条件分岐しています。

### テスト
- api/app/tests/integrations/test_pteams.py
   - クエリパラメータにservice, package_id, related_ticket_statusをそれぞれ指定した時、正しくssvc_priority_countを絞り込めているか確認しています
  - ssvc_business.pyのget_ticket_counts_summary_by_service_id_and_package_id()関数にある条件分岐を1回以上通るようにテストをしています
- api/app/tests/requests/test_pteams.py
  - エラー処理が正しく動作するか確認しています
  - TestGetVulnIdsTiedToServicePackagesを参考に作成しました
