### PR TITLE
add put("/{pteam_id}/tickets/{ticket_id}"

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -941,7 +941,18 @@ def update_ticket_safety_impact(
 
     db.commit()
 
-    return ticket
+    vuln_id = ticket.threat.vuln_id if ticket.threat else None
+
+    return {
+        "ticket_id": ticket.ticket_id,
+        "vuln_id": vuln_id,
+        "dependency_id": ticket.dependency_id,
+        "created_at": ticket.created_at,
+        "ssvc_deployer_priority": ticket.ssvc_deployer_priority,
+        "ticket_safety_impact": ticket.ticket_safety_impact,
+        "reason_safety_impact": ticket.reason_safety_impact,
+        "ticket_status": ticket.ticket_status,
+    }
 
 
 @router.post("", response_model=schemas.PTeamInfo)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -863,7 +863,7 @@ def update_ticket_safety_impact(
     db: Session = Depends(get_db),
 ):
     """
-    Update safety_impact.
+    Update ticket_safety_impact.
     """
     max_reason_safety_impact_length_in_half = 500
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -317,6 +317,11 @@ class TicketResponse(ORMModel):
     ticket_status: TicketStatusResponse
 
 
+class TicketUpdateRequest(ORMModel):
+    ticket_safety_impact: SafetyImpactEnum | None = None
+    reason_safety_impact: str | None = None
+
+
 class PTeamPackagesSummary(ORMModel):
     class PTeamPackageSummary(ORMModel):
         package_id: UUID

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4444,6 +4444,39 @@ class TestPutTicket:
         data = response.json()
         assert data["reason_safety_impact"] == "Updated reason for safety impact"
 
+    def test_it_should_set_reason_safety_impact_none_when_blank(self):
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+        # In case of an empty string
+        request = {
+            "reason_safety_impact": "",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=request,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reason_safety_impact"] is None
+
+        # In case of whitespace characters
+        request = {
+            "reason_safety_impact": "   ",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=request,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reason_safety_impact"] is None
+
     def test_it_should_return_400_when_reason_safety_impact_too_long(self):
         user1_access_token = self._get_access_token(USER1)
         _headers = {
@@ -4523,39 +4556,6 @@ class TestPutTicket:
         )
         assert response.status_code == 403
         assert response.json()["detail"] == "Not a pteam member"
-
-    def test_it_should_set_reason_safety_impact_none_when_blank(self):
-        user1_access_token = self._get_access_token(USER1)
-        _headers = {
-            "Authorization": f"Bearer {user1_access_token}",
-            "Content-Type": "application/json",
-            "accept": "application/json",
-        }
-        # In case of an empty string
-        request = {
-            "reason_safety_impact": "",
-        }
-        response = client.put(
-            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
-            headers=_headers,
-            json=request,
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["reason_safety_impact"] is None
-
-        # In case of whitespace characters
-        request = {
-            "reason_safety_impact": "   ",
-        }
-        response = client.put(
-            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
-            headers=_headers,
-            json=request,
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["reason_safety_impact"] is None
 
     def test_it_should_not_fix_ssvc_priority_when_not_changed(self, mocker):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4668,11 +4668,7 @@ class TestPutTicket:
         initial_priority = self.ticket1.ssvc_deployer_priority
 
         request = {
-            "ticket_safety_impact": (
-                self.ticket1.ticket_safety_impact.value
-                if self.ticket1.ticket_safety_impact
-                else None
-            ),
+            "ticket_safety_impact": models.SafetyImpactEnum.CRITICAL.value,
             "reason_safety_impact": self.ticket1.reason_safety_impact,
         }
 

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4534,7 +4534,7 @@ class TestPutTicket:
             .filter(models.Ticket.ticket_id == self.ticket1.ticket_id)
             .one()
         )
-        assert updated_ticket.ticket_safety_impact.value == initial_request["ticket_safety_impact"]
+        assert updated_ticket.ticket_safety_impact == initial_request["ticket_safety_impact"]
         assert updated_ticket.reason_safety_impact == initial_request["reason_safety_impact"]
 
     def test_it_should_return_400_when_reason_safety_impact_too_long(self):

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4422,8 +4422,8 @@ class TestPutTicket:
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["ticket_safety_impact"] == models.SafetyImpactEnum.CRITICAL.value
-        assert data["reason_safety_impact"] == "Test reason for safety impact"
+        assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
+        assert data["reason_safety_impact"] == request["reason_safety_impact"]
 
     def test_it_should_update_reason_safety_impact(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4451,6 +4451,17 @@ class TestPutTicket:
             "Content-Type": "application/json",
             "accept": "application/json",
         }
+
+        # Add a value to reason_safety_impact in advance
+        set_request = {
+            "reason_safety_impact": "sample",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=set_request,
+        )
+
         # In case of an empty string
         request = {
             "reason_safety_impact": "",
@@ -4463,6 +4474,16 @@ class TestPutTicket:
         assert response.status_code == 200
         data = response.json()
         assert data["reason_safety_impact"] is None
+
+        # Add a value to reason_safety_impact in advance
+        set_request = {
+            "reason_safety_impact": "sample",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=set_request,
+        )
 
         # In case of whitespace characters
         request = {

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4422,9 +4422,11 @@ class TestPutTicket:
         )
         assert response.status_code == 200
         data = response.json()
+        print(data)
         assert data["ticket_id"] == str(self.ticket1.ticket_id)
         assert data["vuln_id"] == str(self.vuln1.vuln_id)
         assert data["dependency_id"] == str(self.dependency1.dependency_id)
+        assert data["created_at"] == self.ticket1.created_at.isoformat()
         assert data["ssvc_deployer_priority"] == models.TopicStatusType.scheduled.value
         assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
         assert data["reason_safety_impact"] == request["reason_safety_impact"]

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4528,6 +4528,39 @@ class TestPutTicket:
         assert data["ticket_safety_impact"] == initial_request["ticket_safety_impact"]
         assert data["reason_safety_impact"] == initial_request["reason_safety_impact"]
 
+    def test_it_should_update_ticket_safety_impact_and_reason_to_none(self, testdb: Session):
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+
+        initial_request = {
+            "ticket_safety_impact": models.SafetyImpactEnum.CRITICAL.value,
+            "reason_safety_impact": "some reason",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=initial_request,
+        )
+        assert response.status_code == 200
+
+        request = {
+            "ticket_safety_impact": None,
+            "reason_safety_impact": None,
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=request,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ticket_safety_impact"] is None
+        assert data["reason_safety_impact"] is None
+
     def test_it_should_return_400_when_reason_safety_impact_too_long(self):
         user1_access_token = self._get_access_token(USER1)
         _headers = {

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4498,6 +4498,45 @@ class TestPutTicket:
         data = response.json()
         assert data["reason_safety_impact"] is None
 
+    def test_it_should_keep_previous_values_when_ticket_safety_impact_and_reason_not_specified(
+        self, testdb: Session
+    ):
+        user1_access_token = self._get_access_token(USER1)
+        _headers = {
+            "Authorization": f"Bearer {user1_access_token}",
+            "Content-Type": "application/json",
+            "accept": "application/json",
+        }
+
+        initial_request = {
+            "ticket_safety_impact": models.SafetyImpactEnum.CRITICAL.value,
+            "reason_safety_impact": "first reason",
+        }
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json=initial_request,
+        )
+
+        response = client.put(
+            f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket1.ticket_id}",
+            headers=_headers,
+            json={},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ticket_safety_impact"] == initial_request["ticket_safety_impact"]
+        assert data["reason_safety_impact"] == initial_request["reason_safety_impact"]
+
+        # DBでも確認
+        updated_ticket = (
+            testdb.query(models.Ticket)
+            .filter(models.Ticket.ticket_id == self.ticket1.ticket_id)
+            .one()
+        )
+        assert updated_ticket.ticket_safety_impact.value == initial_request["ticket_safety_impact"]
+        assert updated_ticket.reason_safety_impact == initial_request["reason_safety_impact"]
+
     def test_it_should_return_400_when_reason_safety_impact_too_long(self):
         user1_access_token = self._get_access_token(USER1)
         _headers = {

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4422,8 +4422,21 @@ class TestPutTicket:
         )
         assert response.status_code == 200
         data = response.json()
+        assert data["ticket_id"] == str(self.ticket1.ticket_id)
+        assert data["vuln_id"] == str(self.vuln1.vuln_id)
+        assert data["dependency_id"] == str(self.dependency1.dependency_id)
+        assert data["ssvc_deployer_priority"] == models.TopicStatusType.scheduled.value
         assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
         assert data["reason_safety_impact"] == request["reason_safety_impact"]
+        assert data["ticket_status"]["status_id"] == self.ticket_status1.status_id
+        assert data["ticket_status"]["ticket_id"] == str(self.ticket1.ticket_id)
+        assert data["ticket_status"]["topic_status"] == models.TopicStatusType.alerted.value
+        assert data["ticket_status"]["user_id"] is None
+        assert data["ticket_status"]["created_at"] == self.ticket_status1.created_at.isoformat()
+        assert data["ticket_status"]["assignees"] == []
+        assert data["ticket_status"]["note"] is None
+        assert data["ticket_status"]["scheduled_at"] is None
+        assert data["ticket_status"]["action_logs"] == []
 
     def test_it_should_update_reason_safety_impact(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4495,7 +4495,10 @@ class TestPutTicket:
             json=request,
         )
         assert response.status_code == 400
-        assert "Too long reason_safety_impact" in response.json()["detail"]
+        assert (
+            "Too long reason_safety_impact. Max length is 500 in half-width or 250 in full-width"
+            in response.json()["detail"]
+        )
 
     def test_it_should_return_404_when_ticket_not_found(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -4499,7 +4499,7 @@ class TestPutTicket:
         assert data["reason_safety_impact"] is None
 
     def test_it_should_keep_previous_values_when_ticket_safety_impact_and_reason_not_specified(
-        self, testdb: Session
+        self,
     ):
         user1_access_token = self._get_access_token(USER1)
         _headers = {
@@ -4527,15 +4527,6 @@ class TestPutTicket:
         data = response.json()
         assert data["ticket_safety_impact"] == initial_request["ticket_safety_impact"]
         assert data["reason_safety_impact"] == initial_request["reason_safety_impact"]
-
-        # DBでも確認
-        updated_ticket = (
-            testdb.query(models.Ticket)
-            .filter(models.Ticket.ticket_id == self.ticket1.ticket_id)
-            .one()
-        )
-        assert updated_ticket.ticket_safety_impact == initial_request["ticket_safety_impact"]
-        assert updated_ticket.reason_safety_impact == initial_request["reason_safety_impact"]
 
     def test_it_should_return_400_when_reason_safety_impact_too_long(self):
         user1_access_token = self._get_access_token(USER1)


### PR DESCRIPTION
- API Put /pteams/{pteam_id}/tickets/{ticket_id}の実装
   - 既存[Put /threats/{threat_id}]に対し、threat_safety_impactがticketに移動したためURL変更
   - schemasにTicketUpdateRequestを追加

- TestPutTicketの実装（テストコードの実装）
   - **test_it_should_update_ticket_safety_impact**
      - ticket_safety_impactとreason_safety_impactを更新できること
   - **test_it_should_update_reason_safety_impact**
      - reason_safety_impactのみを更新できること
   - **test_it_should_set_reason_safety_impact_none_when_blank**
      - reason_safety_impactが空文字や空白文字の場合はNoneになること
   - **test_it_should_return_400_when_reason_safety_impact_too_long**
      - reason_safety_impactが501文字（上限）以上だと400エラーになること
   - **test_it_should_return_404_when_ticket_not_found**
      - 存在しないチケットIDの場合404になること
   - **test_it_should_return_404_when_pteam_not_found**
      - 存在しないpteam_idの場合404になること
   - **test_it_should_return_403_when_not_pteam_member**
      - チームメンバーでないユーザーが更新しようとすると403になること
   - **test_it_should_not_fix_ssvc_priority_when_not_changed**
      - 既存の値と同じ値を送った場合、SSVCの再計算関数が呼ばれないこと
   - **test_it_should_return_422_when_invalid_ticket_safety_impact**
      - ticket_safety_impactに不正な値を指定すると422（バリデーションエラー）になること
