### PR TITLE
Fix/add pteamid query parameter to get vulns search

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -133,6 +133,7 @@ def get_vulns(
     created_before: Optional[datetime] = None,
     updated_after: Optional[datetime] = None,
     updated_before: Optional[datetime] = None,
+    pteam_id: Optional[UUID | str] = None,
     cve_ids: Optional[list[str]] = None,
     package_name: Optional[list[str]] = None,
     ecosystem: Optional[list[str]] = None,
@@ -236,6 +237,31 @@ def get_vulns(
         filters.append(models.Affect.package.has(models.Package.name.in_(package_name)))
     if ecosystem:
         filters.append(models.Affect.package.has(models.Package.ecosystem.in_(ecosystem)))
+
+    # PTeam filter
+    if pteam_id:
+        subq_team_affected_package = (
+            select(models.Package.package_id)
+            .join(models.Affect, models.Affect.package_id == models.Package.package_id)
+            .join(
+                models.PackageVersion, models.PackageVersion.package_id == models.Package.package_id
+            )
+            .join(
+                models.Dependency,
+                models.Dependency.package_version_id == models.PackageVersion.package_version_id,
+            )
+            .join(
+                models.Service,
+                and_(
+                    models.Service.service_id == models.Dependency.service_id,
+                    models.Service.pteam_id == str(pteam_id),
+                ),
+            )
+            .subquery()
+        )
+        filters.append(
+            models.Affect.package_id.in_(select(subq_team_affected_package.c.package_id))
+        )
 
     # Dependency filters
     if package_manager:

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -247,7 +247,7 @@ def get_vulns(
             ).where(models.Service.pteam_id == str(pteam_id))
         else:
             query = (
-                query.join(
+                query.outerjoin(
                     models.PackageVersion,
                     models.Package.package_id == models.PackageVersion.package_id,
                 )

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -243,8 +243,11 @@ def get_vulns(
         if package_manager:
             query = query.join(
                 models.Service,
-                models.Service.service_id == models.Dependency.service_id,
-            ).where(models.Service.pteam_id == str(pteam_id))
+                and_(
+                    models.Service.service_id == models.Dependency.service_id,
+                    models.Service.pteam_id == str(pteam_id),
+                ),
+            )
         else:
             query = (
                 query.outerjoin(

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -261,9 +261,11 @@ def get_vulns(
                 )
                 .join(
                     models.Service,
-                    models.Service.service_id == models.Dependency.service_id,
+                    and_(
+                        models.Service.service_id == models.Dependency.service_id,
+                        models.Service.pteam_id == str(pteam_id),
+                    ),
                 )
-                .where(models.Service.pteam_id == str(pteam_id))
             )
 
     # Dependency filters

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -310,6 +310,7 @@ def get_vulns(
     created_before: datetime | None = Query(None),
     updated_after: datetime | None = Query(None),
     updated_before: datetime | None = Query(None),
+    pteam_id: UUID | None = Query(None),
     cve_ids: list[str] | None = Query(None),
     package_name: list[str] | None = Query(None),
     ecosystem: list[str] | None = Query(None),
@@ -334,6 +335,7 @@ def get_vulns(
     - `created_before`: Filter vulnerabilities created before this datetime.
     - `updated_after`: Filter vulnerabilities updated after this datetime.
     - `updated_before`: Filter vulnerabilities updated before this datetime.
+    - `pteam_id`: Filter vulnerabilities associated with this PTeam ID.
     - `cve_ids`: List of CVE IDs to filter by.
     - `package_name`: List of package names to filter by.
     - `ecosystem`: List of ecosystems to filter by.
@@ -376,6 +378,7 @@ def get_vulns(
             created_before=created_before,
             updated_after=updated_after,
             updated_before=updated_before,
+            pteam_id=pteam_id,
             cve_ids=cve_ids,
             package_name=package_name,
             ecosystem=ecosystem,


### PR DESCRIPTION
## PR の目的
- Get /vulns APIのクエリパラメータにpteam_idを追加

- テストコードの追加（test_it_should_filter_by_pteam_id）
   - SBOMファイル（例: test_trivy_cyclonedx_axios.json）を読み込む
   - bg_create_tags_from_sbom_jsonを使ってSBOMをDBに投入し、依存パッケージ情報を登録
   - SBOMのcomponentsから、テスト対象Package（例: axios）とそのecosystem（例: npm）を取得
   - 脆弱性データの作成
   - pteam_idでフィルタして取得
   - 以下を確認
      - ステータスコードが200であること
      - 返ってきた脆弱性リストが1件のみで、SBOMパッケージに紐づく脆弱性だけであること
