### PR TITLE
fix post actionlogs API

### DIFF
--- a/api/app/routers/actionlogs.py
+++ b/api/app/routers/actionlogs.py
@@ -37,7 +37,7 @@ def create_log(
     db: Session = Depends(get_db),
 ):
     """
-    Add an action log to the topic.
+    Add an action log to the vuln.
 
     `executed_at` is optional, the default is the current time in the server.
 
@@ -52,7 +52,7 @@ def create_log(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a pteam member")
     if not (
         ticket := persistence.get_ticket_by_id(db, data.ticket_id)
-    ) or ticket.threat.dependency.service_id != str(data.service_id):
+    ) or ticket.dependency.service_id != str(data.service_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No such ticket")
     if not (user := persistence.get_account_by_id(db, data.user_id)):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid user id")
@@ -60,21 +60,21 @@ def create_log(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Not a pteam member")
 
     # TODO Provisional Processing
-    # if not (persistence.get_topic_by_id(db, data.topic_id)):
-    #     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No such topic")
+    # if not (persistence.get_vuln_by_id(db, data.vuln_id)):
+    #     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No such vuln")
 
     if not (
-        topic_action := persistence.get_action_by_id(db, data.action_id)
-    ) or topic_action.topic_id != str(data.topic_id):
+        vuln_action := persistence.get_action_by_id(db, data.action_id)
+    ) or vuln_action.vuln_id != str(data.vuln_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid action id")
 
     now = datetime.now()
     log = models.ActionLog(
         action_id=data.action_id,
-        topic_id=data.topic_id,
-        action=topic_action.action,
-        action_type=topic_action.action_type,
-        recommended=topic_action.recommended,
+        vuln_id=data.vuln_id,
+        action=vuln_action.action,
+        action_type=vuln_action.action_type,
+        recommended=vuln_action.recommended,
         user_id=data.user_id,
         pteam_id=data.pteam_id,
         service_id=data.service_id,

--- a/api/app/routers/actionlogs.py
+++ b/api/app/routers/actionlogs.py
@@ -58,10 +58,8 @@ def create_log(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid user id")
     if not check_pteam_membership(pteam, user):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Not a pteam member")
-
-    # TODO Provisional Processing
-    # if not (persistence.get_vuln_by_id(db, data.vuln_id)):
-    #     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No such vuln")
+    if not (persistence.get_vuln_by_id(db, data.vuln_id)):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No such vuln")
 
     if not (
         vuln_action := persistence.get_action_by_id(db, data.action_id)

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -278,7 +278,7 @@ class ActionLogResponse(ORMModel):
 
 class ActionLogRequest(ORMModel):
     action_id: UUID
-    topic_id: UUID
+    vuln_id: UUID
     user_id: UUID
     pteam_id: UUID
     service_id: UUID

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -263,7 +263,7 @@ class ApplyInvitationRequest(ORMModel):
 class ActionLogResponse(ORMModel):
     logging_id: UUID
     action_id: UUID
-    topic_id: UUID
+    vuln_id: UUID
     action: str
     action_type: ActionType
     recommended: bool

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -65,12 +65,7 @@ class TestActionLog:
 
             # Upload the SBOM file and create dependency information
             upload_file_name = "test_trivy_cyclonedx_axios.json"
-            sbom_file = (
-                Path(__file__).resolve().parent.parent.parent
-                / "requests"
-                / "upload_test"
-                / upload_file_name
-            )
+            sbom_file = Path(__file__).resolve().parent / "upload_test" / upload_file_name
             with open(sbom_file, "r") as sbom:
                 sbom_json = json.load(sbom)
             bg_create_tags_from_sbom_json(

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -92,8 +92,7 @@ class TestActionLog:
 
             # Get dependency information (PackageVersion) from the database
             package_version = testdb.scalars(select(models.PackageVersion)).one()
-            self.package_version = package_version
-            self.package_id = package_version.package_id
+            self.package_version1 = package_version
 
             # Create vulnerability and action
             self.vuln1 = create_vuln(USER1, VULN1)
@@ -109,7 +108,7 @@ class TestActionLog:
                 self.pteam1.pteam_id,
                 self.service1["service_id"],
                 self.vuln1.vuln_id,
-                self.package_id,
+                self.package_version1.package_id,
             )[0]
 
     class TestCreate(Common):

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -44,13 +44,6 @@ class TestActionLog:
 
     class Common:
 
-        def get_service_dependencies(self, service_id: UUID | str) -> dict:
-            response = client.get(
-                f"/pteams/{self.pteam1.pteam_id}/services/{service_id}/dependencies",
-                headers=headers(USER1),
-            )
-            return response.json()
-
         def create_action_for_vuln(
             self, user: dict, vuln_id: str | UUID, action: dict
         ) -> schemas.ActionResponse:
@@ -63,15 +56,6 @@ class TestActionLog:
             if response.status_code != 200:
                 raise HTTPError(response)
             return schemas.ActionResponse(**response.json())
-
-        def get_actions_by_vuln_id(
-            self, vuln_id: str | UUID, user: dict
-        ) -> list[schemas.ActionResponse]:
-            response = client.get(f"/vulns/{vuln_id}/actions", headers=headers(user))
-            if response.status_code != 200:
-                raise HTTPError(response)
-            data = response.json()
-            return [schemas.ActionResponse(**a) for a in data]
 
         @pytest.fixture(scope="function", autouse=True)
         def common_setup(self, testdb):

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -12,22 +12,21 @@ from app.tests.medium.constants import (
     SERVICE1,
     SERVICE2,
     TAG1,
-    TOPIC1,
-    TOPIC2,
     USER1,
     USER2,
     USER3,
+    VULN1,
+    VULN2,
 )
 from app.tests.medium.exceptions import HTTPError
 from app.tests.medium.utils import (
     accept_pteam_invitation,
     create_actionlog,
     create_pteam,
-    create_tag,
-    create_topic_with_versioned_actions,
     create_user,
+    create_vuln,
     get_service_by_service_name,
-    get_tickets_related_to_topic_tag,
+    get_tickets_related_to_vuln_package,
     headers,
     invite_to_pteam,
     upload_pteam_tags,
@@ -43,19 +42,20 @@ class TestActionLog:
         @pytest.fixture(scope="function", autouse=True)
         def common_setup(self):
             self.user1 = create_user(USER1)
+            self.user2 = create_user(USER2)
             self.pteam1 = create_pteam(USER1, PTEAM1)
-            self.tag1 = create_tag(USER1, TAG1)
-            self.topic1 = create_topic_with_versioned_actions(USER1, TOPIC1, [[TAG1]])
-            self.action1 = self.topic1.actions[0]
+            self.vuln1 = create_vuln(USER1, VULN1)
+            self.action1 = self.vuln1.actions[0]
             refs0 = {TAG1: [("Pipfile.lock", "1.0.0")]}
             upload_pteam_tags(USER1, self.pteam1.pteam_id, SERVICE1, refs0, True)
             self.service1 = get_service_by_service_name(USER1, self.pteam1.pteam_id, SERVICE1)
-            self.ticket1 = get_tickets_related_to_topic_tag(
+            self.packageversion1 = self.service1.dependency.packageversion
+            self.ticket1 = get_tickets_related_to_vuln_package(
                 USER1,
                 self.pteam1.pteam_id,
                 self.service1["service_id"],
-                self.topic1.topic_id,
-                self.tag1.tag_id,
+                self.vuln1.vuln_id,
+                self.packageversion1.package_id,
             )[0]
 
     class TestCreate(Common):
@@ -65,7 +65,7 @@ class TestActionLog:
             actionlog1 = create_actionlog(
                 USER1,
                 self.action1.action_id,
-                self.topic1.topic_id,
+                self.vuln1.vuln_id,
                 self.user1.user_id,
                 self.pteam1.pteam_id,
                 self.service1["service_id"],
@@ -75,10 +75,10 @@ class TestActionLog:
 
             assert actionlog1.logging_id != ZERO_FILLED_UUID
             assert actionlog1.action_id == self.action1.action_id
-            assert actionlog1.topic_id == self.topic1.topic_id
-            assert actionlog1.action == self.topic1.actions[0].action
-            assert actionlog1.action_type == self.topic1.actions[0].action_type
-            assert actionlog1.recommended == self.topic1.actions[0].recommended
+            assert actionlog1.vuln_id == self.vuln1.vuln_id
+            assert actionlog1.action == self.vuln1.actions[0].action
+            assert actionlog1.action_type == self.vuln1.actions[0].action_type
+            assert actionlog1.recommended == self.vuln1.actions[0].recommended
             assert actionlog1.user_id == self.user1.user_id
             assert actionlog1.pteam_id == self.pteam1.pteam_id
             assert str(actionlog1.service_id) == self.service1["service_id"]
@@ -87,12 +87,12 @@ class TestActionLog:
             assert actionlog1.executed_at == now
             assert actionlog1.created_at > now
 
-        def test_create_log__with_wrong_action(self):
+        def test_create_log_with_wrong_action(self):
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,
                     uuid4(),  # wrong action_id
-                    self.topic1.topic_id,
+                    self.vuln1.vuln_id,
                     self.user1.user_id,
                     self.pteam1.pteam_id,
                     self.service1["service_id"],
@@ -100,12 +100,12 @@ class TestActionLog:
                     None,
                 )
 
-        def test_it_shoud_return_400_when_create_actionlog_with_wrong_topic(self):
+        def test_it_shoud_return_400_when_create_actionlog_with_wrong_vuln(self):
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,
                     self.action1.action_id,
-                    uuid4(),  # wrong topic_id
+                    uuid4(),  # wrong vuln_id
                     self.user1.user_id,
                     self.pteam1.pteam_id,
                     self.service1["service_id"],
@@ -118,7 +118,7 @@ class TestActionLog:
                 create_actionlog(
                     USER1,
                     self.action1.action_id,
-                    self.topic1.topic_id,
+                    self.vuln1.vuln_id,
                     uuid4(),  # wrong user_id
                     self.pteam1.pteam_id,
                     self.service1["service_id"],
@@ -131,7 +131,7 @@ class TestActionLog:
                 create_actionlog(
                     USER1,
                     self.action1.action_id,
-                    self.topic1.topic_id,
+                    self.vuln1.vuln_id,
                     self.user1.user_id,
                     uuid4(),  # wrong pteam_id
                     self.service1["service_id"],
@@ -139,13 +139,12 @@ class TestActionLog:
                     None,
                 )
 
-        def test_create_log__with_called_by_not_pteam_member(self):
-            create_user(USER2)
+        def test_create_log_with_called_by_not_pteam_member(self):
             with pytest.raises(HTTPError, match="403: Forbidden"):
                 create_actionlog(
                     USER2,  # call by USER2
                     self.action1.action_id,
-                    self.topic1.topic_id,
+                    self.vuln1.vuln_id,
                     self.user1.user_id,
                     self.pteam1.pteam_id,
                     self.service1["service_id"],
@@ -154,27 +153,26 @@ class TestActionLog:
                 )
 
         def test_it_should_return_400_create_log_with_not_pteam_member_as_recipient(self):
-            user2 = create_user(USER2)
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,
                     self.action1.action_id,
-                    self.topic1.topic_id,
-                    user2.user_id,  # USER2
+                    self.vuln1.vuln_id,
+                    self.user2.user_id,  # USER2
                     self.pteam1.pteam_id,
                     self.service1["service_id"],
                     self.ticket1["ticket_id"],
                     None,
                 )
 
-        def test_it_should_return_400_when_create_log_with_action_not_belong_specified_topic(self):
-            topic2 = create_topic_with_versioned_actions(USER1, TOPIC2, [[TAG1]])
-            action2 = topic2.actions[0]
+        def test_it_should_return_400_when_create_log_with_action_not_belong_specified_vuln(self):
+            vuln2 = create_vuln(USER1, VULN2)
+            action2 = vuln2.actions[0]
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,
                     action2.action_id,  # action2
-                    self.topic1.topic_id,
+                    self.vuln1.vuln_id,
                     self.user1.user_id,
                     self.pteam1.pteam_id,
                     self.service1["service_id"],

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -102,7 +102,7 @@ class TestActionLog:
                 "action_type": "elimination",
                 "recommended": True,
             }
-            self.action1 = self.create_action_for_vuln(USER1, self.vuln1.vuln_id, action_data)
+            self.action1 = self.create_action(USER1, self.vuln1.vuln_id, action_data)
 
             self.ticket1 = get_tickets_related_to_vuln_package(
                 USER1,
@@ -226,7 +226,7 @@ class TestActionLog:
                 "action_type": "elimination",
                 "recommended": True,
             }
-            action2 = self.create_action_for_vuln(USER1, vuln2.vuln_id, action_data)
+            action2 = self.create_action(USER1, vuln2.vuln_id, action_data)
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -237,7 +237,12 @@ class TestActionLog:
 
         def test_it_should_return_400_when_create_log_with_action_not_belong_specified_vuln(self):
             vuln2 = create_vuln(USER1, VULN2)
-            action2 = vuln2.actions[0]
+            action_data = {
+                "action": "Do something else",
+                "action_type": "elimination",
+                "recommended": True,
+            }
+            action2 = self.create_action_for_vuln(USER1, vuln2.vuln_id, action_data)
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(
                     USER1,

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -44,7 +44,7 @@ class TestActionLog:
 
     class Common:
 
-        def create_action_for_vuln(
+        def create_action(
             self, user: dict, vuln_id: str | UUID, action: dict
         ) -> schemas.ActionResponse:
             action_with_vuln = {**action, "vuln_id": str(vuln_id)}

--- a/api/app/tests/medium/routers/upload_test/test_trivy_cyclonedx_axios.json
+++ b/api/app/tests/medium/routers/upload_test/test_trivy_cyclonedx_axios.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:4e1812f5-5148-4208-9981-9ce455aa6cdb",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2024-01-30T08:12:38+00:00",
+    "tools": [
+      {
+        "vendor": "aquasecurity",
+        "name": "trivy",
+        "version": "0.48.3"
+      }
+    ],
+    "component": {
+      "bom-ref": "d2f1f1cc-5fa1-4bba-b5af-fd19dfbe4718",
+      "type": "application",
+      "name": ".",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:SchemaVersion",
+          "value": "2"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "8c90136c-e90f-4db3-9c25-264e6f54452e",
+      "type": "application",
+      "name": "package-lock.json",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "npm"
+        }
+      ]
+    },
+    {
+      "bom-ref": "pkg:npm/axios@1.6.7",
+      "type": "library",
+      "name": "axios",
+      "version": "1.6.7",
+      "licenses": [
+        {
+          "license": {
+            "name": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/axios@1.6.7",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:PkgID",
+          "value": "axios@1.6.7"
+        },
+        {
+          "name": "aquasecurity:trivy:PkgType",
+          "value": "npm"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "pkg:npm/axios@1.6.7",
+      "dependsOn": [
+        "pkg:npm/follow-redirects@1.15.5",
+        "pkg:npm/form-data@4.0.0",
+        "pkg:npm/proxy-from-env@1.1.0"
+      ]
+    }
+  ],
+  "vulnerabilities": []
+}

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -233,7 +233,7 @@ def get_tickets_related_to_vuln_package(
     package_id: UUID | str,
 ) -> list[dict]:
     response = client.get(
-        f"/pteams//{pteam_id}/tickets?service_id={service_id}&vuln_id={vuln_id}&package_id={package_id}",
+        f"/pteams/{pteam_id}/tickets?service_id={service_id}&vuln_id={vuln_id}&package_id={package_id}",
         headers=headers(user),
     )
     if response.status_code != 200:

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -173,7 +173,7 @@ def create_vuln(
 def create_actionlog(
     user: dict,
     action_id: UUID | str,
-    topic_id: UUID | str,
+    vuln_id: UUID | str,
     user_id: UUID | str,
     pteam_id: UUID | str,
     service_id: UUID | str,
@@ -182,7 +182,7 @@ def create_actionlog(
 ) -> schemas.ActionLogResponse:
     request = {
         "action_id": str(action_id),
-        "topic_id": str(topic_id),
+        "vuln_id": str(vuln_id),
         "user_id": str(user_id),
         "pteam_id": str(pteam_id),
         "service_id": str(service_id),
@@ -225,15 +225,15 @@ def compare_references(refs1: list[dict], refs2: list[dict]) -> bool:
     return _to_tuple_set(refs1) == _to_tuple_set(refs2)
 
 
-def get_tickets_related_to_topic_tag(
+def get_tickets_related_to_vuln_package(
     user: dict,
     pteam_id: UUID | str,
     service_id: UUID | str,
-    topic_id: UUID | str,
-    tag_id: UUID | str,
+    vuln_id: UUID | str,
+    package_id: UUID | str,
 ) -> list[dict]:
     response = client.get(
-        f"/pteams/{pteam_id}/services/{service_id}/topics/{topic_id}/tags/{tag_id}/tickets",
+        f"/pteams//{pteam_id}/tickets?service_id={service_id}&vuln_id={vuln_id}&package_id={package_id}",
         headers=headers(user),
     )
     if response.status_code != 200:


### PR DESCRIPTION
## PR の目的
- 既存API Post /actionlogsの修正
   - TopicAction→VulnAction、Topic→Vuln
   - Ticketテーブルから直接dependencyを参照できるので、ticket.threat.dependency.service_idをticket.dependency.service_idに変更
- ActionLogRequest、ActionLogResponseスキーマの修正
   - topic_id → vuln_id

- テストコードの修正（api/app/tests/medium/routers/test_actionlogs.py :: TestCreate）
   - class TestCreate内の下記テストにおいて変数名、関数名でtopic→vuln、tag→packageに変更
      - test_create_log
      - test_create_log_with_wrong_action
      - test_it_shoud_return_400_when_create_actionlog_with_wrong_vuln
      - test_it_should_return_400_when_create_log_with_wrong_user
      - test_it_should_return_400_when_create_log_with_wrong_pteam
      - test_create_log_with_called_by_not_pteam_member
      - test_it_should_return_400_create_log_with_not_pteam_member_as_recipien
      - test_it_should_return_400_when_create_log_with_action_not_belong_specified_vuln
   - api/app/tests/medium/utils.pyのget_tickets_related_to_topic_tag関数にて関数名、引数、URLを変更

- その他
   - テストの関数名で一部アンダースコアが二つ連なっている場所があったため、修正
      - test_create_log__with_called_by_not_pteam_member
      - test_create_log__with_wrong_action