### PR TITLE
Fix/change action log to be registered even if there is no parent action

### DIFF
--- a/api/app/alembic/versions/68d85e0499fe_make_actionlog_action_and_related_.py
+++ b/api/app/alembic/versions/68d85e0499fe_make_actionlog_action_and_related_.py
@@ -1,0 +1,29 @@
+"""make_actionlog.action_and_related_columns_nullable
+
+Revision ID: 68d85e0499fe
+Revises: 312b1a6f45cf
+Create Date: 2025-05-19 14:13:10.178975
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "68d85e0499fe"
+down_revision = "b842fabcecf2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column("actionlog", "action", existing_type=sa.Text(), nullable=True)
+    op.alter_column("actionlog", "action_type", existing_type=sa.String(length=32), nullable=True)
+    op.alter_column("actionlog", "recommended", existing_type=sa.Boolean(), nullable=True)
+
+
+def downgrade():
+    op.alter_column("actionlog", "action", existing_type=sa.Text(), nullable=False)
+    op.alter_column("actionlog", "action_type", existing_type=sa.String(length=32), nullable=False)
+    op.alter_column("actionlog", "recommended", existing_type=sa.Boolean(), nullable=False)

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -566,7 +566,9 @@ class ActionLog(Base):
     __tablename__ = "actionlog"
 
     logging_id: Mapped[StrUUID] = mapped_column(primary_key=True)
-    action_id: Mapped[StrUUID]  # snapshot: don't set ForeignKey.
+    action_id: Mapped[StrUUID | None] = mapped_column(
+        nullable=True
+    )  # snapshot: don't set ForeignKey.
     vuln_id: Mapped[StrUUID]  # snapshot: don't set ForeignKey.
     action: Mapped[str]  # snapshot: don't update even if VulnAction is modified.
     action_type: Mapped[ActionType]

--- a/api/app/routers/actionlogs.py
+++ b/api/app/routers/actionlogs.py
@@ -61,18 +61,19 @@ def create_log(
     if not (persistence.get_vuln_by_id(db, data.vuln_id)):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No such vuln")
 
-    if not (
-        vuln_action := persistence.get_action_by_id(db, data.action_id)
-    ) or vuln_action.vuln_id != str(data.vuln_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid action id")
+    vuln_action = None
+    if data.action_id:
+        vuln_action = persistence.get_action_by_id(db, data.action_id)
+        if not vuln_action or vuln_action.vuln_id != str(data.vuln_id):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid action id")
 
     now = datetime.now()
     log = models.ActionLog(
         action_id=data.action_id,
         vuln_id=data.vuln_id,
-        action=vuln_action.action,
-        action_type=vuln_action.action_type,
-        recommended=vuln_action.recommended,
+        action=vuln_action.action if vuln_action else None,
+        action_type=vuln_action.action_type if vuln_action else None,
+        recommended=vuln_action.recommended if vuln_action else None,
         user_id=data.user_id,
         pteam_id=data.pteam_id,
         service_id=data.service_id,

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -265,9 +265,9 @@ class ActionLogResponse(ORMModel):
     logging_id: UUID
     action_id: Optional[UUID] = None
     vuln_id: UUID
-    action: str
-    action_type: ActionType
-    recommended: bool
+    action: Optional[str] = None
+    action_type: Optional[ActionType] = None
+    recommended: Optional[bool] = None
     user_id: UUID | None = None
     pteam_id: UUID
     service_id: UUID

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -262,7 +263,7 @@ class ApplyInvitationRequest(ORMModel):
 
 class ActionLogResponse(ORMModel):
     logging_id: UUID
-    action_id: UUID
+    action_id: Optional[UUID] = None
     vuln_id: UUID
     action: str
     action_type: ActionType
@@ -277,7 +278,7 @@ class ActionLogResponse(ORMModel):
 
 
 class ActionLogRequest(ORMModel):
-    action_id: UUID
+    action_id: Optional[UUID] = None
     vuln_id: UUID
     user_id: UUID
     pteam_id: UUID

--- a/api/app/tests/medium/routers/test_actionlogs.py
+++ b/api/app/tests/medium/routers/test_actionlogs.py
@@ -135,6 +135,29 @@ class TestActionLog:
             assert actionlog1.executed_at == now
             assert actionlog1.created_at > now
 
+        def test_create_log_without_action_id(self):
+            now = datetime.now()
+            actionlog = create_actionlog(
+                USER1,
+                None,  # action_id = None
+                self.vuln1.vuln_id,
+                self.user1.user_id,
+                self.pteam1.pteam_id,
+                self.service1["service_id"],
+                self.ticket1["ticket_id"],
+                now,
+            )
+            assert actionlog.logging_id != ZERO_FILLED_UUID
+            assert actionlog.action_id is None
+            assert str(actionlog.vuln_id) == str(self.vuln1.vuln_id)
+            assert actionlog.user_id == self.user1.user_id
+            assert actionlog.pteam_id == self.pteam1.pteam_id
+            assert str(actionlog.service_id) == self.service1["service_id"]
+            assert str(actionlog.ticket_id) == self.ticket1["ticket_id"]
+            assert actionlog.email == USER1["email"]
+            assert actionlog.executed_at == now
+            assert actionlog.created_at > now
+
         def test_create_log_with_wrong_action(self):
             with pytest.raises(HTTPError, match="400: Bad Request"):
                 create_actionlog(

--- a/api/app/tests/medium/utils.py
+++ b/api/app/tests/medium/utils.py
@@ -181,7 +181,6 @@ def create_actionlog(
     executed_at: datetime | None,
 ) -> schemas.ActionLogResponse:
     request = {
-        "action_id": str(action_id),
         "vuln_id": str(vuln_id),
         "user_id": str(user_id),
         "pteam_id": str(pteam_id),
@@ -189,6 +188,8 @@ def create_actionlog(
         "ticket_id": str(ticket_id),
         "executed_at": str(executed_at) if executed_at else None,
     }
+    if action_id is not None:
+        request["action_id"] = str(action_id)
 
     response = client.post("/actionlogs", headers=headers(user), json=request)
 


### PR DESCRIPTION
## PR の目的
- models.pyのactionlogテーブルにおいてaction_idでNullが許容されるようにする
- schemas.pyのActionLogRequestとActionRogResponseのaction_idもOptionalに変更
- テストで呼び出しているcreate_actionlog関数でaction_id=Noneの場合はリクエストにaction_idが含まれなくなるように変更
   - api/app/tests/medium/routers/test_actionlogs.py
- テストケースの作成
   - test_create_log_without_action_id
- マイグレーションスクリプトの作成
   - api/app/alembic/versions/68d85e0499fe_make_actionlog_action_and_related_.py

## 経緯・意図・意思決定
- ActionLogに対して親となるaction_idの指定を必須から任意に変更する。
   - UI上でfixed_versionがある場合はそれにUpdateするアクションを表示する方針に変更したため。
      - データモデル変更に伴い、DB上はfixed_versionからVulnActionテーブルにアクションを登録することはしない