### PR TITLE
Add processing to Get vulns API response to include the count after filtering but before pagination

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -316,7 +316,6 @@ def get_vulns(
 
     # Pageination
     query = query.offset(offset).limit(limit)
-    query = query.offset(offset).limit(limit)
     vulns = db.scalars(query).unique().all()
 
     result = {

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -274,7 +274,7 @@ def get_vulns(
 
     count_query = select(func.count(models.Vuln.vuln_id.distinct()))
     count_query = count_query.join(
-        models.Affect, models.Vuln.vuln_id == models.Affect.vuln_id
+        models.Affect,
     ).join(models.Package, models.Affect.package_id == models.Package.package_id)
 
     # Add a JOIN if referencing Dependency

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -320,9 +320,6 @@ def get_vulns(
 
     result = {
         "num_vulns": num_vulns,
-        "sort_key": sort_key,
-        "offset": offset,
-        "limit": limit,
         "vulns": vulns,
     }
 

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Optional, Sequence
+from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy import (
@@ -120,7 +120,10 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
 
 
 def get_vulns_count(
-    db: Session, filters, package_manager: Optional[str], pteam_id: Optional[UUID | str]
+    db: Session,
+    filters,
+    package_manager: str | None,
+    pteam_id: UUID | str | None,
 ) -> int:
     count_query = select(func.count(models.Vuln.vuln_id.distinct()))
     count_query = count_query.join(
@@ -172,21 +175,21 @@ def get_vulns(
     db: Session,
     offset: int,
     limit: int,
-    min_cvss_v3_score: Optional[float] = None,
-    max_cvss_v3_score: Optional[float] = None,
-    vuln_ids: Optional[list[str]] = None,
-    title_words: Optional[list[str]] = None,
-    detail_words: Optional[list[str]] = None,
-    creator_ids: Optional[list[str]] = None,
-    created_after: Optional[datetime] = None,
-    created_before: Optional[datetime] = None,
-    updated_after: Optional[datetime] = None,
-    updated_before: Optional[datetime] = None,
-    pteam_id: Optional[UUID | str] = None,
-    cve_ids: Optional[list[str]] = None,
-    package_name: Optional[list[str]] = None,
-    ecosystem: Optional[list[str]] = None,
-    package_manager: Optional[str] = None,
+    min_cvss_v3_score: float | None = None,
+    max_cvss_v3_score: float | None = None,
+    vuln_ids: list[str] | None = None,
+    title_words: list[str] | None = None,
+    detail_words: list[str] | None = None,
+    creator_ids: list[str] | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
+    updated_after: datetime | None = None,
+    updated_before: datetime | None = None,
+    pteam_id: UUID | str | None = None,
+    cve_ids: list[str] | None = None,
+    package_name: list[str] | None = None,
+    ecosystem: list[str] | None = None,
+    package_manager: str | None = None,
     sort_key: schemas.VulnSortKey = schemas.VulnSortKey.CVSS_V3_SCORE_DESC,  # set default sort key
 ) -> dict:
 

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -296,7 +296,7 @@ def get_vuln(
     )
 
 
-@router.get("", response_model=list[schemas.VulnResponse])
+@router.get("", response_model=schemas.VulnsListResponse)
 def get_vulns(
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
@@ -364,7 +364,7 @@ def get_vulns(
     - `...?package_name=example` -> Filter by the package name "example".
     """
     try:
-        vulns = command.get_vulns(
+        result = command.get_vulns(
             db=db,
             offset=offset,
             limit=limit,
@@ -392,8 +392,7 @@ def get_vulns(
         )
 
     response_vulns = []
-    for vuln in vulns:
-        # Fetch vulnerable packages associated with the vuln
+    for vuln in result["vulns"]:
         vulnerable_packages = [
             schemas.VulnerablePackage(
                 name=affect.package.name,
@@ -403,7 +402,6 @@ def get_vulns(
             )
             for affect in vuln.affects
         ]
-
         response_vulns.append(
             schemas.VulnResponse(
                 vuln_id=vuln.vuln_id,
@@ -420,7 +418,7 @@ def get_vulns(
             )
         )
 
-    return response_vulns
+    return schemas.VulnsListResponse(num_vulns=result["num_vulns"], vulns=response_vulns)
 
 
 @router.get("/{vuln_id}/actions", response_model=list[schemas.ActionResponse])

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -183,6 +183,11 @@ class VulnResponse(VulnBase):
     created_by: UUID | None = None
 
 
+class VulnsListResponse(BaseModel):
+    num_vulns: int
+    vulns: list[VulnResponse]
+
+
 class VulnUpdate(VulnBase):
     pass
 

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -509,11 +509,12 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == number_of_vulns
+        assert response_data["num_vulns"] == number_of_vulns
+        assert len(response_data["vulns"]) == number_of_vulns
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
-            reversed_index = len(response_data) - 1 - i
+        for i, vuln in enumerate(response_data["vulns"]):
+            reversed_index = len(response_data["vulns"]) - 1 - i
             self.assert_vuln_response(
                 vuln, vuln_ids[reversed_index], self.create_vuln_request(reversed_index)
             )
@@ -535,7 +536,8 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert response_data == []
+        assert response_data["num_vulns"] == 0
+        assert response_data["vulns"] == []
 
     def test_it_should_return_correct_number_of_vulns_with_limit(self, testdb: Session):
         # Given
@@ -550,7 +552,8 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 2
+        assert response_data["num_vulns"] == number_of_vulns
+        assert len(response_data["vulns"]) == 2
 
     def test_it_should_return_correct_vulns_with_offset(self, testdb: Session):
         # Given
@@ -572,17 +575,18 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 4
+        assert response_data["num_vulns"] == number_of_vulns
+        assert len(response_data["vulns"]) == 4
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
-            reversed_index = len(response_data) - 1 - i
+        for i, vuln in enumerate(response_data["vulns"]):
+            reversed_index = len(response_data["vulns"]) - 1 - i
             self.assert_vuln_response(
                 vuln, vuln_ids[reversed_index], self.create_vuln_request(reversed_index)
             )
         assert (
             created_times[3] - timedelta(seconds=10)
-            <= datetime.fromisoformat(response_data[0]["created_at"])
+            <= datetime.fromisoformat(response_data["vulns"][0]["created_at"])
             <= created_times[3] + timedelta(seconds=10)
         )
 
@@ -607,9 +611,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == count
+        assert response_data["num_vulns"] == count
+        assert len(response_data["vulns"]) == count
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(
                 vuln, vuln_ids[i + 1], self.create_vuln_request(i + 1, scores[i + 1])
             )
@@ -635,10 +640,11 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == count
+        assert response_data["num_vulns"] == count
+        assert len(response_data["vulns"]) == count
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i, scores[i]))
 
     def test_it_should_filter_by_vuln_ids(self, testdb: Session):
@@ -657,10 +663,13 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert response_data["num_vulns"] == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of the filtered vuln
-        self.assert_vuln_response(response_data[0], vuln_ids[0], self.create_vuln_request(0))
+        self.assert_vuln_response(
+            response_data["vulns"][0], vuln_ids[0], self.create_vuln_request(0)
+        )
 
     def test_it_should_filter_by_title_words(self, testdb: Session):
         # Given
@@ -684,9 +693,12 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
-        self.assert_vuln_response(response_data[0], vuln_ids[0], self.create_vuln_request(0))
+        self.assert_vuln_response(
+            response_data["vulns"][0], vuln_ids[0], self.create_vuln_request(0)
+        )
 
     def test_it_should_return_vulns_when_title_words_include_empty(self, testdb: Session):
         # Given
@@ -740,10 +752,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == number_of_vulns
+        assert len(response_data["vulns"]) == number_of_vulns
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             if i == 2:
                 assert vuln["title"] == ""
                 assert vuln["cve_id"] == "CVE-0000-0000"
@@ -756,7 +768,7 @@ class TestGetVulns:
                 assert vuln["vulnerable_packages"][0]["affected_versions"] == ["<2.0.0"]
                 assert vuln["vulnerable_packages"][0]["fixed_versions"] == ["2.0.0"]
             else:
-                reversed_index = len(response_data) - 1 - i
+                reversed_index = len(response_data["vulns"]) - 1 - i
                 self.assert_vuln_response(
                     vuln, vuln_ids[reversed_index], self.create_vuln_request(reversed_index)
                 )
@@ -783,9 +795,11 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
-        self.assert_vuln_response(response_data[0], vuln_ids[0], self.create_vuln_request(0))
+        self.assert_vuln_response(
+            response_data["vulns"][0], vuln_ids[0], self.create_vuln_request(0)
+        )
 
     def test_it_should_return_all_vulns_when_detail_words_include_empty(self, testdb: Session):
         # Given
@@ -839,10 +853,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == number_of_vulns
+        assert len(response_data["vulns"]) == number_of_vulns
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             if i == 2:
                 assert vuln["title"] == "Example-vuln-0"
                 assert vuln["cve_id"] == "CVE-0000-0000"
@@ -855,7 +869,7 @@ class TestGetVulns:
                 assert vuln["vulnerable_packages"][0]["affected_versions"] == ["<2.0.0"]
                 assert vuln["vulnerable_packages"][0]["fixed_versions"] == ["2.0.0"]
             else:
-                reversed_index = len(response_data) - 1 - i
+                reversed_index = len(response_data["vulns"]) - 1 - i
                 self.assert_vuln_response(
                     vuln, vuln_ids[reversed_index], self.create_vuln_request(reversed_index)
                 )
@@ -928,8 +942,8 @@ class TestGetVulns:
         # Then:
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
-        self.assert_vuln_response(response_data[0], vuln_id_sbom, vuln_request_sbom)
+        assert len(response_data["vulns"]) == 1
+        self.assert_vuln_response(response_data["vulns"][0], vuln_id_sbom, vuln_request_sbom)
 
     def test_it_should_filter_by_cve_ids(self, testdb: Session):
         # Given
@@ -953,10 +967,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     def test_it_should_return_400_when_cve_ids_is_empty(self, testdb: Session):
@@ -1011,15 +1025,15 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 2
+        assert len(response_data["vulns"]) == 2
         # Filter vuln_ids based on the created_after condition
         filtered_vuln_ids = [
             vuln_ids[i] for i in range(number_of_vulns) if created_at_list[i] > created_after
         ]
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
-            reversed_index = len(response_data) - 1 - i
+        for i, vuln in enumerate(response_data["vulns"]):
+            reversed_index = len(response_data["vulns"]) - 1 - i
             self.assert_vuln_response(
                 vuln,
                 filtered_vuln_ids[reversed_index],
@@ -1033,10 +1047,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
         updated_after = "2023-01-15 00:00:00"
@@ -1045,7 +1059,7 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 2
+        assert len(response_data["vulns"]) == 2
 
         # Filter vuln_ids based on the created_after condition
         filtered_vuln_ids = [
@@ -1053,8 +1067,8 @@ class TestGetVulns:
         ]
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
-            reversed_index = len(response_data) - 1 - i
+        for i, vuln in enumerate(response_data["vulns"]):
+            reversed_index = len(response_data["vulns"]) - 1 - i
             self.assert_vuln_response(
                 vuln,
                 filtered_vuln_ids[reversed_index],
@@ -1067,10 +1081,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     def test_it_should_filter_by_creator_ids(self, testdb: Session):
@@ -1102,10 +1116,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     def test_it_should_return_all_vulns_when_creator_ids_is_empty(self, testdb: Session):
@@ -1124,11 +1138,11 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == number_of_vulns
+        assert len(response_data["vulns"]) == number_of_vulns
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
-            reversed_index = len(response_data) - 1 - i
+        for i, vuln in enumerate(response_data["vulns"]):
+            reversed_index = len(response_data["vulns"]) - 1 - i
             self.assert_vuln_response(
                 vuln, vuln_ids[reversed_index], self.create_vuln_request(reversed_index)
             )
@@ -1156,10 +1170,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     def test_it_should_filter_by_ecosystem(self, testdb: Session):
@@ -1185,10 +1199,10 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     def test_it_should_filter_by_package_manager(self, testdb: Session):
@@ -1272,10 +1286,11 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data) == 1
+        print(response_data)
+        assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln
-        for i, vuln in enumerate(response_data):
+        for i, vuln in enumerate(response_data["vulns"]):
             self.assert_vuln_response(vuln, vuln_ids[i], self.create_vuln_request(i))
 
     # Test sort_key
@@ -1310,7 +1325,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [3.0, 5.0, 8.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [3.0, 5.0, 8.0]
 
     # A2
     def test_it_should_sort_by_cvss_v3_score_with_null(self, testdb: Session):
@@ -1323,7 +1338,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [None, 3.0, 8.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [None, 3.0, 8.0]
 
     # A3
     def test_it_should_sort_by_descending_updated_at_when_cvss_v3_scores_are_equal(
@@ -1337,7 +1352,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["updated_at"] for vuln in response_data] == [
+        assert [vuln["updated_at"] for vuln in response_data["vulns"]] == [
             "2024-01-01T00:00:00",
             "2023-01-01T00:00:00",
         ]
@@ -1356,8 +1371,10 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [None, 5.0, 5.0, 8.0]
-        assert [vuln["updated_at"] for vuln in response_data if vuln["cvss_v3_score"] == 5.0] == [
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [None, 5.0, 5.0, 8.0]
+        assert [
+            vuln["updated_at"] for vuln in response_data["vulns"] if vuln["cvss_v3_score"] == 5.0
+        ] == [
             "2025-01-02T00:00:00",
             "2023-01-01T00:00:00",
         ]
@@ -1374,7 +1391,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [8.0, 5.0, 3.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [8.0, 5.0, 3.0]
 
     # B2
     def test_it_should_sort_by_cvss_v3_score_descending_with_null(self, testdb: Session):
@@ -1387,7 +1404,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [8.0, 5.0, None]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [8.0, 5.0, None]
 
     # B3
     def test_sort_by_cvss_v3_score_descending_updated_at_when_cvss_v3_scores_are_equal(
@@ -1401,7 +1418,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["updated_at"] for vuln in response_data] == [
+        assert [vuln["updated_at"] for vuln in response_data["vulns"]] == [
             "2023-01-01T00:00:00",
             "2022-01-01T00:00:00",
         ]
@@ -1420,8 +1437,10 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=cvss_v3_score_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [8.0, 5.0, 5.0, None]
-        assert [vuln["updated_at"] for vuln in response_data if vuln["cvss_v3_score"] == 5.0] == [
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [8.0, 5.0, 5.0, None]
+        assert [
+            vuln["updated_at"] for vuln in response_data["vulns"] if vuln["cvss_v3_score"] == 5.0
+        ] == [
             "2025-01-02T00:00:00",
             "2023-01-01T00:00:00",
         ]
@@ -1438,7 +1457,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["updated_at"] for vuln in response_data] == [
+        assert [vuln["updated_at"] for vuln in response_data["vulns"]] == [
             "2023-01-01T00:00:00",
             "2024-01-01T00:00:00",
             "2025-01-01T00:00:00",
@@ -1457,7 +1476,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [8.0, 5.0, 3.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [8.0, 5.0, 3.0]
 
     # C3
     def test_it_should_sort_by_ascending_updated_at_and_by_descending_cvss_v3_score(
@@ -1472,7 +1491,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [3.0, 8.0, 5.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [3.0, 8.0, 5.0]
 
     # D: sortkey is UPDATED_AT_DESC
     # D1
@@ -1486,7 +1505,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["updated_at"] for vuln in response_data] == [
+        assert [vuln["updated_at"] for vuln in response_data["vulns"]] == [
             "2023-01-01T00:00:00",
             "2022-01-01T00:00:00",
             "2021-01-01T00:00:00",
@@ -1505,7 +1524,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [8.0, 5.0, 3.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [8.0, 5.0, 3.0]
 
     # D3
     def test_it_should_sort_by_descending_updated_at_and_by_descending_cvss_v3_score(
@@ -1520,7 +1539,7 @@ class TestGetVulns:
         response = client.get("/vulns?sort_key=updated_at_desc", headers=self.headers_user)
         assert response.status_code == 200
         response_data = response.json()
-        assert [vuln["cvss_v3_score"] for vuln in response_data] == [5.0, 8.0, 3.0]
+        assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [5.0, 8.0, 3.0]
 
 
 class TestDeleteVuln:

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -753,6 +753,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == number_of_vulns
+        assert response_data["num_vulns"] == number_of_vulns
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -796,6 +797,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         self.assert_vuln_response(
             response_data["vulns"][0], vuln_ids[0], self.create_vuln_request(0)
@@ -854,6 +856,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == number_of_vulns
+        assert response_data["num_vulns"] == number_of_vulns
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -943,6 +946,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
         self.assert_vuln_response(response_data["vulns"][0], vuln_id_sbom, vuln_request_sbom)
 
     def test_it_should_filter_by_cve_ids(self, testdb: Session):
@@ -968,6 +972,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1026,6 +1031,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 2
+        assert response_data["num_vulns"] == 2
         # Filter vuln_ids based on the created_after condition
         filtered_vuln_ids = [
             vuln_ids[i] for i in range(number_of_vulns) if created_at_list[i] > created_after
@@ -1048,6 +1054,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1060,6 +1067,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 2
+        assert response_data["num_vulns"] == 2
 
         # Filter vuln_ids based on the created_after condition
         filtered_vuln_ids = [
@@ -1082,6 +1090,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1117,6 +1126,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1139,6 +1149,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == number_of_vulns
+        assert response_data["num_vulns"] == number_of_vulns
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1171,6 +1182,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1200,6 +1212,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1287,6 +1300,7 @@ class TestGetVulns:
         assert response.status_code == 200
         response_data = response.json()
         assert len(response_data["vulns"]) == 1
+        assert response_data["num_vulns"] == 1
 
         # Check the details of each vuln
         for i, vuln in enumerate(response_data["vulns"]):
@@ -1553,8 +1567,8 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert response_data["num_vulns"] == number_of_vulns
         assert len(response_data["vulns"]) == 2
+        assert response_data["num_vulns"] == number_of_vulns
         assert response_data["num_vulns"] > len(response_data["vulns"])
 
 

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -1540,6 +1540,23 @@ class TestGetVulns:
         response_data = response.json()
         assert [vuln["cvss_v3_score"] for vuln in response_data["vulns"]] == [5.0, 8.0, 3.0]
 
+    def test_num_vulns_and_len_vulns_differ_when_limit_is_less_than_total(self, testdb: Session):
+        # Given
+        number_of_vulns = 5
+        for i in range(number_of_vulns):
+            vuln_request = self.create_vuln_request(i)
+            client.put(f"/vulns/{uuid4()}", headers=self.headers_user, json=vuln_request)
+
+        # When: Get with limit=2
+        response = client.get("/vulns?offset=0&limit=2", headers=self.headers_user)
+
+        # Then
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["num_vulns"] == number_of_vulns
+        assert len(response_data["vulns"]) == 2
+        assert response_data["num_vulns"] > len(response_data["vulns"])
+
 
 class TestDeleteVuln:
     @pytest.fixture(scope="function", autouse=True)

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -1286,7 +1286,6 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        print(response_data)
         assert len(response_data["vulns"]) == 1
 
         # Check the details of each vuln


### PR DESCRIPTION
## PR の目的
- Get /vulns APIのフィルタ後のレスポンスに、ページング前の件数を追加
- 上記のために以下のファイルを修正
   - api/app/command.py
      - get_vulns関数の戻り値の型の修正
         - Sequence[models.Vuln] → dict
      - 指定された検索条件に合致する脆弱性の総数の取得処理の追加
         - ベースとなるカウントクエリの作成
         - Affect・PackageテーブルとのJOIN
         - Dependencyテーブルへの条件付きJOIN
         - フィルタ適用
         - クエリの実行及び件数取得
   - api/app/routers/vulns.py
      - 上記のcommand.pyの修正に合わせて、件数も取得できるように型などを修正
   - api/app/schemas.py
      - 上記のvulns.pyの戻り値に使用するためにVulnsListResponseを定義
   - api/app/tests/requests/test_vulns.py
      - 上記３ファイルの修正に合わせて、テストが通るように修正

## 経緯・意図・意思決定
- 従来[Get /topics/search] APIはフィルタ後、ページング前の件数を返していたが、改修後の[Get /vulns]では返していないため
   - UIでページングする際に必要なため
