### PR TITLE
Topic/delete package manager from status page

### DIFF
--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -25,7 +25,7 @@ def get_vuln_ids_summary_by_service_id_and_package_id(
     vuln_ids_sorted = sorted(
         vuln_ids_dict.values(),
         key=lambda x: (
-            x["highest_ssvc_priority"],
+            x["highest_ssvc_priority"].value,
             -(_dt.timestamp() if (_dt := x["vuln_updated_at"]) else 0),
         ),
     )

--- a/web/src/pages/Status/PTeamStatusCard.jsx
+++ b/web/src/pages/Status/PTeamStatusCard.jsx
@@ -146,8 +146,6 @@ export function PTeamStatusCard(props) {
           {packageInfo.package_name}
           {":"}
           {packageInfo.ecosystem}
-          {":"}
-          {packageInfo.package_manager}
         </Typography>
         {serviceIds &&
           pteam.services
@@ -192,7 +190,6 @@ PTeamStatusCard.propTypes = {
     updated_at: PropTypes.string,
     status_count: PropTypes.object,
     ecosystem: PropTypes.string,
-    package_manager: PropTypes.string,
   }).isRequired,
   serviceIds: PropTypes.array,
 };

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -253,7 +253,7 @@ export function Status() {
             ssvcPriorityProps[packageInfo.ssvc_priority || "defer"].displayName,
           )) &&
       (!searchWord?.length > 0 ||
-        (packageInfo.package_name + ":" + packageInfo.ecosystem + ":" + packageInfo.package_manager)
+        (packageInfo.package_name + ":" + packageInfo.ecosystem)
           .toLowerCase()
           .includes(searchWord)),
   );


### PR DESCRIPTION
## PR の目的
- StatusページのPackage情報からpackage_managerを削除

## 経緯・意図・意思決定
- package_name、ecosystemが同じでpackage_managerだけが異なる場合は同じ行に集約するという処理を別タスクで実装するため
