### PR TITLE
bugfix/delete useGetVulnActionsQuery

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -449,20 +449,7 @@ export const tcApi = createApi({
       ],
     }),
 
-    /* Vuln Action */
-    getVulnActions: builder.query({
-      query: (vulnId) => ({
-        url: `vulns/${vulnId}/actions`,
-        method: "GET",
-      }),
-      providesTags: (result, error, arg) => [
-        ...(result?.reduce(
-          (ret, action) => [...ret, { type: "VulnAction", id: action.action_id }],
-          [],
-        ) ?? []),
-        { type: "VulnAction", id: "ALL" },
-      ],
-    }),
+    /* Topic Action */
     getTopicActions: builder.query({
       query: (topicId) => ({
         url: `topics/${topicId}/actions/user/me`,
@@ -597,7 +584,6 @@ export const {
   useGetVulnActionsQuery,
   useGetTopicActionsQuery,
   useGetUserMeQuery,
-  useGetVulnActionsQuery,
   useGetVulnsQuery,
   useTryLoginMutation,
   useCreateUserMutation,


### PR DESCRIPTION
## PR の目的
- web/src/services/tcApi.jsにgetVulnActionsが2つあったため片方を削除しました。
