### PR TITLE
bugfix/delete useGetTicketQuery

### DIFF
--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -586,7 +586,6 @@ export const {
   useGetThreatQuery,
   useUpdateThreatMutation,
   useGetTicketsQuery,
-  useGetTicketQuery,
   useUpdateTicketSafetyImpactMutation,
   useUpdateTicketStatusMutation,
   useGetVulnQuery,


### PR DESCRIPTION
## PR の目的
- web/src/services/tcApi.jsに使用していないuseGetTicketQueryがあったため削除しました


