### PR TITLE
Bugfix/fix create action log

### DIFF
--- a/web/src/pages/Package/TopicTables/AssigneesSelector.jsx
+++ b/web/src/pages/Package/TopicTables/AssigneesSelector.jsx
@@ -25,7 +25,7 @@ export function AssigneesSelector(props) {
       .map((member) => member.user_id);
     if (setEquals(new Set(newAssigneeIds), new Set(currentAssigneeIds))) return; // not modified
 
-    await updateTicketStatus({ pteamId, serviceId, ticketId, data: { assignees: newAssigneeIds } })
+    await updateTicketStatus({ pteamId, ticketId, data: { assignees: newAssigneeIds } })
       .unwrap()
       .then(() => {
         enqueueSnackbar("Change assignees succeeded", { variant: "success" });

--- a/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
+++ b/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
@@ -89,7 +89,7 @@ export function ReportCompletedActions(props) {
       })
     )
       .then(
-        async (actionLogs) => 
+        async (actionLogs) =>
           await updateTicketStatus({
             pteamId,
             ticketId,

--- a/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
+++ b/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
@@ -66,10 +66,15 @@ export function ReportCompletedActions(props) {
 
   const handleAction = async () =>
     await Promise.all(
-      selectedAction.map(
-        async (actionId) =>
-          await createActionLog({
-            action_id: actionId,
+      selectedAction.map(async (actionId) => {
+          const action = actions.find((action) => action.action_id === actionId);
+          const isInActionText = actionText.action_id === actionId;
+          
+          return await createActionLog({
+            action_id: isInActionText ? null : action.action_id,
+            action: action.action,
+            action_type: action.action_type,
+            recommended: action.recommended,
             pteam_id: pteamId,
             service_id: serviceId,
             ticket_id: ticketId,
@@ -80,14 +85,13 @@ export function ReportCompletedActions(props) {
             .then((data) => {
               enqueueSnackbar("Action succeeded", { variant: "success" });
               return data;
-            }),
-      ),
+            })
+      })
     )
       .then(
-        async (actionLogs) =>
+        async (actionLogs) => 
           await updateTicketStatus({
             pteamId,
-            serviceId,
             ticketId,
             data: {
               topic_status: "completed",
@@ -112,13 +116,13 @@ export function ReportCompletedActions(props) {
     onSetShow(false);
   };
 
-  const handleSelectAction = async (action) => {
-    if (!action) {
+  const handleSelectAction = async (actionId) => {
+    if (!actionId) {
       if (selectedAction.length) setSelectedAction([]);
       else setSelectedAction(vulnActions.map((action) => action.action_id));
     } else {
-      if (selectedAction.includes(action)) selectedAction.splice(selectedAction.indexOf(action), 1);
-      else selectedAction.push(action);
+      if (selectedAction.includes(actionId)) selectedAction.splice(selectedAction.indexOf(actionId), 1);
+      else selectedAction.push(actionId);
       setSelectedAction([...selectedAction]);
     }
   };

--- a/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
+++ b/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
@@ -68,6 +68,11 @@ export function ReportCompletedActions(props) {
     await Promise.all(
       selectedAction.map(async (actionId) => {
           const action = actions.find((action) => action.action_id === actionId);
+          if (!action) {
+            console.error(`Action with ID ${actionId} not found in actions array.`);
+            return;
+          }
+
           const isInActionText = actionText.action_id === actionId;
           
           return await createActionLog({

--- a/web/src/pages/Package/TopicTables/VulnStatusSelector.jsx
+++ b/web/src/pages/Package/TopicTables/VulnStatusSelector.jsx
@@ -75,7 +75,7 @@ export function VulnStatusSelector(props) {
     } else if (selectedStatus === "acknowledged") {
       requestParams["scheduled_at"] = null;
     }
-    await updateTicketStatus({ pteamId, serviceId, ticketId, data: requestParams })
+    await updateTicketStatus({ pteamId, ticketId, data: requestParams })
       .unwrap()
       .then(() => {
         enqueueSnackbar("Change ticket status succeeded", { variant: "success" });


### PR DESCRIPTION
## PR の目的
- web/src/pages/Package/TopicTables/ReportCompletedActions.jsxでcreateActionLogとの繋ぎこみができていなかったので行いました。

## 経緯・意図・意思決定
- web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
  - createActionLogの引数にaction, action_type, recommendedが必要になったため追加しました
  - actionTextにあるaction_idはUI上で擬似的に作成したaciont_idのため、リクエストに入れるとエラーが出ます。そのためactionTextにあるaction_idと合致する場合、nullを設定するようにしています。
  - handleSelectActionの引数をactionからactionIdに変更しました
- web/src/pages/Package/TopicTables/AssigneesSelector.jsx
  - updateTicketStatusにおいてserviceIdがいらないため、削除しました
- web/src/pages/Package/TopicTables/VulnStatusSelector.jsx
  - updateTicketStatusにおいてserviceIdがいらないため、削除しました