### PR TITLE
rename topic status type

### DIFF
--- a/api/app/alembic/versions/2c762d1af82e_vuln_status_type.py
+++ b/api/app/alembic/versions/2c762d1af82e_vuln_status_type.py
@@ -1,0 +1,64 @@
+"""vuln-status-type
+
+Revision ID: 2c762d1af82e
+Revises: 62a9068190ec
+Create Date: 2025-05-26 00:49:22.652455
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "2c762d1af82e"
+down_revision = "62a9068190ec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    vuln_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="vulnstatustype"
+    )
+    vuln_status_type.create(connection)
+    op.add_column(
+        "ticketstatus",
+        sa.Column(
+            "vuln_status",
+            vuln_status_type,
+            server_default="alerted",
+            nullable=False,
+        ),
+    )
+    op.alter_column("ticketstatus", "vuln_status", server_default=None, nullable=False)
+    op.drop_column("ticketstatus", "topic_status")
+    topic_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="topicstatustype"
+    )
+    topic_status_type.drop(op.get_bind())
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    topic_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="topicstatustype"
+    )
+    topic_status_type.create(connection)
+    op.add_column(
+        "ticketstatus",
+        sa.Column(
+            "topic_status",
+            topic_status_type,
+            autoincrement=False,
+            server_default="alerted",
+            nullable=False,
+        ),
+    )
+    op.alter_column("ticketstatus", "topic_status", server_default=None, nullable=False)
+    op.drop_column("ticketstatus", "vuln_status")
+    vuln_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="vulnstatustype"
+    )
+    vuln_status_type.drop(op.get_bind())

--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -44,7 +44,7 @@ def _update_vuln_ids_from_dependencies(
     related_ticket_status: str | None,
     vuln_ids_dict: dict,
 ):
-    _completed = models.TopicStatusType.completed
+    _completed = models.VulnStatusType.completed
 
     for dependency in service.dependencies:
         if package_id and dependency.package_version.package_id != str(package_id):
@@ -52,14 +52,11 @@ def _update_vuln_ids_from_dependencies(
         for ticket in dependency.tickets:
             ssvc_priority = ticket.ssvc_deployer_priority or models.SSVCDeployerPriorityEnum.DEFER
 
-            if (
-                related_ticket_status == "solved"
-                and ticket.ticket_status.topic_status != _completed
-            ):
+            if related_ticket_status == "solved" and ticket.ticket_status.vuln_status != _completed:
                 continue
             elif (
                 related_ticket_status == "unsolved"
-                and ticket.ticket_status.topic_status == _completed
+                and ticket.ticket_status.vuln_status == _completed
             ):
                 continue
 
@@ -118,7 +115,7 @@ def _update_ticket_counts_from_dependencies(
     related_ticket_status: str | None,
     ticket_counts_dict: dict,
 ):
-    _completed = models.TopicStatusType.completed
+    _completed = models.VulnStatusType.completed
 
     for dependency in service.dependencies:
         if package_id and dependency.package_version.package_id != str(package_id):
@@ -126,14 +123,11 @@ def _update_ticket_counts_from_dependencies(
         for ticket in dependency.tickets:
             ssvc_priority = ticket.ssvc_deployer_priority or models.SSVCDeployerPriorityEnum.DEFER
 
-            if (
-                related_ticket_status == "solved"
-                and ticket.ticket_status.topic_status != _completed
-            ):
+            if related_ticket_status == "solved" and ticket.ticket_status.vuln_status != _completed:
                 continue
             elif (
                 related_ticket_status == "unsolved"
-                and ticket.ticket_status.topic_status == _completed
+                and ticket.ticket_status.vuln_status == _completed
             ):
                 continue
 

--- a/api/app/business/ticket_business.py
+++ b/api/app/business/ticket_business.py
@@ -44,7 +44,7 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     if ticket.ssvc_deployer_priority is None:
         return False
 
-    if ticket.ticket_status.topic_status == models.TopicStatusType.completed:
+    if ticket.ticket_status.vuln_status == models.VulnStatusType.completed:
         return False
 
     pteam = ticket.dependency.service.pteam
@@ -73,7 +73,7 @@ def create_ticket_internal(
         status_id=None,
         ticket_id=ticket.ticket_id,
         user_id=None,
-        topic_status=models.TopicStatusType.alerted,
+        vuln_status=models.VulnStatusType.alerted,
         note=None,
         logging_ids=[],
         assignees=[],

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -376,7 +376,7 @@ def get_packages_summary(
             models.TicketStatus,
             and_(
                 models.TicketStatus.ticket_id == models.Ticket.ticket_id,
-                models.TicketStatus.topic_status != models.TopicStatusType.completed,
+                models.TicketStatus.vuln_status != models.VulnStatusType.completed,
             ),
         )
         .join(models.Threat)
@@ -430,8 +430,8 @@ def get_packages_summary(
     count_status_stmt = (
         select(
             models.Package.package_id,
-            models.TicketStatus.topic_status,
-            func.count(models.TicketStatus.topic_status).label("num_status"),
+            models.TicketStatus.vuln_status,
+            func.count(models.TicketStatus.vuln_status).label("num_status"),
         )
         .join(models.PackageVersion)
         .join(models.Dependency)
@@ -446,7 +446,7 @@ def get_packages_summary(
         .join(models.TicketStatus)
         .group_by(
             models.Package.package_id,
-            models.TicketStatus.topic_status,
+            models.TicketStatus.vuln_status,
         )
     )
 
@@ -454,7 +454,7 @@ def get_packages_summary(
         count_status_stmt = count_status_stmt.where(models.Dependency.service_id == str(service_id))
 
     status_count_dict = {
-        (row.package_id, row.topic_status): row.num_status
+        (row.package_id, row.vuln_status): row.num_status
         for row in db.execute(count_status_stmt).all()
     }
     summary = [
@@ -468,7 +468,7 @@ def get_packages_summary(
             "service_ids": row.service_ids,
             "status_count": {
                 status_type.value: status_count_dict.get((row.package_id, status_type.value), 0)
-                for status_type in list(models.TopicStatusType)
+                for status_type in list(models.VulnStatusType)
             },
         }
         for row in db.execute(summarize_stmt).all()

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -53,7 +53,7 @@ class ActionType(str, enum.Enum):
     rejection = "rejection"
 
 
-class TopicStatusType(str, enum.Enum):
+class VulnStatusType(str, enum.Enum):
     alerted = "alerted"
     acknowledged = "acknowledged"
     scheduled = "scheduled"
@@ -387,7 +387,7 @@ class TicketStatus(Base):
     user_id: Mapped[StrUUID | None] = mapped_column(
         ForeignKey("account.user_id", ondelete="SET NULL"), index=True
     )
-    topic_status: Mapped[TopicStatusType]
+    vuln_status: Mapped[VulnStatusType]
     note: Mapped[str | None]
     logging_ids: Mapped[list[StrUUID]] = mapped_column(default=[])
     assignees: Mapped[list[StrUUID]] = mapped_column(default=[])

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -687,7 +687,7 @@ def set_ticket_status(
     Set status of the ticket.
     Current value should be inherited if not specified.
 
-    scheduled_at is necessary to make topic_status "scheduled".
+    scheduled_at is necessary to make vuln_status "scheduled".
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM
@@ -698,10 +698,10 @@ def set_ticket_status(
 
     update_data = data.model_dump(exclude_unset=True)
 
-    if "topic_status" in update_data.keys() and data.topic_status is None:
+    if "vuln_status" in update_data.keys() and data.vuln_status is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot specify None for topic_status",
+            detail="Cannot specify None for vuln_status",
         )
     if "logging_ids" in update_data.keys() and data.logging_ids is None:
         raise HTTPException(
@@ -714,7 +714,7 @@ def set_ticket_status(
             detail="Cannot specify None for assignees",
         )
 
-    if data.topic_status == models.TopicStatusType.alerted:
+    if data.vuln_status == models.VulnStatusType.alerted:
         # user cannot set alerted
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wrong topic status")
 
@@ -722,12 +722,12 @@ def set_ticket_status(
     if data.scheduled_at:
         data_scheduled_at = data.scheduled_at.replace(tzinfo=None)
 
-    if data.topic_status == models.TopicStatusType.scheduled or (
-        "topic_status" not in update_data.keys()
-        and ticket.ticket_status.topic_status == models.TopicStatusType.scheduled
+    if data.vuln_status == models.VulnStatusType.scheduled or (
+        "vuln_status" not in update_data.keys()
+        and ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled
     ):
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.topic_status != models.TopicStatusType.scheduled:
+            if ticket.ticket_status.vuln_status != models.VulnStatusType.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="If status is scheduled, specify schduled_at",
@@ -745,7 +745,7 @@ def set_ticket_status(
                 )
     else:
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.topic_status == models.TopicStatusType.scheduled:
+            if ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
@@ -788,11 +788,11 @@ def set_ticket_status(
         ticket.ticket_status.assignees = list(map(str, data.assignees))
     elif ticket.ticket_status.assignees == []:
         ticket.ticket_status.assignees = [UUID(current_user.user_id)]
-    if "topic_status" in update_data.keys():
-        ticket.ticket_status.topic_status = data.topic_status
-    elif ticket.ticket_status.topic_status == models.TopicStatusType.alerted:
+    if "vuln_status" in update_data.keys():
+        ticket.ticket_status.vuln_status = data.vuln_status
+    elif ticket.ticket_status.vuln_status == models.VulnStatusType.alerted:
         # this is the first update
-        ticket.ticket_status.topic_status = models.TopicStatusType.acknowledged
+        ticket.ticket_status.vuln_status = models.VulnStatusType.acknowledged
     if "logging_ids" in update_data.keys() and data.logging_ids is not None:
         ticket.ticket_status.logging_ids = list(map(str, data.logging_ids))
     if "note" in update_data.keys():
@@ -802,7 +802,7 @@ def set_ticket_status(
             ticket.ticket_status.scheduled_at = None
         elif (
             data_scheduled_at > now
-            and ticket.ticket_status.topic_status == models.TopicStatusType.scheduled
+            and ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled
         ):
             ticket.ticket_status.scheduled_at = data.scheduled_at
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -14,7 +14,7 @@ from app.models import (
     SafetyImpactEnum,
     SSVCDeployerPriorityEnum,
     SystemExposureEnum,
-    TopicStatusType,
+    VulnStatusType,
 )
 
 
@@ -298,7 +298,7 @@ class ActionLogRequest(ORMModel):
 
 
 class TicketStatusRequest(ORMModel):
-    topic_status: TopicStatusType | None = None
+    vuln_status: VulnStatusType | None = None
     logging_ids: list[UUID] | None = None
     assignees: list[UUID] | None = None
     note: str | None = None
@@ -308,7 +308,7 @@ class TicketStatusRequest(ORMModel):
 class TicketStatusResponse(ORMModel):
     status_id: UUID
     ticket_id: UUID
-    topic_status: TopicStatusType
+    vuln_status: VulnStatusType
     user_id: UUID | None  # None: auto created when ticket is created
     created_at: datetime
     assignees: list[UUID] = []
@@ -342,7 +342,7 @@ class PTeamPackagesSummary(ORMModel):
         service_ids: list[UUID]
         ssvc_priority: SSVCDeployerPriorityEnum | None
         updated_at: datetime | None
-        status_count: dict[str, int]  # TopicStatusType.value: tickets count
+        status_count: dict[str, int]  # VUlnStatusType.value: tickets count
 
     ssvc_priority_count: dict[SSVCDeployerPriorityEnum, int]  # priority: packages count
     packages: list[PTeamPackageSummary]

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -72,7 +72,7 @@ class TestGetVulnIdsTiedToServicePackage:
             testdb, USER1, PTEAM1, service_name1, VULN1
         )
         json_data = {
-            "topic_status": "acknowledged",
+            "vuln_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -164,7 +164,7 @@ class TestGetVulnIdsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "topic_status": "completed",
+            "vuln_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -210,7 +210,7 @@ class TestGetVulnIdsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "topic_status": "completed",
+            "vuln_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -305,7 +305,7 @@ class TestGetTicketCountsTiedToServicePackage:
             testdb, USER1, PTEAM1, service_name1, VULN1
         )
         json_data = {
-            "topic_status": "acknowledged",
+            "vuln_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -407,7 +407,7 @@ class TestGetTicketCountsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "topic_status": "completed",
+            "vuln_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -458,7 +458,7 @@ class TestGetTicketCountsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "topic_status": "completed",
+            "vuln_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -262,7 +262,7 @@ class TestDeleteUserSideEffects:
 
         # Set ticket status
         status_request1 = {
-            "topic_status": models.TopicStatusType.completed.value,
+            "vuln_status": models.VulnStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -274,7 +274,7 @@ class TestDeleteUserSideEffects:
         )
 
         status_request2 = {
-            "topic_status": models.TopicStatusType.completed.value,
+            "vuln_status": models.VulnStatusType.completed.value,
             "assignees": [str(self.user2.user_id)],
             "logging_ids": [self.actionlog2["logging_id"]],
         }
@@ -436,7 +436,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "topic_status": models.TopicStatusType.completed.value,
+            "vuln_status": models.VulnStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -461,7 +461,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "topic_status": models.TopicStatusType.completed.value,
+            "vuln_status": models.VulnStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }

--- a/api/app/tests/requests/test_pteams.py
+++ b/api/app/tests/requests/test_pteams.py
@@ -1845,7 +1845,7 @@ class TestGetVulnIdsTiedToServicePackage:
         )
 
         json_data = {
-            "topic_status": "acknowledged",
+            "vuln_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -1977,7 +1977,7 @@ class TestGetTicketCountsTiedToServicePackage:
         )
 
         json_data = {
-            "topic_status": "acknowledged",
+            "vuln_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -2306,7 +2306,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                    status_type.value: 0 for status_type in list(models.VulnStatusType)
                 },
             }
         ]
@@ -2350,7 +2350,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                    status_type.value: 0 for status_type in list(models.VulnStatusType)
                 },
             }
         ]
@@ -2399,8 +2399,8 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.TopicStatusType)},
-                    models.TopicStatusType.alerted.value: 1,  # default status is ALERTED
+                    **{status_type.value: 0 for status_type in list(models.VulnStatusType)},
+                    models.VulnStatusType.alerted.value: 1,  # default status is ALERTED
                 },
             }
         ]
@@ -2496,8 +2496,8 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.TopicStatusType)},
-                    models.TopicStatusType.alerted.value: 2,  # default status is ALERTED
+                    **{status_type.value: 0 for status_type in list(models.VulnStatusType)},
+                    models.VulnStatusType.alerted.value: 2,  # default status is ALERTED
                 },
             }
         ]
@@ -2550,7 +2550,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TopicStatusType)
+                    status_type.value: 0 for status_type in list(models.VulnStatusType)
                 },
             }
         ]
@@ -2667,7 +2667,7 @@ class TestTicketStatus:
             expected_status = {
                 "status_id": data["status_id"],  # do not check
                 "ticket_id": str(self.ticket_id1),
-                "topic_status": models.TopicStatusType.alerted.value,
+                "vuln_status": models.VulnStatusType.alerted.value,
                 "user_id": None,
                 "created_at": data["created_at"],  # check later
                 "assignees": [],
@@ -2682,7 +2682,7 @@ class TestTicketStatus:
 
         def test_returns_current_status_if_status_created(self, actionable_topic1):
             status_request = {
-                "topic_status": models.TopicStatusType.scheduled.value,
+                "vuln_status": models.VulnStatusType.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10",
@@ -2715,12 +2715,12 @@ class TestTicketStatus:
 
     class TestSet(Common):
 
-        def common_setup_for_set_ticket_status(self, topic_status, need_scheduled_at, scheduled_at):
+        def common_setup_for_set_ticket_status(self, vuln_status, need_scheduled_at, scheduled_at):
             status_request = {
                 "assignees": [str(self.user2.user_id)],
             }
-            if topic_status is not None:
-                status_request["topic_status"] = topic_status
+            if vuln_status is not None:
+                status_request["vuln_status"] = vuln_status
             if need_scheduled_at:
                 status_request["scheduled_at"] = scheduled_at
             url = f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket_id1}/ticketstatuses"
@@ -2735,7 +2735,7 @@ class TestTicketStatus:
 
         def test_set_requested_status(self, actionable_topic1):
             status_request = {
-                "topic_status": models.TopicStatusType.scheduled.value,
+                "vuln_status": models.VulnStatusType.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10",
@@ -2766,7 +2766,7 @@ class TestTicketStatus:
         @pytest.mark.parametrize(
             "field_name, expected_response_detail",
             [
-                ("topic_status", "Cannot specify None for topic_status"),
+                ("vuln_status", "Cannot specify None for vuln_status"),
                 ("logging_ids", "Cannot specify None for logging_ids"),
                 ("assignees", "Cannot specify None for assignees"),
             ],
@@ -2790,90 +2790,90 @@ class TestTicketStatus:
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "topic_status, scheduled_at, expected_response_detail",
+            "vuln_status, scheduled_at, expected_response_detail",
             [
-                (models.TopicStatusType.alerted.value, None, "Wrong topic status"),
+                (models.VulnStatusType.alerted.value, None, "Wrong topic status"),
                 (
-                    models.TopicStatusType.alerted.value,
+                    models.VulnStatusType.alerted.value,
                     None,
                     "Wrong topic status",
                 ),
                 (
-                    models.TopicStatusType.alerted.value,
+                    models.VulnStatusType.alerted.value,
                     "2000-01-01T00:00:00",
                     "Wrong topic status",
                 ),
                 (
-                    models.TopicStatusType.alerted.value,
+                    models.VulnStatusType.alerted.value,
                     "2345-06-07T08:09:10",
                     "Wrong topic status",
                 ),
             ],
         )
-        def test_it_should_return_400_when_topic_status_is_alerted(
+        def test_it_should_return_400_when_vuln_status_is_alerted(
             self,
             actionable_topic1,
-            topic_status,
+            vuln_status,
             scheduled_at,
             expected_response_detail,
         ):
-            response = self.common_setup_for_set_ticket_status(topic_status, True, scheduled_at)
+            response = self.common_setup_for_set_ticket_status(vuln_status, True, scheduled_at)
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "topic_status, scheduled_at, expected_response_detail",
+            "vuln_status, scheduled_at, expected_response_detail",
             [
                 (
-                    models.TopicStatusType.acknowledged.value,
+                    models.VulnStatusType.acknowledged.value,
                     "2000-01-01T00:00:00",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TopicStatusType.acknowledged.value,
+                    models.VulnStatusType.acknowledged.value,
                     "2345-06-07T08:09:10",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TopicStatusType.completed.value,
+                    models.VulnStatusType.completed.value,
                     "2000-01-01T00:00:00",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TopicStatusType.completed.value,
+                    models.VulnStatusType.completed.value,
                     "2345-06-07T08:09:10",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
             ],
         )
-        def test_it_should_return_400_when_topic_status_is_not_scheduled_and_schduled_at_is_time(
+        def test_it_should_return_400_when_vuln_statuss_is_not_scheduled_and_schduled_at_is_time(
             self,
             actionable_topic1,
-            topic_status,
+            vuln_status,
             scheduled_at,
             expected_response_detail,
         ):
-            response = self.common_setup_for_set_ticket_status(topic_status, True, scheduled_at)
+            response = self.common_setup_for_set_ticket_status(vuln_status, True, scheduled_at)
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "topic_status, need_scheduled_at, scheduled_at, expected_response_detail",
+            "vuln_status, need_scheduled_at, scheduled_at, expected_response_detail",
             [
                 (
-                    models.TopicStatusType.scheduled.value,
+                    models.VulnStatusType.scheduled.value,
                     False,
                     None,
                     "If status is scheduled, specify schduled_at",
                 ),
                 (
-                    models.TopicStatusType.scheduled.value,
+                    models.VulnStatusType.scheduled.value,
                     True,
                     None,
                     "If status is scheduled, unable to reset schduled_at",
                 ),
                 (
-                    models.TopicStatusType.scheduled.value,
+                    models.VulnStatusType.scheduled.value,
                     True,
                     "2000-01-01T00:00:00",
                     "If status is scheduled, schduled_at must be a future time",
@@ -2883,64 +2883,64 @@ class TestTicketStatus:
         def test_it_should_return_400_when_schduled_at_is_not_future_time(
             self,
             actionable_topic1,
-            topic_status,
+            vuln_status,
             need_scheduled_at,
             scheduled_at,
             expected_response_detail,
         ):
-            # when topic_status is schduled and schduled at is not future time, return 200.
+            # when vuln_status is schduled and schduled at is not future time, return 200.
 
             response = self.common_setup_for_set_ticket_status(
-                topic_status, need_scheduled_at, scheduled_at
+                vuln_status, need_scheduled_at, scheduled_at
             )
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "topic_status, need_scheduled_at, scheduled_at, expected_response_status_code",
+            "vuln_status, need_scheduled_at, scheduled_at, expected_response_status_code",
             [
-                (models.TopicStatusType.acknowledged.value, False, None, 200),
+                (models.VulnStatusType.acknowledged.value, False, None, 200),
                 (
-                    models.TopicStatusType.acknowledged.value,
+                    models.VulnStatusType.acknowledged.value,
                     True,
                     None,
                     200,
                 ),
-                (models.TopicStatusType.scheduled.value, True, "2345-06-07T08:09:10", 200),
-                (models.TopicStatusType.completed.value, False, None, 200),
-                (models.TopicStatusType.completed.value, True, None, 200),
+                (models.VulnStatusType.scheduled.value, True, "2345-06-07T08:09:10", 200),
+                (models.VulnStatusType.completed.value, False, None, 200),
+                (models.VulnStatusType.completed.value, True, None, 200),
             ],
         )
-        def test_it_should_return_200_when_topic_status_and_schduled_at_have_the_correct_values(
+        def test_it_should_return_200_when_vuln_statuss_and_schduled_at_have_the_correct_values(
             self,
             actionable_topic1,
-            topic_status,
+            vuln_status,
             need_scheduled_at,
             scheduled_at,
             expected_response_status_code,
         ):
             response = self.common_setup_for_set_ticket_status(
-                topic_status, need_scheduled_at, scheduled_at
+                vuln_status, need_scheduled_at, scheduled_at
             )
             assert response.status_code == expected_response_status_code
             set_response = response.json()
             assert set_response["ticket_id"] == self.ticket_id1
-            assert set_response["topic_status"] == topic_status
+            assert set_response["vuln_status"] == vuln_status
             assert set_response["user_id"] == str(self.user1.user_id)
             assert set_response["assignees"] == [str(self.user2.user_id)]
             assert set_response["scheduled_at"] == scheduled_at
 
         @pytest.mark.parametrize(
-            "current_topic_status, current_scheduled_at, expected_response_detail",
+            "current_vuln_status, current_scheduled_at, expected_response_detail",
             [
                 (
-                    models.TopicStatusType.completed.value,
+                    models.VulnStatusType.completed.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
                 ),
                 (
-                    models.TopicStatusType.acknowledged.value,
+                    models.VulnStatusType.acknowledged.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
@@ -2950,29 +2950,29 @@ class TestTicketStatus:
         def test_it_should_return_400_when_previous_status_is_schduled_and_schduled_at_is_reset(
             self,
             actionable_topic1,
-            current_topic_status,
+            current_vuln_status,
             current_scheduled_at,
             expected_response_detail,
         ):
-            # When previou topic_status is schduled and current topic_status is not schduled,
+            # When previou vuln_status is schduled and current vuln_status is not schduled,
             # return 400 if current_scheduled_at does not contain
             # a value to reset None.
 
-            previous_topic_status = models.TopicStatusType.scheduled.value
+            previous_vuln_status = models.VulnStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_topic_status, True, previous_scheduled_at
+                previous_vuln_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_topic_status, False, current_scheduled_at
+                current_vuln_status, False, current_scheduled_at
             )
             assert current_response.status_code == 400
             assert current_response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "current_topic_status, current_scheduled_at, expected_response_detail",
+            "current_vuln_status, current_scheduled_at, expected_response_detail",
             [
                 (
                     None,
@@ -2986,32 +2986,32 @@ class TestTicketStatus:
                 ),
             ],
         )
-        def test_it_should_return_400_when_topic_status_and_scheduled_at_is_not_appropriate(
+        def test_it_should_return_400_when_vuln_status_and_scheduled_at_is_not_appropriate(
             self,
             actionable_topic1,
-            current_topic_status,
+            current_vuln_status,
             current_scheduled_at,
             expected_response_detail,
         ):
-            # When previou topic_status is schduled and current topic_status is None,
+            # When previou vuln_status is schduled and current vuln_status is None,
             # return 400 if current_scheduled_at does not contain
             # future time or None.
 
-            previous_topic_status = models.TopicStatusType.scheduled.value
+            previous_vuln_status = models.VulnStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_topic_status, True, previous_scheduled_at
+                previous_vuln_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_topic_status, True, current_scheduled_at
+                current_vuln_status, True, current_scheduled_at
             )
             assert current_response.status_code == 400
             assert current_response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "current_topic_status, need_scheduled_at, "
+            "current_vuln_status, need_scheduled_at, "
             + "current_scheduled_at, expected_response_status_code",
             [
                 (
@@ -3021,7 +3021,7 @@ class TestTicketStatus:
                     200,
                 ),
                 (
-                    models.TopicStatusType.completed.value,
+                    models.VulnStatusType.completed.value,
                     True,
                     None,
                     200,
@@ -3031,27 +3031,27 @@ class TestTicketStatus:
         def test_it_should_return_200_when_previous_and_current_status_have_the_correct_values(
             self,
             actionable_topic1,
-            current_topic_status,
+            current_vuln_status,
             need_scheduled_at,
             current_scheduled_at,
             expected_response_status_code,
         ):
-            # When previou topic_status is schduled and current topic_status is None,
+            # When previou vuln_status is schduled and current vuln_status is None,
             # return 200 if current_scheduled_at contain None.
 
-            # When previou topic_status is schduled and current topic_status is completed,
+            # When previou vuln_status is schduled and current vuln_status is completed,
             # return 200 if current_scheduled_at contain
             # a value to reset None.
 
-            previous_topic_status = models.TopicStatusType.scheduled.value
+            previous_vuln_status = models.VulnStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_topic_status, True, previous_scheduled_at
+                previous_vuln_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_topic_status, need_scheduled_at, current_scheduled_at
+                current_vuln_status, need_scheduled_at, current_scheduled_at
             )
             assert current_response.status_code == expected_response_status_code
 
@@ -3060,10 +3060,10 @@ class TestTicketStatus:
             assert set_response["user_id"] == str(self.user1.user_id)
             assert set_response["assignees"] == [str(self.user2.user_id)]
 
-            _current_topic_status = current_topic_status
-            if current_topic_status is None:
-                _current_topic_status = models.TopicStatusType.scheduled.value
-            assert set_response["topic_status"] == _current_topic_status
+            _current_vuln_status = current_vuln_status
+            if current_vuln_status is None:
+                _current_vuln_status = models.VulnStatusType.scheduled.value
+            assert set_response["vuln_status"] == _current_vuln_status
 
             if need_scheduled_at:
                 _scheduled_at = current_scheduled_at
@@ -3075,7 +3075,7 @@ class TestTicketStatus:
             self, actionable_topic1
         ):
             status_request = {
-                "topic_status": models.TopicStatusType.completed.value,
+                "vuln_status": models.VulnStatusType.completed.value,
                 "note": "assign None",
             }
             url = f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket_id1}/ticketstatuses"
@@ -3185,7 +3185,7 @@ class TestGetTickets:
                 "ticket_status": {
                     "status_id": db_status1.status_id,  # do not check
                     "ticket_id": str(db_ticket1.ticket_id),
-                    "topic_status": models.TopicStatusType.alerted.value,
+                    "vuln_status": models.VulnStatusType.alerted.value,
                     "user_id": None,
                     "created_at": datetime.isoformat(db_status1.created_at),  # check later
                     "assignees": [],
@@ -4161,7 +4161,7 @@ class TestUpdatePTeamService:
             )
             assert response_ticket.status_code == 200
             data = response_ticket.json()
-            request_ticket_status = {"topic_status": models.TopicStatusType.completed.value}
+            request_ticket_status = {"vuln_status": models.VulnStatusType.completed.value}
             response_ticket_status = client.put(
                 f"/pteams/{self.pteam0.pteam_id}/tickets/{data[0]['ticket_id']}/ticketstatuses",
                 headers=_headers,
@@ -4436,12 +4436,12 @@ class TestPutTicket:
         assert data["vuln_id"] == str(self.vuln1.vuln_id)
         assert data["dependency_id"] == str(self.dependency1.dependency_id)
         assert data["created_at"] == self.ticket1.created_at.isoformat()
-        assert data["ssvc_deployer_priority"] == models.TopicStatusType.scheduled.value
+        assert data["ssvc_deployer_priority"] == models.VulnStatusType.scheduled.value
         assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
         assert data["reason_safety_impact"] == request["reason_safety_impact"]
         assert data["ticket_status"]["status_id"] == self.ticket_status1.status_id
         assert data["ticket_status"]["ticket_id"] == str(self.ticket1.ticket_id)
-        assert data["ticket_status"]["topic_status"] == models.TopicStatusType.alerted.value
+        assert data["ticket_status"]["vuln_status"] == models.VulnStatusType.alerted.value
         assert data["ticket_status"]["user_id"] is None
         assert data["ticket_status"]["created_at"] == self.ticket_status1.created_at.isoformat()
         assert data["ticket_status"]["assignees"] == []
@@ -4728,7 +4728,7 @@ class TestPutTicket:
             .one()
         )
         assert updated_ticket.ssvc_deployer_priority != initial_priority
-        assert updated_ticket.ssvc_deployer_priority == models.TopicStatusType.scheduled
+        assert updated_ticket.ssvc_deployer_priority == models.VulnStatusType.scheduled
 
     def test_it_should_return_422_when_invalid_ticket_safety_impact(self):
         user1_access_token = self._get_access_token(USER1)

--- a/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
+++ b/web/src/pages/Package/TopicTables/ReportCompletedActions.jsx
@@ -67,31 +67,31 @@ export function ReportCompletedActions(props) {
   const handleAction = async () =>
     await Promise.all(
       selectedAction.map(async (actionId) => {
-          const action = actions.find((action) => action.action_id === actionId);
-          if (!action) {
-            console.error(`Action with ID ${actionId} not found in actions array.`);
-            return;
-          }
+        const action = actions.find((action) => action.action_id === actionId);
+        if (!action) {
+          console.error(`Action with ID ${actionId} not found in actions array.`);
+          return;
+        }
 
-          const isInActionText = actionText.action_id === actionId;
-          
-          return await createActionLog({
-            action_id: isInActionText ? null : action.action_id,
-            action: action.action,
-            action_type: action.action_type,
-            recommended: action.recommended,
-            pteam_id: pteamId,
-            service_id: serviceId,
-            ticket_id: ticketId,
-            vuln_id: vulnId,
-            user_id: userMe.user_id,
-          })
-            .unwrap()
-            .then((data) => {
-              enqueueSnackbar("Action succeeded", { variant: "success" });
-              return data;
-            })
-      })
+        const isInActionText = actionText.action_id === actionId;
+
+        return await createActionLog({
+          action_id: isInActionText ? null : action.action_id,
+          action: action.action,
+          action_type: action.action_type,
+          recommended: action.recommended,
+          pteam_id: pteamId,
+          service_id: serviceId,
+          ticket_id: ticketId,
+          vuln_id: vulnId,
+          user_id: userMe.user_id,
+        })
+          .unwrap()
+          .then((data) => {
+            enqueueSnackbar("Action succeeded", { variant: "success" });
+            return data;
+          });
+      }),
     )
       .then(
         async (actionLogs) =>
@@ -99,7 +99,7 @@ export function ReportCompletedActions(props) {
             pteamId,
             ticketId,
             data: {
-              topic_status: "completed",
+              vuln_status: "completed",
               logging_ids: actionLogs.map((log) => log.logging_id),
               note: note.trim() || null,
               scheduled_at: null, // clear scheduled date
@@ -126,7 +126,8 @@ export function ReportCompletedActions(props) {
       if (selectedAction.length) setSelectedAction([]);
       else setSelectedAction(vulnActions.map((action) => action.action_id));
     } else {
-      if (selectedAction.includes(actionId)) selectedAction.splice(selectedAction.indexOf(actionId), 1);
+      if (selectedAction.includes(actionId))
+        selectedAction.splice(selectedAction.indexOf(actionId), 1);
       else selectedAction.push(actionId);
       setSelectedAction([...selectedAction]);
     }

--- a/web/src/pages/Package/TopicTables/TicketTableRow.jsx
+++ b/web/src/pages/Package/TopicTables/TicketTableRow.jsx
@@ -54,7 +54,7 @@ export function TicketTableRow(props) {
             actionText={actionText}
             vulnActions={vulnActions}
           />
-          {(ticket.ticket_status.topic_status ?? "alerted") === "alerted" && (
+          {(ticket.ticket_status.vuln_status ?? "alerted") === "alerted" && (
             <WarningTooltip message="No one has acknowledged this vuln" />
           )}
         </Box>

--- a/web/src/pages/Package/TopicTables/VulnStatusSelector.jsx
+++ b/web/src/pages/Package/TopicTables/VulnStatusSelector.jsx
@@ -25,7 +25,7 @@ import { useRef, useState } from "react";
 
 import dialogStyle from "../../../cssModule/dialog.module.css";
 import { useUpdateTicketStatusMutation } from "../../../services/tcApi";
-import { topicStatusProps } from "../../../utils/const";
+import { vulnStatusProps } from "../../../utils/const";
 import { errorToString } from "../../../utils/func";
 
 import { ReportCompletedActions } from "./ReportCompletedActions";
@@ -57,18 +57,18 @@ export function VulnStatusSelector(props) {
     {
       display: "Acknowledge",
       rawStatus: "acknowledged",
-      disabled: currentStatus.topic_status === "acknowledged",
+      disabled: currentStatus.vuln_status === "acknowledged",
     },
     { display: "Schedule", rawStatus: "scheduled", disabled: false },
     {
       display: "Complete",
       rawStatus: "completed",
-      disabled: currentStatus.topic_status === "completed",
+      disabled: currentStatus.vuln_status === "completed",
     },
   ];
 
   const modifyTicketStatus = async (selectedStatus) => {
-    let requestParams = { topic_status: selectedStatus };
+    let requestParams = { vuln_status: selectedStatus };
     if (selectedStatus === "scheduled") {
       if (!schedule) return;
       requestParams["scheduled_at"] = schedule.toISOString();
@@ -133,7 +133,7 @@ export function VulnStatusSelector(props) {
       <Button
         endIcon={<ArrowDropDownIcon />}
         sx={{
-          ...topicStatusProps[currentStatus.topic_status].buttonStyle,
+          ...vulnStatusProps[currentStatus.vuln_status].buttonStyle,
           fontSize: 14,
           padding: "1px 3px",
           minHeight: "25px",
@@ -151,7 +151,7 @@ export function VulnStatusSelector(props) {
         onClick={() => setOpen(!open)}
         ref={anchorRef}
       >
-        {topicStatusProps[currentStatus.topic_status].chipLabelCapitalized}
+        {vulnStatusProps[currentStatus.vuln_status].chipLabelCapitalized}
       </Button>
       <Popper
         open={open}
@@ -174,7 +174,7 @@ export function VulnStatusSelector(props) {
                   {selectableItems.map((item) => (
                     <MenuItem
                       key={item.rawStatus}
-                      selected={currentStatus.topic_status === item.rawStatus}
+                      selected={currentStatus.vuln_status === item.rawStatus}
                       disabled={item.disabled}
                       onClick={(event) => handleUpdateStatus(event, item)}
                       dense={true}

--- a/web/src/pages/Status/PTeamStatusCard.jsx
+++ b/web/src/pages/Status/PTeamStatusCard.jsx
@@ -4,12 +4,12 @@ import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 
 import { SSVCPriorityStatusChip } from "../../components/SSVCPriorityStatusChip";
-import { topicStatusProps, sortedTopicStatus } from "../../utils/const";
+import { vulnStatusProps, sortedVulnStatus } from "../../utils/const";
 import { calcTimestampDiff, compareSSVCPriority } from "../../utils/func";
 
 function LineWithTooltip(props) {
-  const { topicStatus, ratio, num } = props;
-  const constProp = topicStatusProps[topicStatus];
+  const { vulnStatus, ratio, num } = props;
+  const constProp = vulnStatusProps[vulnStatus];
 
   const tipAreaHeight = 15;
   const lineHeight = 5;
@@ -49,7 +49,7 @@ function LineWithTooltip(props) {
 }
 
 LineWithTooltip.propTypes = {
-  topicStatus: PropTypes.string,
+  vulnStatus: PropTypes.string,
   ratio: PropTypes.number,
   num: PropTypes.number,
 };
@@ -89,7 +89,7 @@ function StatusRatioGraph(props) {
       {keys.map((key) => (
         <LineWithTooltip
           key={key}
-          topicStatus={key}
+          vulnStatus={key}
           ratio={ratios[key] ?? 0}
           num={counts[key] ?? 0}
         />
@@ -111,7 +111,7 @@ export function PTeamStatusCard(props) {
     displaySSVCPriority = "safe"; // solved all and at least 1 tickets
   } else if (
     !packageInfo.ssvc_priority &&
-    sortedTopicStatus.every((topicStatus) => packageInfo.status_count[topicStatus] === 0)
+    sortedVulnStatus.every((vulnStatus) => packageInfo.status_count[vulnStatus] === 0)
   ) {
     displaySSVCPriority = "empty";
   } else {

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -231,8 +231,8 @@ export const safetyImpactProps = {
   Negligible: propSafetyImpactNegligible,
 };
 
-export const sortedTopicStatus = ["alerted", "acknowledged", "scheduled", "completed"];
-export const topicStatusProps = {
+export const sortedVulnStatus = ["alerted", "acknowledged", "scheduled", "completed"];
+export const vulnStatusProps = {
   alerted: {
     chipLabel: "alerted",
     chipLabelCapitalized: "Alerted",


### PR DESCRIPTION
## PR の目的

- データモデル変更に伴い、下記をリネーム
  - TicketStatusテーブルのtopic_status列　→　vuln_status
  - 上記vuln_status列の型名　TopicStatusType　→　VulnStatusType
  - schemas.py　TicketStatusRequest、TicketStatusResponseの変数topic_status　→　vuln_status

## 経緯・意図・意思決定
マイグレーションスクリプトにおいて、upgrade時にtopic_stausの値をvuln_statusにセットすることもできるが、やっていない。
理由は、そもそもmainマージ時にはvuln_statusを生成するマイグレーションスクリプトと同時にマージするため、データ変換が必要なのは開発ブランチのみ。


