### PR TITLE
bugfix/get_vulns

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -352,8 +352,8 @@ def get_vulns(
     query = query.order_by(*sortkey2orderby[sort_key])
 
     # Pageination
-    query = query.offset(offset).limit(limit)
-    vulns = db.scalars(query).unique().all()
+    query = query.distinct().offset(offset).limit(limit)
+    vulns = db.scalars(query).all()
 
     result = {
         "num_vulns": num_vulns,


### PR DESCRIPTION
## PR の目的
- command.pyのget_vulnsを修正しました
- 修正前
  - 重複をなくす前にoffset、limitで範囲を絞り、その後unique()を用いて重複をなくしている為、取得する件数がoffset、limitの範囲と合わなくなっている
- 修正後
  - distinct()で重複をなくした後にoffset、limitで範囲を絞り込むように変更

