### PR TITLE
fix delete packageVersion rule

### DIFF
--- a/api/app/business/package_business.py
+++ b/api/app/business/package_business.py
@@ -1,14 +1,18 @@
-from sqlalchemy.orm import Session
 from typing import Sequence
+
+from sqlalchemy.orm import Session
 
 from app import models, persistence, schemas
 
 
 def fix_package(db: Session, package: models.Package) -> None:
+    is_referenced_by_dependency = False
     for package_version in package.package_versions:
-        if len(package_version.dependencies) > 0:
-            return
-    if len(package.affects) > 0:
+        if len(package_version.dependencies) == 0:
+            persistence.delete_package_version(db, package_version)
+        else:
+            is_referenced_by_dependency = True
+    if is_referenced_by_dependency or len(package.affects) > 0:
         return
     persistence.delete_package(db, package)
 

--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -248,6 +248,11 @@ def create_package_version(db: Session, package_version: models.PackageVersion) 
     db.flush()
 
 
+def delete_package_version(db: Session, package_version: models.PackageVersion) -> None:
+    db.delete(package_version)
+    db.flush()
+
+
 ### Threat
 
 

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -202,6 +202,7 @@ def __handle_update_vuln(
                 persistence.create_affect(db, new_affect)
 
     vuln.updated_at = datetime.now()
+    db.flush()
 
     new_threats: list[models.Threat] = threat_business.fix_threat_by_vuln(db, vuln)
     for threat in new_threats:

--- a/api/app/tests/common/ticket_utils.py
+++ b/api/app/tests/common/ticket_utils.py
@@ -54,5 +54,6 @@ def create_ticket(testdb: Session, user: dict, pteam: dict, service_name: str, v
         "package_id": str(package_version.package_id),
         "package_version_id": str(package_version.package_version_id),
         "vuln_id": str(vuln1.vuln_id),
+        "threat_id": str(ticket.threat.threat_id),
         "ticket_id": str(ticket.ticket_id),
     }

--- a/api/app/tests/integrations/business/test_package_business.py
+++ b/api/app/tests/integrations/business/test_package_business.py
@@ -128,7 +128,7 @@ class TestFixPackage:
             is not None
         )
 
-    def test_it_should_not_delete_package_when_has_affect(
+    def test_it_should_not_delete_package_and_delete_package_version_when_has_affect(
         self,
         testdb: Session,
         package1: models.Package,
@@ -159,7 +159,7 @@ class TestFixPackage:
                     models.PackageVersion.package_version_id == package_version.package_version_id
                 )
             ).first()
-            is not None
+            is None
         )
         assert (
             testdb.execute(

--- a/api/app/tests/requests/pteams/test_pteam_services.py
+++ b/api/app/tests/requests/pteams/test_pteam_services.py
@@ -309,9 +309,7 @@ def test_remove_pteam_by_service_id(testdb):
     response2 = upload_pteam_packages(USER1, pteam1.pteam_id, service2, ext_packages)
 
     for extPackage in response2:
-        print("testes extPackage:", extPackage)
         for reference in extPackage.references:
-            print("testes reference:", reference)
             assert reference.service in [service1, service2]
 
     def _get_service_id(testdb, pteam_id, service_name):


### PR DESCRIPTION
## PR の目的

- Package、PackageVersionは、参照されなくなった時点で削除する方針であったが、下記APIで削除が漏れていた
  - Delete /pteams/{pteam_id}
  - Delete /pteams/{pteam_id}/services/{service_id}
- PackageVersionの削除チェックする際、従来は関連するPackageがVulnに参照されていればPackageVersionも削除しない、としていたが、PackageVersionはDependencyのみチェックして参照されなければ削除する方針に変更した
- 本件実装中、package_business.fix_package()の実行前にdb.flush()を実行しないと正常にチェックできない、というバグが見つかった。その周辺確認として、下記にも問題があり、修正した。
  - [Post /pteams/{pteam_id}/upload_sbom_file]上のpackage_business.fix_package()
  - [Post /pteams/{pteam_id}/upload_packages_file]上のpackage_business.fix_package()
  - [Put /vulns/{vuln_id}]上のthreat_business.fix_threat_by_vuln()
