### PR TITLE
fix ecosystem in trivydb2tc

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -290,7 +290,7 @@ def create_os_tag_info(os_repos):
             os_name = family_name
 
         version = raw_version_text.lower()
-    return f"{os_name}-{version}:" if version else f"{os_name}:"
+    return f"{os_name}-{version}" if version else f"{os_name}"
 
 
 def get_package_info(repos):


### PR DESCRIPTION
## PR の目的

- trivydb2tcでOSの脆弱性を取り込んだ際、チケットが生成されていない
  - trivydb2tcでOSの脆弱性を取り込んだ場合、ecosystemの末尾に「:」を付けていたため、これを削除する