### PR TITLE
change display of CVEID when DVEID is none

### DIFF
--- a/web/src/pages/VulnDetail/VulnDetailView.jsx
+++ b/web/src/pages/VulnDetail/VulnDetailView.jsx
@@ -78,7 +78,7 @@ export function VulnDetailView(props) {
               <Typography sx={{ fontWeight: "bold" }}>CVE ID</Typography>
             </Box>
             {vuln.cve_id === null ? (
-              <Typography sx={{ margin: 1 }}>No data</Typography>
+              <Typography sx={{ margin: 1 }}>No Known CVE</Typography>
             ) : (
               <Box sx={{ mt: 1 }}>
                 <Chip

--- a/web/src/pages/VulnManagement/VulnManagementTableRow.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementTableRow.jsx
@@ -50,6 +50,7 @@ export function VulnManagementTableRow(props) {
     vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null ? "N/A" : vuln.cvss_v3_score;
 
   const cvss = cvssConvertToName(cvssScore);
+  const cveId = vuln.cve_id === null ? "No Known CVE" : vuln.cve_id;
 
   return (
     <TableRow
@@ -79,12 +80,7 @@ export function VulnManagementTableRow(props) {
         </Typography>
       </TableCell>
       <TableCell>
-        <Chip
-          key={vuln.cve_id}
-          label={vuln.cve_id}
-          size="small"
-          sx={{ m: 0.5, borderRadius: 0.5 }}
-        />
+        <Chip key={cveId} label={cveId} size="small" sx={{ m: 0.5, borderRadius: 0.5 }} />
       </TableCell>
     </TableRow>
   );

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -71,7 +71,7 @@ export function VulnerabilityView(props) {
           CVE ID
         </Typography>
         {vuln.cve_id === null ? (
-          <Typography sx={{ margin: 1 }}>No data</Typography>
+          <Typography sx={{ margin: 1 }}>No Known CVE</Typography>
         ) : (
           <Box>
             {vuln.cve_id && <Chip label={vuln.cve_id} sx={{ m: 1 }} />}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- vuln一覧ページにおいて、CVE IDが無い場合、CVE ID列に何も表示されなかった。vuln詳細ページ、Vulnerabilityページは「No data」と表示していた。
  - CVE IDが無い場合の表示を「No Known CVE」に統一する

<!-- I want to review in Japanese. -->
