### PR TITLE
resolve error that was occurring in account settings dialog

### DIFF
--- a/web/src/pages/App/UserMenu/AccountSettingsDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog.jsx
@@ -7,7 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import PropTypes from "prop-types";
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 
 import { DeleteAccountDialog } from "./DeleteAccountDialog";
 
@@ -69,12 +69,12 @@ export function AccountSettingsDialog(props) {
                 Team
               </Typography>
               {userMe.pteam_roles.map((pteam_role) => (
-                <React.Fragment key={pteam_role.pteam.pteam_id}>
+                <Fragment key={pteam_role.pteam.pteam_id}>
                   <DialogContentText>{pteam_role.pteam.pteam_name}</DialogContentText>
                   <DialogContentText variant="caption">
                     {pteam_role.pteam.pteam_id}
                   </DialogContentText>
-                </React.Fragment>
+                </Fragment>
               ))}
             </Box>
             <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>


### PR DESCRIPTION
## PR の目的
- web/src/pages/App/UserMenu/AccountSettingsDialog.jsxで下記修正を実施
   - DeleteAccountDialogコンポーネントにuserMeを渡す
   - 該当箇所において`<Fragment>`でkeyを指定

## 経緯・意図・意思決定
- Statusページ表示時、Consoleに下記警告が出るため
- `Warning: Each child in a list should have a unique "key" prop.`
- `Warning: Failed prop type: The prop userMeis marked as required inDeleteAccountDialog, but its value is undefined.`