### PR TITLE
add get assignees ticket

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -48,15 +48,17 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
     service_id: UUID | str | None,
     package_id: UUID | str | None,
     vuln_id: UUID | str | None,
-    user_id: UUID | str | None = None,
+    assigned_user_id: UUID | str | None = None,
 ) -> Sequence[models.Ticket]:
     select_stmt = select(models.Ticket)
-    if user_id:
+    if assigned_user_id:
         select_stmt = select_stmt.join(
             models.TicketStatus,
             and_(
                 models.TicketStatus.ticket_id == models.Ticket.ticket_id,
-                func.array_position(models.TicketStatus.assignees, str(user_id)).isnot(None),
+                func.array_position(models.TicketStatus.assignees, str(assigned_user_id)).isnot(
+                    None
+                ),
             ),
         )
     else:

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -84,7 +84,9 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
 
     if user_id:
         select_stmt = select_stmt.where(
-            models.Ticket.ticket_status.has(models.TicketStatus.assignees.any(str(user_id)))
+            models.Ticket.ticket_status.has(
+                func.array_position(models.TicketStatus.assignees, str(user_id)) != None
+            )
         )
 
     select_stmt = select_stmt.order_by(

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -50,17 +50,25 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
     vuln_id: UUID | str | None,
     user_id: UUID | str | None = None,
 ) -> Sequence[models.Ticket]:
-    select_stmt = (
-        select(models.Ticket)
-        .options(
+    select_stmt = select(models.Ticket)
+    if user_id:
+        select_stmt = select_stmt.join(
+            models.TicketStatus,
+            and_(
+                models.TicketStatus.ticket_id == models.Ticket.ticket_id,
+                func.array_position(models.TicketStatus.assignees, str(user_id)).isnot(None),
+            ),
+        )
+    else:
+        select_stmt = select_stmt.options(
             joinedload(models.Ticket.ticket_status, innerjoin=True).joinedload(
                 models.TicketStatus.action_logs, innerjoin=False
             ),
         )
-        .join(
-            models.Threat,
-            models.Threat.threat_id == models.Ticket.threat_id,
-        )
+
+    select_stmt = select_stmt.join(
+        models.Threat,
+        models.Threat.threat_id == models.Ticket.threat_id,
     )
 
     if vuln_id:
@@ -80,13 +88,6 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
                 models.Dependency.dependency_id == models.Ticket.dependency_id,
                 models.Dependency.service_id == str(service_id),
             ),
-        )
-
-    if user_id:
-        select_stmt = select_stmt.where(
-            models.Ticket.ticket_status.has(
-                func.array_position(models.TicketStatus.assignees, str(user_id)).isnot(None)
-            )
         )
 
     select_stmt = select_stmt.order_by(

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -85,7 +85,7 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
     if user_id:
         select_stmt = select_stmt.where(
             models.Ticket.ticket_status.has(
-                func.array_position(models.TicketStatus.assignees, str(user_id)) != None
+                func.array_position(models.TicketStatus.assignees, str(user_id)).isnot(None)
             )
         )
 

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -48,6 +48,7 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
     service_id: UUID | str | None,
     package_id: UUID | str | None,
     vuln_id: UUID | str | None,
+    user_id: UUID | str | None = None,
 ) -> Sequence[models.Ticket]:
     select_stmt = (
         select(models.Ticket)
@@ -79,6 +80,11 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
                 models.Dependency.dependency_id == models.Ticket.dependency_id,
                 models.Dependency.service_id == str(service_id),
             ),
+        )
+
+    if user_id:
+        select_stmt = select_stmt.where(
+            models.Ticket.ticket_status.has(models.TicketStatus.assignees.any(str(user_id)))
         )
 
     select_stmt = select_stmt.order_by(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -838,7 +838,7 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
     service_id: UUID | None = Query(None),
     package_id: UUID | None = Query(None),
     vuln_id: UUID | None = Query(None),
-    user_id: UUID | None = Query(None),
+    assigned_to_me: bool = Query(False),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -859,9 +859,14 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
     if vuln_id and not (persistence.get_vuln_by_id(db, vuln_id)):
         raise NO_SUCH_VULN
 
-    tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
-        db, service_id, package_id, vuln_id, user_id
-    )
+    if assigned_to_me:
+        tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
+            db, service_id, package_id, vuln_id, current_user.user_id
+        )
+    else:
+        tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
+            db, service_id, package_id, vuln_id
+        )
 
     ret = [
         {

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -838,6 +838,7 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
     service_id: UUID | None = Query(None),
     package_id: UUID | None = Query(None),
     vuln_id: UUID | None = Query(None),
+    user_id: UUID | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -859,7 +860,7 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
         raise NO_SUCH_VULN
 
     tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
-        db, service_id, package_id, vuln_id
+        db, service_id, package_id, vuln_id, user_id
     )
 
     ret = [

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -961,7 +961,7 @@ class TestGetTickets:
 
             return user2
 
-        def test_it_should_return_200_and_tickets_with_user1_in_assignees(self, testdb):
+        def test_it_should_return_200_and_two_tickets_with_user1_in_assignees(self, testdb):
             # Given
             self._setup_tickets_with_two_users_and_assignees(testdb)
 
@@ -981,7 +981,7 @@ class TestGetTickets:
                 ticket_status = ticket["ticket_status"]
                 assert str(self.user1.user_id) in ticket_status["assignees"]
 
-        def test_it_should_return_200_and_tickets_with_user2_in_assignees(self, testdb):
+        def test_it_should_return_200_and_one_ticket_with_user2_in_assignees(self, testdb):
             # Given
             user2 = self._setup_tickets_with_two_users_and_assignees(testdb)
 

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -735,6 +735,18 @@ class TestGetTickets:
 
             ticket_business.fix_ticket_by_threat(testdb, self.threat1)
 
+        @staticmethod
+        def _get_access_token(user: dict) -> str:
+            body = {
+                "username": user["email"],
+                "password": user["pass"],
+            }
+            response = client.post("/auth/token", data=body)
+            if response.status_code != 200:
+                raise HTTPError(response)
+            data = response.json()
+            return data["access_token"]
+
     class TestQueryParameter(Common):
         @pytest.fixture(scope="function", autouse=True)
         def common_setup_for_test_query_parameter(self, testdb):
@@ -875,6 +887,125 @@ class TestGetTickets:
             # When
             response = client.get(
                 f"/pteams/{self.pteam1.pteam_id}/tickets?service_id={service2.service_id}",
+                headers=headers(USER1),
+            )
+
+            # Then
+            assert response.status_code == 200
+            assert response.json() == []
+
+        def _setup_tickets_with_two_users_and_assignees(self, testdb):
+            """Set up test environment with two tickets and two users for assignee tests"""
+            # Create second pteam member
+            user2 = create_user(USER2)
+            invitation1 = invite_to_pteam(USER1, self.pteam1.pteam_id)
+            accept_pteam_invitation(USER2, invitation1.invitation_id)
+
+            # Get first ticket
+            ticket1 = persistence.get_ticket_by_threat_id_and_dependency_id(
+                testdb, self.threat1.threat_id, self.dependency1.dependency_id
+            )
+
+            # Create second ticket with new vulnerability
+            vuln2 = models.Vuln(
+                title="Test Vulnerability2",
+                detail="This is a test vulnerability.",
+                cvss_v3_score=7.5,
+                created_by=self.user1.user_id,
+                created_at="2023-10-01T00:00:00Z",
+                updated_at="2023-10-01T00:00:00Z",
+            )
+            persistence.create_vuln(testdb, vuln2)
+
+            affect2 = models.Affect(
+                vuln_id=vuln2.vuln_id,
+                package_id=self.package1.package_id,
+                affected_versions=["<=1.0.0"],
+                fixed_versions=["2.0.0"],
+            )
+            persistence.create_affect(testdb, affect2)
+
+            threat2 = models.Threat(
+                package_version_id=self.package_version1.package_version_id,
+                vuln_id=vuln2.vuln_id,
+            )
+            persistence.create_threat(testdb, threat2)
+
+            ticket_business.fix_ticket_by_threat(testdb, threat2)
+
+            ticket2 = persistence.get_ticket_by_threat_id_and_dependency_id(
+                testdb, threat2.threat_id, self.dependency1.dependency_id
+            )
+
+            # Prepare ticket status request objects
+            status_request1 = {
+                "assignees": [str(self.user1.user_id)],
+            }
+            status_request2 = {
+                "assignees": [str(self.user1.user_id), str(user2.user_id)],
+            }
+
+            # Prepare API endpoint URLs
+            url1 = f"/pteams/{self.pteam1.pteam_id}/tickets/{ticket1.ticket_id}/ticketstatuses"
+            url2 = f"/pteams/{self.pteam1.pteam_id}/tickets/{ticket2.ticket_id}/ticketstatuses"
+
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            client.put(url1, headers=_headers, json=status_request1)
+            client.put(url2, headers=_headers, json=status_request2)
+
+            return user2
+
+        def test_it_should_return_200_and_tickets_with_user1_in_assignees(self, testdb):
+            # Given
+            self._setup_tickets_with_two_users_and_assignees(testdb)
+
+            # When
+            response = client.get(
+                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={self.user1.user_id}",
+                headers=headers(USER1),
+            )
+
+            # Then
+            assert response.status_code == 200
+            assert len(response.json()) == 2
+
+            # Check ticket assignees
+            tickets_data = response.json()
+            for ticket in tickets_data:
+                ticket_status = ticket["ticket_status"]
+                assert str(self.user1.user_id) in ticket_status["assignees"]
+
+        def test_it_should_return_200_and_tickets_with_user2_in_assignees(self, testdb):
+            # Given
+            user2 = self._setup_tickets_with_two_users_and_assignees(testdb)
+
+            # When
+            response = client.get(
+                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={user2.user_id}",
+                headers=headers(USER2),
+            )
+
+            # Then
+            assert response.status_code == 200
+            # There are two tickets in db but only one has user2 assigned
+            assert len(response.json()) == 1
+
+            # Check ticket assignees
+            tickets_data = response.json()
+            for ticket in tickets_data:
+                ticket_status = ticket["ticket_status"]
+                assert str(user2.user_id) in ticket_status["assignees"]
+
+        def test_it_should_return_empty_list_when_querying_unassigned_user(self):
+            # no tickets have been assigned to user1 yet
+            # When
+            response = client.get(
+                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={self.user1.user_id}",
                 headers=headers(USER1),
             )
 

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -961,8 +961,11 @@ class TestGetTickets:
 
             return user2
 
-        def test_it_should_return_200_and_two_tickets_with_user1_in_assignees(self, testdb):
+        def test_it_should_return_all_assigned_tickets_when_assigned_to_me_is_true_for_user1(
+            self, testdb
+        ):
             # Given
+            # user1 is assigned to all tickets
             self._setup_tickets_with_two_users_and_assignees(testdb)
 
             # When
@@ -981,8 +984,11 @@ class TestGetTickets:
                 ticket_status = ticket["ticket_status"]
                 assert str(self.user1.user_id) in ticket_status["assignees"]
 
-        def test_it_should_return_200_and_one_ticket_with_user2_in_assignees(self, testdb):
+        def test_it_should_return_only_one_ticket_when_assigned_to_me_is_true_for_user2(
+            self, testdb
+        ):
             # Given
+            # user2 is assigned to one ticket
             user2 = self._setup_tickets_with_two_users_and_assignees(testdb)
 
             # When

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -966,7 +966,7 @@ class TestGetTickets:
 
             # When
             response = client.get(
-                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={self.user1.user_id}",
+                f"/pteams/{self.pteam1.pteam_id}/tickets?assigned_to_me=true",
                 headers=headers(USER1),
             )
 
@@ -986,7 +986,7 @@ class TestGetTickets:
 
             # When
             response = client.get(
-                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={user2.user_id}",
+                f"/pteams/{self.pteam1.pteam_id}/tickets?assigned_to_me=true",
                 headers=headers(USER2),
             )
 
@@ -1005,7 +1005,7 @@ class TestGetTickets:
             # no tickets have been assigned to user1 yet
             # When
             response = client.get(
-                f"/pteams/{self.pteam1.pteam_id}/tickets?user_id={self.user1.user_id}",
+                f"/pteams/{self.pteam1.pteam_id}/tickets?assigned_to_me=true",
                 headers=headers(USER1),
             )
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
get tickets APIを変更し、assigneesを指定して取得できるように変更する。
- get_tickets_by_service_id_and_package_id_and_vuln_id関数にuser_idをクエリパラメータとして追加
- 指定された場合、assignees中のuser_idによる絞り込みを実施

### 相談事項
- 追加するクエリパラメータはuser_idで良いか？、それともbool型のmytaskとかにするか。
- APIを叩いたユーザとクエリパラメータのuser_idの合致などは確認していないので、他のユーザのticketも取得できるが問題ないか。


<!-- I want to review in Japanese. -->
