### PR TITLE
fix e2etest environment

### DIFF
--- a/.github/workflows/e2etest.yml
+++ b/.github/workflows/e2etest.yml
@@ -8,12 +8,6 @@ on:
 env:
   DB_USER: postgres
   DB_PASSWORD: postgres
-  DB_HOST: db
-  TESTDB_HOST: testdb
-  DB_PORT: 5432
-  DB_SCHEMA: postgres
-  FLASHSENSE_API_URL: http://flashsense.api.url.example/api
-  FIREBASE_CRED: /key/firebase_credentials.json
   FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 jobs:
   e2etest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,6 @@ env:
   TESTDB_HOST: localhost
   DB_PORT: 5432
   DB_SCHEMA: postgres
-  FLASHSENSE_API_URL: http://flashsense.api.url.example/api
   FIREBASE_CRED: ../key/firebase_credentials.json
   FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
   SENDGRID_API_KEY: fake_api_key_for_sendgrid_test

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -23,13 +23,13 @@ services:
       - WEBUI_URL=${WEBUI_URL}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
-      - DB_HOST=${TESTDB_HOST} # overwright
-      - DB_PORT=${DB_PORT}
-      - DB_SCHEMA=${DB_SCHEMA}
-      - TESTDB_HOST=${TESTDB_HOST}
+      - DB_HOST=testdb
+      - DB_PORT=5432
+      - DB_SCHEMA=postgres
+      - TESTDB_HOST=testdb
       - AUTH_SERVICE=FIREBASE
       - FIREBASE_API_KEY=${FIREBASE_API_KEY}
-      - FIREBASE_CRED=${FIREBASE_CRED}
+      - FIREBASE_CRED=/key/firebase_credentials.json
     labels:
       - traefik.http.routers.api.entrypoints=http
       - traefik.http.routers.api.priority=10


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- docker-compose-e2e.ymlについて、docker-compose-firebase-local.ymlに合わせて以下の項目を環境変数からではなく、固定値を適用する
  - DB_HOST、DB_PORT、DB_SCHEMA、TESTDB_HOST、FIREBASE_CRED
- 上記に伴い、e2etest.ymlで定義不要になった環境変数を削除する
- 周辺見直しで発見した問題として、main.ymlにおいて、不要な環境変数FLASHSENSE_API_URLを定義していたため、削除する。

## 経緯・意図・意思決定
Supabase対応時にdocker-compose-firebase-local.ymlと.envの関係を整理したが、.envの影響を受けるteste2e.shの考慮が漏れていた。そのため、e2etest.ymlからは動作するがteste2e.shからは動作しない状態になっていた。


<!-- I want to review in Japanese. -->
