### PR TITLE
fix get pteam members

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1401,10 +1401,10 @@ def get_pteam_members(
 
     pteam_members = []
     for member in pteam.members:
-        for pteam_role in member.pteam_roles:
-            if pteam_role.pteam_id == str(pteam_id):
-                is_admin = pteam_role.is_admin
-                break
+        is_admin = next(
+            (pteam_role.is_admin for pteam_role in member.pteam_roles if pteam_role.pteam_id == str(pteam_id)),
+            False
+        )
 
         pteam_members.append(
             schemas.PteamMemberGetResponse(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1404,6 +1404,7 @@ def get_pteam_members(
         for pteam_role in member.pteam_roles:
             if pteam_role.pteam_id == str(pteam_id):
                 is_admin = pteam_role.is_admin
+                break
 
         pteam_members.append(
             schemas.PteamMemberGetResponse(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1385,7 +1385,7 @@ def update_pteam(
     return pteam
 
 
-@router.get("/{pteam_id}/members", response_model=list[schemas.UserResponse])
+@router.get("/{pteam_id}/members", response_model=list[schemas.PteamMemberGetResponse])
 def get_pteam_members(
     pteam_id: UUID,
     current_user: models.Account = Depends(get_current_user),
@@ -1398,14 +1398,32 @@ def get_pteam_members(
         raise NO_SUCH_PTEAM
     if not check_pteam_membership(pteam, current_user):
         raise NOT_A_PTEAM_MEMBER
-    return pteam.members
+
+    pteam_members = []
+    for member in pteam.members:
+        for pteam_role in member.pteam_roles:
+            if pteam_role.pteam_id == str(pteam_id):
+                is_admin = pteam_role.is_admin
+
+        pteam_members.append(
+            schemas.PteamMemberGetResponse(
+                user_id=member.user_id,
+                uid=member.uid,
+                email=member.email,
+                disabled=member.disabled,
+                years=member.years,
+                is_admin=is_admin,
+            )
+        )
+
+    return pteam_members
 
 
-@router.put("/{pteam_id}/members/{user_id}", response_model=schemas.PTeamMemberResponse)
+@router.put("/{pteam_id}/members/{user_id}", response_model=schemas.PTeamMemberUpdateResponse)
 def update_pteam_member(
     pteam_id: UUID,
     user_id: UUID,
-    data: schemas.PTeamMemberRequest,
+    data: schemas.PTeamMemberUpdateRequest,
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1402,8 +1402,12 @@ def get_pteam_members(
     pteam_members = []
     for member in pteam.members:
         is_admin = next(
-            (pteam_role.is_admin for pteam_role in member.pteam_roles if pteam_role.pteam_id == str(pteam_id)),
-            False
+            (
+                pteam_role.is_admin
+                for pteam_role in member.pteam_roles
+                if pteam_role.pteam_id == str(pteam_id)
+            ),
+            False,
         )
 
         pteam_members.append(

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -74,6 +74,15 @@ class UserResponse(ORMModel):
     pteam_roles: list[PTeamRole]
 
 
+class PteamMemberGetResponse(ORMModel):
+    user_id: UUID
+    uid: str
+    email: str
+    disabled: bool
+    years: int
+    is_admin: bool
+
+
 class UserCreateRequest(ORMModel):
     years: int = 0
 
@@ -236,11 +245,11 @@ class PTeamAuthInfo(ORMModel):
     pseudo_uuids: list[PseudoUUID]
 
 
-class PTeamMemberRequest(ORMModel):
+class PTeamMemberUpdateRequest(ORMModel):
     is_admin: bool
 
 
-class PTeamMemberResponse(ORMModel):
+class PTeamMemberUpdateResponse(ORMModel):
     pteam_id: UUID
     user_id: UUID
     is_admin: bool

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -314,14 +314,14 @@ class TestDeleteUserSideEffects:
     @staticmethod
     def update_pteam_member(
         operate_user, user_id, pteam_id, is_admin: bool
-    ) -> schemas.PTeamMemberResponse:
+    ) -> schemas.PTeamMemberUpdateResponse:
         request = {"is_admin": is_admin}
         response = client.put(
             f"/pteams/{pteam_id}/members/{user_id}", headers=headers(operate_user), json=request
         )
         if response.status_code != 200:
             raise HTTPError(response)
-        return schemas.PTeamMemberResponse(**response.json())
+        return schemas.PTeamMemberUpdateResponse(**response.json())
 
     def test_cannot_get_user_after_deleted(self, testdb):
         self.delete_user_me(USER1)

--- a/api/app/tests/requests/pteams/test_pteam_invitations.py
+++ b/api/app/tests/requests/pteams/test_pteam_invitations.py
@@ -353,4 +353,4 @@ def test_apply_invitation__individual_auth():
 
     response = client.get(f"/pteams/{pteam1.pteam_id}/members", headers=headers(USER1))
     members_map = {UUID(x["user_id"]): x for x in response.json()}
-    assert members_map.get(user2.user_id).get("is_admin") == False
+    assert members_map.get(user2.user_id).get("is_admin") is False

--- a/api/app/tests/requests/pteams/test_pteam_invitations.py
+++ b/api/app/tests/requests/pteams/test_pteam_invitations.py
@@ -353,4 +353,4 @@ def test_apply_invitation__individual_auth():
 
     response = client.get(f"/pteams/{pteam1.pteam_id}/members", headers=headers(USER1))
     members_map = {UUID(x["user_id"]): x for x in response.json()}
-    assert {p["is_admin"] for p in members_map.get(user2.user_id).get("pteam_roles", [])} == {False}
+    assert members_map.get(user2.user_id).get("is_admin") == False

--- a/web/src/pages/PTeam/PTeamMember.jsx
+++ b/web/src/pages/PTeam/PTeamMember.jsx
@@ -53,7 +53,7 @@ export function PTeamMember(props) {
                     >
                       <TableCell align="left" style={{ width: "30%" }}>
                         <Box display="flex" flexDirection="row">
-                          {checkAdmin(member, pteamId) && <StarIcon color="warning" />}
+                          {member.is_admin && <StarIcon color="warning" />}
                           <Typography>{member.email}</Typography>
                         </Box>
                         <UUIDTypography>{member.user_id}</UUIDTypography>
@@ -77,7 +77,7 @@ export function PTeamMember(props) {
                           pteamId={pteamId}
                           memberUserId={member.user_id}
                           userEmail={member.email}
-                          isTargetMemberAdmin={checkAdmin(member, pteamId)}
+                          isTargetMemberAdmin={member.is_admin}
                         />
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
get pteam members APIを実行した時にユーザ情報経由で指定したpteam以外のpteamの情報が見てしまう問題の修正
- APIのレスポンスをUserResponseからPteamMemberGetResponseに変更
  - UserResponseではユーザ情報としてlist[pteam_role]を返していたが、これだと余計なpteamの情報を含むため、指定したpteamのis_admin情報のみを返すように変更 
 

変更に伴う影響箇所の修正
- Update pteam memberのレスポンスの名称をPteamMemberResponseから、PteamMemberUpdateResponseに変更
  - PteamMemberGetResponseとの区別のため
- test_pteam_invitations.pyのget pteam members APIを利用している部分を修正
-  UIの影響箇所を修正
  - PTeamMember.jsxのadmin情報を参照している部分を変更
    - check_admin関数を用いる実装から、直接member.is_adminを参照する方法に変更
    - check_admin関数自体はget pteam members api関係以外でも利用しているため、そのまま
    
    
    
```
    [
  {
    "user_id": "cf7b2d3d-c73d-41fe-8992-bf982c5babff",
    "uid": "vpBv4hMkLC44tnosIiJbZkVgS4VO",
    "email": "user1@demo.test",
    "disabled": false,
    "years": 0,
    "is_admin": false
  },
  {
    "user_id": "6c38ea6b-1d98-491e-87d9-526c6b75da15",
    "uid": "6RtWTP0Rrm8acwLi1Ah0GWqZ29Uw",
    "email": "user2@demo.test",
    "disabled": false,
    "years": 0,
    "is_admin": true
  }
]
```


<!-- I want to review in Japanese. -->
