### PR TITLE
add ubuntu 24.04 to trivydb2tc allow_list

### DIFF
--- a/scripts/trivydb2tc.py
+++ b/scripts/trivydb2tc.py
@@ -137,6 +137,7 @@ allow_list = [
     b"ubuntu 22.04",
     # b"ubuntu 22.10",
     # b"ubuntu 23.04",
+    b"ubuntu 24.04",
     # b"wolfi",
 ]
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- trivydb2tc のallow_listに「ubuntu 24.04」を追加する

## 経緯・意図・意思決定
本PR完了後、Deployリポジトリに反映する

<!-- I want to review in Japanese. -->
