### PR TITLE
ナビゲーションドロワーのレスポンシブ対応とレイアウトの最適化

### DIFF
--- a/web/src/pages/App/AppBar.jsx
+++ b/web/src/pages/App/AppBar.jsx
@@ -1,5 +1,13 @@
 import { Menu as MenuIcon } from "@mui/icons-material";
-import { AppBar as MuiAppBar, Box, Divider, IconButton, Toolbar } from "@mui/material";
+import {
+  AppBar as MuiAppBar,
+  Box,
+  Divider,
+  IconButton,
+  Toolbar,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { ErrorBoundary } from "react-error-boundary";
 import { useDispatch, useSelector } from "react-redux";
@@ -37,10 +45,12 @@ export function AppBar() {
   const system = useSelector((state) => state.system);
 
   const handleDrawerOpen = () => dispatch(setDrawerOpen(!system.drawerOpen));
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   return (
     <>
-      <StyledAppBar open={system.drawerOpen} position="fixed">
+      <StyledAppBar open={!isMobile && system.drawerOpen} position="fixed">
         <Toolbar>
           <IconButton
             aria-label="menu"

--- a/web/src/pages/App/AppPage.jsx
+++ b/web/src/pages/App/AppPage.jsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, useMediaQuery, useTheme } from "@mui/material";
 import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,13 +40,16 @@ export function App() {
     dispatch(setRedirectedFrom({ from: location.pathname, search: location.search }));
   }, [dispatch, location.pathname, location.search]);
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
   return (
     <>
       <Box flexGrow={1}>
         <AppBar />
       </Box>
       <Drawer />
-      <Main open={system.drawerOpen}>
+      <Main open={!isMobile && system.drawerOpen}>
         <Box display="flex" flexDirection="row" flexGrow={1} justifyContent="center" m={1}>
           <Box display="flex" flexDirection="column" flexGrow={1} maxWidth={mainMaxWidth}>
             <ErrorBoundary FallbackComponent={AppFallback} resetKeys={[location.pathname]}>

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -60,9 +60,15 @@ export function Drawer() {
   const theme = useTheme();
   const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  // --- Effects for responsive drawer behavior ---
+
+  // Auto-open drawer on large screens.
   useEffect(() => {
     dispatch(setDrawerOpen(isLargeScreen));
   }, [isLargeScreen, dispatch]);
+
+  // Force-close drawer on mobile to prevent a resize bug.
   useEffect(() => {
     if (isMobile) {
       dispatch(setDrawerOpen(false));

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -58,11 +58,16 @@ export function Drawer() {
 
   const dispatch = useDispatch();
   const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   useEffect(() => {
-    dispatch(setDrawerOpen(isDesktop));
-  }, [isDesktop, dispatch]);
+    dispatch(setDrawerOpen(isLargeScreen));
+  }, [isLargeScreen, dispatch]);
+  useEffect(() => {
+    if (isMobile) {
+      dispatch(setDrawerOpen(false));
+    }
+  }, [isMobile, dispatch]);
 
   const drawerTitle = "Threatconnectome";
 

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -59,6 +59,7 @@ export function Drawer() {
   const dispatch = useDispatch();
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   useEffect(() => {
     dispatch(setDrawerOpen(isDesktop));
   }, [isDesktop, dispatch]);
@@ -69,7 +70,8 @@ export function Drawer() {
     <MuiDrawer
       anchor="left"
       open={system.drawerOpen}
-      variant="persistent"
+      variant={isMobile ? "temporary" : "persistent"}
+      onClose={() => dispatch(setDrawerOpen(false))}
       sx={{
         flexShrink: 0,
         "& .MuiDrawer-paper": {

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -6,11 +6,16 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { useSelector } from "react-redux";
+import { set } from "date-fns";
+import { use, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import { setDrawerOpen } from "../../slices/system";
 import { LocationReader } from "../../utils/LocationReader";
 import { drawerWidth, drawerParams } from "../../utils/const";
 
@@ -50,6 +55,13 @@ export function Drawer() {
   const handleNavigateTop = () => {
     navigate("/?" + queryParams);
   };
+
+  const dispatch = useDispatch();
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up("lg"));
+  useEffect(() => {
+    dispatch(setDrawerOpen(isDesktop));
+  }, [isDesktop, dispatch]);
 
   const drawerTitle = "Threatconnectome";
 

--- a/web/src/slices/system.js
+++ b/web/src/slices/system.js
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const systemSlice = createSlice({
   name: "system",
   initialState: {
-    drawerOpen: true,
+    drawerOpen: false,
   },
   reducers: {
     setDrawerOpen: (state, action) => ({


### PR DESCRIPTION
## PR の目的

アプリケーションのナビゲーションドロワーにレスポンシブ対応を導入し、さまざまなデバイスサイズでのユーザー体験 (UX) を向上させます。

画面サイズに応じて、ドロワーの表示形式を動的に切り替えることで、以下を実現します。
- **デスクトップ表示:** ナビゲーションへのアクセス性を優先し、常時表示される`persistent`形式を採用。
- **モバイル表示:** コンテンツの閲覧スペースを優先し、必要な時だけオーバーレイ表示される`temporary`形式を採用。

## 経緯・意図・意思決定

### 経緯
従来のUIでは、ドロワーは常に表示されており、特にモバイル端末などの画面が小さいデバイスではコンテンツエリアが狭くなってしまう問題がありました。この問題を解決し、デスクトップではナビゲーションの視認性を、モバイルではコンテンツの可読性を優先するUIを目指しました。

### 実装の意図・意思決定
- **レスポンシブ制御の実装:**
  - Material-UI の `useMediaQuery` フックを利用して、画面のブレークポイント (`lg`, `sm`) を検知するアプローチを採用しました。
  - `useEffect` を用い、検知した画面サイズに応じてドロワーの開閉状態 (`drawerOpen`) を Redux ストアで一元管理するようにしました。
- **レイアウトの最適化:**
  - `variant`プロパティを`persistent`と`temporary`で動的に切り替え、各画面サイズに最適な表示を実現しました。
  - `temporary` ドロワー（モバイル表示）の際にメインコンテンツが横にずれないよう、`open` プロパティの制御ロジックを修正しました。
- **Reduxストアの初期値変更:**
  - `system`スライスの`drawerOpen`の初期値を`true`から`false`に変更しました。これにより、「デフォルトではドロワーは閉じており、`useEffect`による画面サイズ判定後に必要に応じて開く」という、モバイルファーストな挙動の土台を整えています。

### 既知の課題・トレードオフ

- **初期表示時のちらつき（Flicker）**
  - デスクトップ表示での初回読み込み時に、ドロワーが僅かに遅れて表示されるちらつきが発生します。
  - これはクライアントサイドでの状態解決に伴う一般的な課題であり、将来的なUIシステムの変更可能性を考慮し、現時点では特定のUIライブラリに深く依存する対策を避ける方針としました。この挙動は既知のトレードオフとして許容しています。

## 補足情報

レビューの際、ブラウザの開発者ツールなどで画面幅を変更することで、以下のブレークポイントで挙動が切り替わることを確認できます。

- **`1200px` 以上 (`lg`, `xl`) - デスクトップ**
  - ドロワーが自動で開き、コンテンツを押しのける `persistent` 形式で表示されます。

- **`600px` 〜 `1199px` (`sm`, `md`) - タブレット**
  - ドロワーは自動で閉じますが、メニューボタンで開閉可能です。この範囲でも表示形式は `persistent` です。

- **`600px` 未満 (`xs`) - モバイル**
  - ドロワーは自動で閉じ、表示形式がコンテンツの上に重なる `temporary`（オーバーレイ表示）に切り替わります。

**補足:** このPRはサイドバーのレスポンシブ対応のみを対象としています。メインコンテンツ部分の対応は、後続のPRで実施します。