### PR TITLE
fix get vulns API

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -171,10 +171,8 @@ def get_vulns(
                 raise ValueError(f"Invalid CVE ID format: {cve_id}")
 
     # Base query
-    query = (
-        select(models.Vuln, models.Affect)
-        .select_from(models.Vuln)
-        .join(models.Affect, models.Affect.vuln_id == models.Vuln.vuln_id)
+    query = select(models.Vuln, models.Affect).join(
+        models.Affect, models.Affect.vuln_id == models.Vuln.vuln_id
     )
 
     filters = []

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -414,6 +414,7 @@ def get_packages_summary(
             "package_id": row.package_id,
             "package_name": row.name,
             "ecosystem": row.ecosystem,
+            "package_managers": row.package_managers,
             "ssvc_priority": row.min_ssvc_priority,
             "updated_at": row.max_updated_at,
             "service_ids": row.service_ids,

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -267,20 +267,13 @@ def get_vulns(
     # Pageination
     query = query.distinct().offset(offset).limit(limit)
 
-    rows = db.execute(query).all()
-
-    vuln_dict = {}
-    for (vuln,) in rows:
-        if vuln.vuln_id not in vuln_dict:
-            vuln_dict[vuln.vuln_id] = {
-                "vuln": vuln,
-                "affects": [affect for affect in vuln.affects],
-            }
+    vulns = db.scalars(query).all()
 
     result = {
         "num_vulns": num_vulns,
-        "vulns": list(vuln_dict.values()),
+        "vulns": vulns,
     }
+
     return result
 
 

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -193,8 +193,6 @@ def get_vulns(
         )
     )
 
-    # Conditionally join Dependency if package_manager is specified
-
     filters = []
 
     if min_cvss_v3_score is not None:

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -188,8 +188,20 @@ def get_vulns(
         .join(models.Affect, models.Affect.vuln_id == models.Vuln.vuln_id)
         .join(
             models.Package,
-            (models.Package.name == models.Affect.affected_name)
-            & (models.Package.ecosystem == models.Affect.ecosystem),
+            or_(
+                # LangPackage: name, ecosystem
+                (
+                    (models.Package.type == models.PackageType.LANG)
+                    & (models.Package.name == models.Affect.affected_name)
+                    & (models.Package.ecosystem == models.Affect.ecosystem)
+                ),
+                # OSPackage: source_name, ecosystem
+                (
+                    (models.Package.type == models.PackageType.OS)
+                    & (models.OSPackage.source_name == models.Affect.affected_name)
+                    & (models.Package.ecosystem == models.Affect.ecosystem)
+                ),
+            ),
         )
     )
 

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -190,16 +190,16 @@ def get_vulns(
             models.Package,
             or_(
                 # LangPackage: name, ecosystem
-                (
-                    (models.Package.type == models.PackageType.LANG)
-                    & (models.Package.name == models.Affect.affected_name)
-                    & (models.Package.ecosystem == models.Affect.ecosystem)
+                and_(
+                    models.Package.type == models.PackageType.LANG,
+                    models.Package.name == models.Affect.affected_name,
+                    models.Package.ecosystem == models.Affect.ecosystem,
                 ),
                 # OSPackage: source_name, ecosystem
-                (
-                    (models.Package.type == models.PackageType.OS)
-                    & (models.OSPackage.source_name == models.Affect.affected_name)
-                    & (models.Package.ecosystem == models.Affect.ecosystem)
+                and_(
+                    models.Package.type == models.PackageType.OS,
+                    models.OSPackage.source_name == models.Affect.affected_name,
+                    models.Package.ecosystem == models.Affect.ecosystem,
                 ),
             ),
         )

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -171,9 +171,7 @@ def get_vulns(
                 raise ValueError(f"Invalid CVE ID format: {cve_id}")
 
     # Base query
-    query = select(models.Vuln, models.Affect).join(
-        models.Affect, models.Affect.vuln_id == models.Vuln.vuln_id
-    )
+    query = select(models.Vuln).join(models.Affect, models.Affect.vuln_id == models.Vuln.vuln_id)
 
     filters = []
 

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -409,16 +409,18 @@ def get_vulns(
         )
 
     response_vulns = []
-    for vuln in result["vulns"]:
+    for vuln_entry in result["vulns"]:
+        vuln = vuln_entry["vuln"]
+        affects = vuln_entry["affects"]
         vulnerable_packages = [
             schemas.VulnerablePackageResponse(
-                package_id=affect.package_id,
-                name=affect.package.name,
-                ecosystem=affect.package.ecosystem,
+                package_id=package.package_id,
+                name=affect.affected_name,
+                ecosystem=affect.ecosystem,
                 affected_versions=affect.affected_versions,
                 fixed_versions=affect.fixed_versions,
             )
-            for affect in vuln.affects
+            for affect, package in affects
         ]
         response_vulns.append(
             schemas.VulnResponse(

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -414,13 +414,12 @@ def get_vulns(
         affects = vuln_entry["affects"]
         vulnerable_packages = [
             schemas.VulnerablePackageResponse(
-                package_id=package.package_id,
-                name=affect.affected_name,
+                affected_name=affect.affected_name,
                 ecosystem=affect.ecosystem,
                 affected_versions=affect.affected_versions,
                 fixed_versions=affect.fixed_versions,
             )
-            for affect, package in affects
+            for affect in affects
         ]
         response_vulns.append(
             schemas.VulnResponse(

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -376,7 +376,7 @@ def get_vulns(
                 affected_versions=affect.affected_versions,
                 fixed_versions=affect.fixed_versions,
             )
-            for affect, package in affects
+            for affect in affects
         ]
         response_vulns.append(
             schemas.VulnResponse(

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -334,7 +334,6 @@ def get_vulns(
     cve_ids: list[str] | None = Query(None),
     package_name: list[str] | None = Query(None),
     ecosystem: list[str] | None = Query(None),
-    package_manager: str | None = Query(None),
     sort_key: schemas.VulnSortKey = Query(schemas.VulnSortKey.CVSS_V3_SCORE_DESC),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -359,7 +358,6 @@ def get_vulns(
     - `cve_ids`: List of CVE IDs to filter by.
     - `package_name`: List of package names to filter by.
     - `ecosystem`: List of ecosystems to filter by.
-    - `package_manager`: Package manager to filter by.
 
     ### Sorting:
     - `sort_key`: Sort key for the results. Default is `CVSS_V3_SCORE_DESC`.
@@ -402,7 +400,6 @@ def get_vulns(
             cve_ids=cve_ids,
             package_name=package_name,
             ecosystem=ecosystem,
-            package_manager=package_manager,
             sort_key=sort_key,
         )
     except ValueError as e:

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -376,7 +376,7 @@ def get_vulns(
                 affected_versions=affect.affected_versions,
                 fixed_versions=affect.fixed_versions,
             )
-            for affect in affects
+            for affect, package in affects
         ]
         response_vulns.append(
             schemas.VulnResponse(

--- a/api/app/routers/vulns.py
+++ b/api/app/routers/vulns.py
@@ -366,9 +366,8 @@ def get_vulns(
         )
 
     response_vulns = []
-    for vuln_entry in result["vulns"]:
-        vuln = vuln_entry["vuln"]
-        affects = vuln_entry["affects"]
+    for vuln in result["vulns"]:
+        affects = vuln.affects
         vulnerable_packages = [
             schemas.VulnerablePackageResponse(
                 affected_name=affect.affected_name,

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -167,15 +167,11 @@ class ActionUpdateRequest(ORMModel):
     recommended: bool | None = None
 
 
-class VulnerablePackageBase(BaseModel):
-    name: str
+class VulnerablePackageResponse(BaseModel):
+    affected_name: str
     ecosystem: str
     affected_versions: list[str]
     fixed_versions: list[str]
-
-
-class VulnerablePackageResponse(VulnerablePackageBase):
-    package_id: UUID
 
 
 class VulnBase(BaseModel):
@@ -185,6 +181,7 @@ class VulnBase(BaseModel):
     exploitation: ExploitationEnum | None = None
     automatable: AutomatableEnum | None = None
     cvss_v3_score: float | None = None
+    vulnerable_packages: list[VulnerablePackageResponse] = []
 
     _validate_cve_id = field_validator("cve_id", mode="before")(validate_cve_id)
 
@@ -194,7 +191,6 @@ class VulnResponse(VulnBase):
     created_at: datetime
     updated_at: datetime
     created_by: UUID | None = None
-    vulnerable_packages: list[VulnerablePackageResponse] = []
 
 
 class VulnsListResponse(BaseModel):
@@ -203,7 +199,7 @@ class VulnsListResponse(BaseModel):
 
 
 class VulnUpdateRequest(VulnBase):
-    vulnerable_packages: list[VulnerablePackageBase] = []
+    pass
 
 
 class PTeamInfo(PTeamEntry):

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -544,22 +544,6 @@ class TestGetVulns:
         created_times = []
         updated_times = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i <= 4:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -610,22 +594,6 @@ class TestGetVulns:
         # Given
         number_of_vulns = 5
         for i in range(number_of_vulns):
-            package: models.Package
-            if i <= 4:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{uuid4()}", headers=self.headers_user, json=vuln_request)
 
@@ -645,22 +613,6 @@ class TestGetVulns:
         created_times = []
         updated_times = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i <= 4:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -700,22 +652,6 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(len(scores)):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i, scores[i])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -748,22 +684,6 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(len(scores)):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i, scores[i])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -794,22 +714,6 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -838,22 +742,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -885,22 +773,6 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             if i == 0:
                 vuln_request: dict[str, Any] = {
@@ -979,22 +851,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1029,13 +885,6 @@ class TestGetVulns:
             vuln_id = uuid4()
             package: models.Package
             if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-                testdb.add(package)
-                testdb.flush()
                 vuln_request: dict[str, Any] = {
                     "title": f"Example-vuln-{i}",
                     "cve_id": f"CVE-0000-000{i}",
@@ -1053,14 +902,6 @@ class TestGetVulns:
                     ],
                 }
             else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-                testdb.add(package)
-                testdb.flush()
                 vuln_request = {
                     "title": f"Example-vuln-{i}",
                     "cve_id": f"CVE-0000-000{i}",
@@ -1200,22 +1041,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1249,22 +1074,6 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1282,22 +1091,6 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1411,22 +1204,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(2):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             if i == 0:
@@ -1468,22 +1245,6 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1514,22 +1275,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1565,22 +1310,6 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1616,22 +1345,6 @@ class TestGetVulns:
         testdb.commit()
 
         for i, data in enumerate(vulns_data):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i, data["cvss_v3_score"])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1878,22 +1591,6 @@ class TestGetVulns:
         # Given
         number_of_vulns = 5
         for i in range(number_of_vulns):
-            package: models.Package
-            if i == 0:
-                package = models.LangPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    type=models.PackageType.LANG,
-                )
-            else:
-                package = models.OSPackage(
-                    name=f"example-lib-{i}",
-                    ecosystem=f"ecosystem-{i}",
-                    source_name=f"example-lib-{i}",
-                    type=models.PackageType.OS,
-                )
-            testdb.add(package)
-            testdb.flush()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{uuid4()}", headers=self.headers_user, json=vuln_request)
 

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import Session
 
 from app import models
 from app.main import app
-from app.persistence import get_package_by_name_and_ecosystem
 from app.routers.pteams import bg_create_tags_from_sbom_json
 from app.tests.medium.constants import PTEAM1, USER1, USER2
 from app.tests.medium.utils import (
@@ -513,7 +512,7 @@ class TestGetVulns:
             "cvss_v3_score": cvss_v3_score,
             "vulnerable_packages": [
                 {
-                    "name": f"example-lib-{index}",
+                    "affected_name": f"example-lib-{index}",
                     "ecosystem": f"ecosystem-{index}",
                     "affected_versions": ["<2.0.0"],
                     "fixed_versions": ["2.0.0"],
@@ -533,14 +532,10 @@ class TestGetVulns:
         assert actual_vuln["cvss_v3_score"] == expected_request["cvss_v3_score"]
         pkg_resp = actual_vuln["vulnerable_packages"][0]
         req_pkg = expected_request["vulnerable_packages"][0]
-        assert pkg_resp["name"] == req_pkg["name"]
+        assert pkg_resp["affected_name"] == req_pkg["affected_name"]
         assert pkg_resp["ecosystem"] == req_pkg["ecosystem"]
         assert pkg_resp["affected_versions"] == req_pkg["affected_versions"]
         assert pkg_resp["fixed_versions"] == req_pkg["fixed_versions"]
-        # get package_id from DB and compare it.
-        package = get_package_by_name_and_ecosystem(testdb, req_pkg["name"], req_pkg["ecosystem"])
-        assert package is not None
-        assert pkg_resp["package_id"] == str(package.package_id)
 
     def test_it_should_return_200_and_vulns_list(self, testdb: Session):
         # Given
@@ -549,6 +544,22 @@ class TestGetVulns:
         created_times = []
         updated_times = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i <= 4:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -558,7 +569,7 @@ class TestGetVulns:
 
         # When
         response = client.get("/vulns?offset=0&limit=100", headers=self.headers_user)
-
+        print(response.json())
         # Then
         assert response.status_code == 200
         response_data = response.json()
@@ -599,6 +610,22 @@ class TestGetVulns:
         # Given
         number_of_vulns = 5
         for i in range(number_of_vulns):
+            package: models.Package
+            if i <= 4:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{uuid4()}", headers=self.headers_user, json=vuln_request)
 
@@ -618,6 +645,22 @@ class TestGetVulns:
         created_times = []
         updated_times = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i <= 4:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -657,6 +700,22 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(len(scores)):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i, scores[i])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -689,6 +748,22 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(len(scores)):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i, scores[i])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -719,6 +794,22 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -747,6 +838,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -778,6 +885,22 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             if i == 0:
                 vuln_request: dict[str, Any] = {
@@ -789,7 +912,7 @@ class TestGetVulns:
                     "cvss_v3_score": 7.5,
                     "vulnerable_packages": [
                         {
-                            "name": f"example-lib-{i}",
+                            "affected_name": f"example-lib-{i}",
                             "ecosystem": f"ecosystem-{i}",
                             "affected_versions": ["<2.0.0"],
                             "fixed_versions": ["2.0.0"],
@@ -806,7 +929,7 @@ class TestGetVulns:
                     "cvss_v3_score": 7.5,
                     "vulnerable_packages": [
                         {
-                            "name": f"example-lib-{i}",
+                            "affected_name": f"example-lib-{i}",
                             "ecosystem": f"ecosystem-{i}",
                             "affected_versions": ["<2.0.0"],
                             "fixed_versions": ["2.0.0"],
@@ -837,7 +960,7 @@ class TestGetVulns:
                 assert vuln["exploitation"] == "active"
                 assert vuln["automatable"] == "yes"
                 assert vuln["cvss_v3_score"] == 7.5
-                assert vuln["vulnerable_packages"][0]["name"] == "example-lib-0"
+                assert vuln["vulnerable_packages"][0]["affected_name"] == "example-lib-0"
                 assert vuln["vulnerable_packages"][0]["ecosystem"] == "ecosystem-0"
                 assert vuln["vulnerable_packages"][0]["affected_versions"] == ["<2.0.0"]
                 assert vuln["vulnerable_packages"][0]["fixed_versions"] == ["2.0.0"]
@@ -856,6 +979,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -888,7 +1027,15 @@ class TestGetVulns:
         vuln_ids = []
         for i in range(number_of_vulns):
             vuln_id = uuid4()
+            package: models.Package
             if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+                testdb.add(package)
+                testdb.flush()
                 vuln_request: dict[str, Any] = {
                     "title": f"Example-vuln-{i}",
                     "cve_id": f"CVE-0000-000{i}",
@@ -898,7 +1045,7 @@ class TestGetVulns:
                     "cvss_v3_score": 7.5,
                     "vulnerable_packages": [
                         {
-                            "name": f"example-lib-{i}",
+                            "affected_name": f"example-lib-{i}",
                             "ecosystem": f"ecosystem-{i}",
                             "affected_versions": ["<2.0.0"],
                             "fixed_versions": ["2.0.0"],
@@ -906,6 +1053,14 @@ class TestGetVulns:
                     ],
                 }
             else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+                testdb.add(package)
+                testdb.flush()
                 vuln_request = {
                     "title": f"Example-vuln-{i}",
                     "cve_id": f"CVE-0000-000{i}",
@@ -915,7 +1070,7 @@ class TestGetVulns:
                     "cvss_v3_score": 7.5,
                     "vulnerable_packages": [
                         {
-                            "name": f"example-lib-{i}",
+                            "affected_name": f"example-lib-{i}",
                             "ecosystem": f"ecosystem-{i}",
                             "affected_versions": ["<2.0.0"],
                             "fixed_versions": ["2.0.0"],
@@ -947,7 +1102,7 @@ class TestGetVulns:
                 assert vuln["exploitation"] == "active"
                 assert vuln["automatable"] == "yes"
                 assert vuln["cvss_v3_score"] == 7.5
-                assert vuln["vulnerable_packages"][0]["name"] == "example-lib-0"
+                assert vuln["vulnerable_packages"][0]["affected_name"] == "example-lib-0"
                 assert vuln["vulnerable_packages"][0]["ecosystem"] == "ecosystem-0"
                 assert vuln["vulnerable_packages"][0]["affected_versions"] == ["<2.0.0"]
                 assert vuln["vulnerable_packages"][0]["fixed_versions"] == ["2.0.0"]
@@ -993,7 +1148,7 @@ class TestGetVulns:
             "cvss_v3_score": 7.5,
             "vulnerable_packages": [
                 {
-                    "name": package_name,
+                    "affected_name": package_name,
                     "ecosystem": ecosystem,
                     "affected_versions": ["<2.0.0"],
                     "fixed_versions": ["2.0.0"],
@@ -1013,7 +1168,7 @@ class TestGetVulns:
             "cvss_v3_score": 5.0,
             "vulnerable_packages": [
                 {
-                    "name": "other-lib",
+                    "affected_name": "other-lib",
                     "ecosystem": "other-eco",
                     "affected_versions": ["<1.0.0"],
                     "fixed_versions": ["1.0.0"],
@@ -1045,6 +1200,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1078,6 +1249,22 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1095,6 +1282,22 @@ class TestGetVulns:
         vuln_ids = []
 
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1208,6 +1411,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(2):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             if i == 0:
@@ -1249,6 +1468,22 @@ class TestGetVulns:
         number_of_vulns = 3
         vuln_ids = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
@@ -1279,6 +1514,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1289,7 +1540,7 @@ class TestGetVulns:
 
         # When
         response = client.get(
-            f"/vulns?package_name={put_response_data[0]['vulnerable_packages'][0]['name']}",
+            f"/vulns?package_name={put_response_data[0]['vulnerable_packages'][0]['affected_name']}",
             headers=self.headers_user,
         )
 
@@ -1314,6 +1565,22 @@ class TestGetVulns:
         vuln_ids = []
         put_response_data = []
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
             vuln_request = self.create_vuln_request(i)
             put_response = client.put(
@@ -1343,115 +1610,30 @@ class TestGetVulns:
                 testdb,
             )
 
-    def test_it_should_filter_by_package_manager(self, testdb: Session):
-        # Given
-        package_manager = "package-manager-0"
-        number_of_vulns = 2
-        vuln_ids = []
-
-        for i in range(number_of_vulns):
-            vuln_id = uuid4()
-            vuln_request = self.create_vuln_request(i)
-            response = client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
-            vuln_ids.append(vuln_id)
-
-            if i == 0:  # Get the package_id of the first record
-                response_data = response.json()
-                # Get the package_id from the database
-                package = testdb.execute(
-                    text(
-                        """
-                        SELECT package_id FROM package
-                        WHERE name = 'example-lib-0' AND ecosystem = 'ecosystem-0';
-                        """
-                    )
-                ).fetchone()
-
-                if package:
-                    package_id = package._mapping["package_id"]
-                else:
-                    raise ValueError("package_id could not be determined.")
-
-        if not package_id:
-            raise ValueError("package_id could not be determined.")
-
-        pteam_id = uuid4()
-        testdb.execute(
-            text(
-                f"""
-                INSERT INTO pteam (pteam_id, pteam_name, contact_info)
-                VALUES ('{pteam_id}', 'example-pteam', 'contact@example.com');
-                """
-            )
-        )
-
-        service_id = uuid4()
-        testdb.execute(
-            text(
-                f"""
-                INSERT INTO service (service_id, pteam_id, service_name)
-                VALUES ('{service_id}', '{pteam_id}', 'example-service');
-                """
-            )
-        )
-
-        # Add a dependency with the specified package_manager
-        package_version_id = uuid4()
-        dependency_id = uuid4()
-
-        testdb.execute(
-            text(
-                f"""
-            INSERT INTO packageversion (package_version_id, package_id, version)
-            VALUES ('{package_version_id}', '{package_id}', '1.0.0');
-            """
-            )
-        )
-        testdb.execute(
-            text(
-                f"""
-                INSERT INTO dependency (
-                    dependency_id, service_id, package_version_id, target, package_manager
-                )
-                VALUES (
-                '{dependency_id}',
-                '{service_id}',
-                '{package_version_id}',
-                'target',
-                '{package_manager}'
-                );
-                """
-            )
-        )
-
-        # When
-        response = client.get(
-            f"/vulns?package_manager={package_manager}", headers=self.headers_user
-        )
-
-        # Then
-        assert response.status_code == 200
-        response_data = response.json()
-        assert len(response_data["vulns"]) == 1
-        assert response_data["num_vulns"] == 1
-
-        # Check the details of each vuln
-        for i, vuln in enumerate(response_data["vulns"]):
-            self.assert_vuln_response(
-                vuln,
-                vuln_ids[i],
-                self.create_vuln_request(i),
-                testdb,
-            )
-
     # Test sort_key
     def setup_vulns(self, testdb: Session, vulns_data):
         testdb.execute(text("DELETE FROM vuln"))
         testdb.commit()
 
-        for data in vulns_data:
+        for i, data in enumerate(vulns_data):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_id = uuid4()
-            vuln_request = self.create_vuln_request(len(vulns_data), data["cvss_v3_score"])
+            vuln_request = self.create_vuln_request(i, data["cvss_v3_score"])
             client.put(f"/vulns/{vuln_id}", headers=self.headers_user, json=vuln_request)
             testdb.execute(
                 text(
@@ -1696,6 +1878,22 @@ class TestGetVulns:
         # Given
         number_of_vulns = 5
         for i in range(number_of_vulns):
+            package: models.Package
+            if i == 0:
+                package = models.LangPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    type=models.PackageType.LANG,
+                )
+            else:
+                package = models.OSPackage(
+                    name=f"example-lib-{i}",
+                    ecosystem=f"ecosystem-{i}",
+                    source_name=f"example-lib-{i}",
+                    type=models.PackageType.OS,
+                )
+            testdb.add(package)
+            testdb.flush()
             vuln_request = self.create_vuln_request(i)
             client.put(f"/vulns/{uuid4()}", headers=self.headers_user, json=vuln_request)
 

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -883,7 +883,6 @@ class TestGetVulns:
         vuln_ids = []
         for i in range(number_of_vulns):
             vuln_id = uuid4()
-            package: models.Package
             if i == 0:
                 vuln_request: dict[str, Any] = {
                     "title": f"Example-vuln-{i}",

--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -569,7 +569,7 @@ class TestGetVulns:
 
         # When
         response = client.get("/vulns?offset=0&limit=100", headers=self.headers_user)
-        print(response.json())
+
         # Then
         assert response.status_code == 200
         response_data = response.json()


### PR DESCRIPTION
## PR の目的
- 既存の [Get /vulns]APIにおいて下記の修正を実施
   - package_managerによるフィルタリングの廃止
   - Affectテーブルのaffected_name及びecosystemによるフィルタリングの追加
   - package_idをレスポンスから削除

- TestGetVulnsの修正（各テストpass確認済み）

## 経緯・意図・意思決定
- [Get /vulns]APIのSource Package対応に伴い、データモデルの変更があったためPackage対応に伴い、データモデルの変更があったため