### PR TITLE
fix TestGetVulnActions

### DIFF
--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -1774,7 +1774,7 @@ class TestGetVulnActions:
             "cvss_v3_score": 7.5,
             "vulnerable_packages": [
                 {
-                    "name": "example-lib",
+                    "affected_name": "example-lib",
                     "ecosystem": "pypi",
                     "affected_versions": ["<2.0.0"],
                     "fixed_versions": ["2.0.0"],


### PR DESCRIPTION
## PR の目的
- api/app/tests/requests/test_vulns.pyのTestGetVulnActionsの修正（全テストpass確認済み）
   - vulnerable_packagesのnameをaffected_nameに修正

## 経緯・意図・意思決定
- データモデルの修正により、affectテーブルのカラム名が変更になったため

