### PR TITLE
topic/fix Affect refinement in Package screen

### DIFF
--- a/web/src/pages/Package/PackagePage.jsx
+++ b/web/src/pages/Package/PackagePage.jsx
@@ -109,15 +109,18 @@ export function Package() {
     });
   if (ticketCountsUnSolvedIsLoading) return <>Now loading ticketCountsUnSolved...</>;
 
+  const serviceDict = pteam.services.find((service) => service.service_id === serviceId);
   const currentPackageDependencies = (serviceDependencies ?? []).filter(
     (dependency) => dependency.package_id === packageId,
   );
-  const serviceDict = pteam.services.find((service) => service.service_id === serviceId);
   const references = currentPackageDependencies.map((dependency) => ({
     dependencyId: dependency.dependency_id,
     target: dependency.target,
     version: dependency.package_version,
     service: serviceDict.service_name,
+    package_name: dependency.package_name,
+    package_source_name: dependency.package_source_name,
+    ecosystem: dependency.package_ecosystem,
   }));
 
   const numSolved = vulnIdsSolved.vuln_ids?.length ?? 0;

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -19,8 +19,12 @@ export function VulnTableRowView(props) {
   const [ticketOpen, setTicketOpen] = useState(true);
   const [vulnDrawerOpen, setVulnDrawerOpen] = useState(false);
 
+  const { package_source_name, package_name, ecosystem } = references[0];
+  const targetName = package_source_name ? package_source_name : package_name;
   const vulnerable_package = vuln.vulnerable_packages.find(
-    (vulnerable_package) => vulnerable_package.package_id === packageId,
+    (vulnerable_package) =>
+      vulnerable_package.affected_name === targetName &&
+      vulnerable_package.ecosystem === ecosystem
   );
   const affectedVersions = vulnerable_package.affected_versions;
   const patchedVersions = vulnerable_package.fixed_versions;

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -20,10 +20,11 @@ export function VulnTableRowView(props) {
   const [vulnDrawerOpen, setVulnDrawerOpen] = useState(false);
 
   const { package_source_name, package_name, ecosystem } = references[0];
-  const targetName = package_source_name ? package_source_name : package_name;
   const vulnerable_package = vuln.vulnerable_packages.find(
     (vulnerable_package) =>
-      vulnerable_package.affected_name === targetName && vulnerable_package.ecosystem === ecosystem,
+      vulnerable_package.ecosystem === ecosystem &&
+      (vulnerable_package.affected_name === package_source_name ||
+        vulnerable_package.affected_name === package_name),
   );
   const affectedVersions = vulnerable_package.affected_versions;
   const patchedVersions = vulnerable_package.fixed_versions;

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -23,8 +23,7 @@ export function VulnTableRowView(props) {
   const targetName = package_source_name ? package_source_name : package_name;
   const vulnerable_package = vuln.vulnerable_packages.find(
     (vulnerable_package) =>
-      vulnerable_package.affected_name === targetName &&
-      vulnerable_package.ecosystem === ecosystem
+      vulnerable_package.affected_name === targetName && vulnerable_package.ecosystem === ecosystem,
   );
   const affectedVersions = vulnerable_package.affected_versions;
   const patchedVersions = vulnerable_package.fixed_versions;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- source_name対応に伴い、Package画面のaffectも絞り込みの機能を修正しました。

## 経緯・意図・意思決定
- web/src/pages/Package/PackagePage.jsx
  - referencesにpackage_name, package_source_name, ecosystemを追加しました

- web/src/pages/Package/VulnTables/VulnTableRowView.jsx
  - PackagePage.jsxにおいて、packageIdを用いてdependenciesの絞り込みをしているため、referencesに入るpackage_name, package_source_name, ecosystemは同一のものになっています。そのためVulnTables/VulnTableRowView.jsxではreferences[0]を用いてaffectの絞り込みを行っています。
<!-- I want to review in Japanese. -->
