### PR TITLE
fix api tests

### DIFF
--- a/api/app/sbom/parser/syft_cdx_parser.py
+++ b/api/app/sbom/parser/syft_cdx_parser.py
@@ -162,6 +162,7 @@ class SyftCDXParser(SBOMParser):
                 artifacts_key,
                 Artifact(
                     package_name=package_info["pkg_name"],
+                    source_name="",  # TODO: support source_name
                     ecosystem=package_info["ecosystem"],
                     package_manager=package_info["pkg_mgr"],
                 ),

--- a/api/app/tests/integrations/business/test_package_business.py
+++ b/api/app/tests/integrations/business/test_package_business.py
@@ -128,7 +128,7 @@ class TestFixPackage:
             is not None
         )
 
-    def test_it_should_not_delete_package_and_delete_package_version_when_has_affect(
+    def test_it_should_delete_package_and_delete_package_version_when_related_affect(
         self,
         testdb: Session,
         package1: models.Package,
@@ -144,9 +144,10 @@ class TestFixPackage:
 
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         testdb.add(affect)
         testdb.flush()
@@ -165,5 +166,5 @@ class TestFixPackage:
             testdb.execute(
                 select(models.Package).where(models.Package.package_id == package1.package_id)
             ).first()
-            is not None
+            is None
         )

--- a/api/app/tests/integrations/business/test_threat_business.py
+++ b/api/app/tests/integrations/business/test_threat_business.py
@@ -52,9 +52,10 @@ class TestFixThreatByVuln:
         )
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         persistence.create_package_version(testdb, package_version)
         persistence.create_affect(testdb, affect)
@@ -80,9 +81,10 @@ class TestFixThreatByVuln:
         )
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         threat = models.Threat(
             package_version_id=package_version.package_version_id, vuln_id=vuln1.vuln_id
@@ -116,15 +118,17 @@ class TestFixThreatByVuln:
         )
         affect1 = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         affect2 = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=2.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         threat = models.Threat(
             package_version_id=package_version.package_version_id, vuln_id=vuln1.vuln_id
@@ -161,9 +165,10 @@ class TestFixThreatByPackageVersionId:
         )
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         persistence.create_package_version(testdb, package_version)
         persistence.create_affect(testdb, affect)
@@ -191,9 +196,10 @@ class TestFixThreatByPackageVersionId:
         )
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         threat = models.Threat(
             package_version_id=package_version.package_version_id, vuln_id=vuln1.vuln_id
@@ -227,15 +233,17 @@ class TestFixThreatByPackageVersionId:
         )
         affect1 = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         affect2 = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=2.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         threat = models.Threat(
             package_version_id=package_version.package_version_id, vuln_id=vuln1.vuln_id
@@ -297,9 +305,10 @@ class TestDeleteThreatByVulnWhemAllAffectsUnmatch:
         )
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         threat = models.Threat(
             package_version_id=package_version.package_version_id, vuln_id=vuln1.vuln_id

--- a/api/app/tests/integrations/business/test_ticket_business.py
+++ b/api/app/tests/integrations/business/test_ticket_business.py
@@ -85,9 +85,10 @@ class TestFixTicketByThreat:
 
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=["2.0.0"],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         persistence.create_affect(testdb, affect)
 
@@ -133,9 +134,10 @@ class TestFixTicketByThreat:
 
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         persistence.create_affect(testdb, affect)
 
@@ -192,9 +194,10 @@ class TestFixTicketByThreat:
 
         affect = models.Affect(
             vuln_id=vuln1.vuln_id,
-            package_id=package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=[],
+            affected_name=package1.name,
+            ecosystem=package1.ecosystem,
         )
         persistence.create_affect(testdb, affect)
 

--- a/api/app/tests/integrations/test_actions.py
+++ b/api/app/tests/integrations/test_actions.py
@@ -81,7 +81,7 @@ class TestCreateAction:
             "cvss_v3_score": 7.8,
             "vulnerable_packages": [
                 {
-                    "name": "axios",
+                    "affected_name": "axios",
                     "ecosystem": "npm",
                     "affected_versions": ["<2.0.0"],
                     "fixed_versions": [],
@@ -280,7 +280,7 @@ class TestDeleteAction:
             "cvss_v3_score": 7.8,
             "vulnerable_packages": [
                 {
-                    "name": "axios",
+                    "affected_name": "axios",
                     "ecosystem": "npm",
                     "affected_versions": ["<2.0.0"],
                     "fixed_versions": [],

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -721,9 +721,10 @@ class TestGetTickets:
 
             affect1 = models.Affect(
                 vuln_id=self.vuln1.vuln_id,
-                package_id=self.package1.package_id,
                 affected_versions=["<=1.0.0"],
                 fixed_versions=["2.0.0"],
+                affected_name=self.package1.name,
+                ecosystem=self.package1.ecosystem,
             )
             persistence.create_affect(testdb, affect1)
 
@@ -917,7 +918,7 @@ class TestGetTickets:
                 "cvss_v3_score": 7.5,
                 "vulnerable_packages": [
                     {
-                        "name": self.package1.name,
+                        "affected_name": self.package1.name,
                         "ecosystem": self.package1.ecosystem,
                         "affected_versions": ["<=1.0.0"],
                         "fixed_versions": ["2.0.0"],
@@ -1132,9 +1133,10 @@ class TestGetTicket:
         persistence.create_vuln(testdb, self.vuln1)
         affect1 = models.Affect(
             vuln_id=self.vuln1.vuln_id,
-            package_id=self.package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=["2.0.0"],
+            affected_name=self.package1.name,
+            ecosystem=self.package1.ecosystem,
         )
         persistence.create_affect(testdb, affect1)
         self.threat1 = models.Threat(
@@ -1268,9 +1270,10 @@ class TestPutTicket:
         persistence.create_vuln(testdb, self.vuln1)
         affect1 = models.Affect(
             vuln_id=self.vuln1.vuln_id,
-            package_id=self.package1.package_id,
             affected_versions=["<=1.0.0"],
             fixed_versions=["2.0.0"],
+            affected_name=self.package1.name,
+            ecosystem=self.package1.ecosystem,
         )
         persistence.create_affect(testdb, affect1)
         self.threat1 = models.Threat(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- source package対応におけるデータモデル変更に伴い、API自動テストを修正する
- command.get_related_affects_by_package()のテストがAPI全体のテストしかなかったため、内部ロジックのみでsource_nameが機能することを確認するテストをtest_threat_businessに追加した
- trivyのSBOM投入時、syft_cdx_parser.pyでエラーが出た。syftはsource_name取得を後日対応予定だが、エラー回避のための暫定修正を実施した



<!-- I want to review in Japanese. -->
