### PR TITLE
Bugfix/check os

### DIFF
--- a/api/app/detector/ecosystem_analyzer.py
+++ b/api/app/detector/ecosystem_analyzer.py
@@ -1,0 +1,31 @@
+OS_TYPES = [
+    "alma",
+    "alpine",
+    "amazon",
+    "azurelinux",
+    "bottlerocket",
+    "cbl-mariner",
+    "centos",
+    "chainguard",
+    "debian",
+    "echo",
+    "fedora",
+    "minimos",
+    "opensuse",
+    "opensuse-leap",
+    "opensuse-tumbleweed",
+    "oracle",
+    "photon",
+    "redhat",
+    "rocky",
+    "slem",
+    "sles",
+    "ubuntu",
+    "wolfi",
+]
+
+
+def is_os_ecosystem(ecosystem: str) -> bool:
+    if not ecosystem:
+        return False
+    return any(ecosystem.startswith(type) for type in OS_TYPES)

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -22,7 +22,7 @@ from app.business.ssvc_business import (
 )
 from app.business.ticket_business import fix_ticket_ssvc_priority
 from app.database import get_db, open_db_session
-from app.detector.package_family import PackageFamily
+from app.detector import ecosystem_analyzer
 from app.notification.alert import notify_sbom_upload_ended
 from app.notification.slack import validate_slack_webhook_url
 from app.routers.validators.account_validator import (
@@ -1236,8 +1236,7 @@ def apply_service_packages(
             _package := persistence.get_package_by_name_and_ecosystem(db, package_name, ecosystem)
         ):
             # create new package
-            package_family = PackageFamily.from_registry(ecosystem)
-            if package_family == PackageFamily.DEBIAN:
+            if ecosystem_analyzer.is_os_ecosystem(ecosystem):
                 _package = models.OSPackage(
                     name=package_name, ecosystem=ecosystem, source_name=str(line.get("source_name"))
                 )


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- debian、ubuntu以外のOSにおいて、source_nameで脆弱性マッチングすべきところを、binary_nameでマッチングしていたため、修正する
  - trivyがサポートするOSのtypeで始まるecosystemを持つ場合、OSであると判定する

## 経緯・意図・意思決定
既知不具合により、trivy+cyclonedxで解析したalpineをTcに投入すると、ecosystemが3.22.0になるため、alpineはbinary_nameでマッチングされるままとなっている。
この問題は別途対応予定。


## 参考文献
ecosystemが、trivyの以下文字列で開始されていたらOSパッケージと判定する、で良さそう
ここのOSType文字列がSBOM生成時にも使われてそう
https://github.com/aquasecurity/trivy/blob/3adfd988d1e3e680a7184bfd6326eb7cfe00c1f3/pkg/fanal/types/const.go#L23 
<!-- I want to review in Japanese. -->
