### PR TITLE
fix package_id nullable in downgrade script

### DIFF
--- a/api/app/alembic/versions/2025_06_20_0630-461c9acd767e_add_lang_and_os_package.py
+++ b/api/app/alembic/versions/2025_06_20_0630-461c9acd767e_add_lang_and_os_package.py
@@ -189,6 +189,7 @@ def downgrade() -> None:
         ondelete="CASCADE",
     )
 
+    op.alter_column("affect", "package_id", nullable=False)
     op.create_index("ix_affect_package_id", "affect", ["package_id"], unique=False)
     op.drop_column("affect", "ecosystem")
     op.drop_column("affect", "affected_name")


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- 2025_06_20_0630-461c9acd767e_add_lang_and_os_package.py によってDB定義をダウングレードした際、Affect.package_idを非NULLにすべきところを、NULL許容にしていたため、修正する

<!-- I want to review in Japanese. -->
