### PR TITLE
fix: Drawerの表示切替に起因するUI操作不能の問題を解決

### DIFF
--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -10,8 +10,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { set } from "date-fns";
-import { use, useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -64,16 +63,16 @@ export function Drawer() {
   // --- Effects for responsive drawer behavior ---
 
   // Auto-open drawer on large screens.
+  // HACK: Use async update to prevent UI freeze from Drawer's race condition.
   useEffect(() => {
-    dispatch(setDrawerOpen(isLargeScreen));
-  }, [isLargeScreen, dispatch]);
+    const timer = setTimeout(() => {
+      dispatch(setDrawerOpen(isLargeScreen));
+    }, 0);
 
-  // Force-close drawer on mobile to prevent a resize bug.
-  useEffect(() => {
-    if (isMobile) {
-      dispatch(setDrawerOpen(false));
-    }
-  }, [isMobile, dispatch]);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isLargeScreen, dispatch]);
 
   const drawerTitle = "Threatconnectome";
 

--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -57,8 +57,8 @@ export function Drawer() {
 
   const dispatch = useDispatch();
   const theme = useTheme();
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up("lg"));
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isLgUp = useMediaQuery(theme.breakpoints.up("lg"));
+  const isSmDown = useMediaQuery(theme.breakpoints.down("sm"));
 
   // --- Effects for responsive drawer behavior ---
 
@@ -66,13 +66,13 @@ export function Drawer() {
   // HACK: Use async update to prevent UI freeze from Drawer's race condition.
   useEffect(() => {
     const timer = setTimeout(() => {
-      dispatch(setDrawerOpen(isLargeScreen));
+      dispatch(setDrawerOpen(isLgUp));
     }, 0);
 
     return () => {
       clearTimeout(timer);
     };
-  }, [isLargeScreen, dispatch]);
+  }, [isLgUp, dispatch]);
 
   const drawerTitle = "Threatconnectome";
 
@@ -80,7 +80,7 @@ export function Drawer() {
     <MuiDrawer
       anchor="left"
       open={system.drawerOpen}
-      variant={isMobile ? "temporary" : "persistent"}
+      variant={isSmDown ? "temporary" : "persistent"}
       onClose={() => dispatch(setDrawerOpen(false))}
       sx={{
         flexShrink: 0,


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

レスポンシブ表示に対応したDrawerコンポーネントにおいて、画面のリサイズ時にUIがフリーズする（操作不能になる）致命的なバグを修正します。

## 経緯・意図・意思決定

### 経緯
ブラウザのウィンドウサイズを変更し、Drawerの表示モード（`variant`）がPC向け（`persistent`）からモバイル向け（`temporary`）へ切り替わるタイミングで、画面全体の操作ができなくなる問題が確認されました。

### 原因
Drawerの`variant`プロパティの変更と、開閉状態（`open`）を更新する処理が、Reactの同一レンダリングサイクル内で同時に実行されることが原因でした。
この競合状態により、MUIコンポーネント内部で状態遷移が正しく処理されず、背景のオーバーレイ（Backdrop）が画面に残り続けてしまい、UIをブロックしていました。

### 意思決定と実装
**1. バグ修正**
この競合状態を回避するため、`useEffect`内で`setTimeout(..., 0)`を用いて状態更新処理を意図的に非同期化するアプローチを採用しました。
これにより、まず`variant`の変更がDOMに反映され、その後の別のイベントループで`open`状態が更新されるため、レンダリングサイクルが安全に分離されます。結果として、MUIコンポーネントが安定して状態を遷移させることが可能になります。

**2. リファクタリング**
本修正と密接に関連するレスポンシブ判定の変数名を、より自己説明的なものにリファクタリングしました（例: `isLargeScreen` → `isLgUp`）。これにより、MUIのブレークポイント指定との対応が明確になり、コードの意図が理解しやすくなっています。

## 補足事項

### レビュー担当者の方へ
動作確認の際は、ブラウザのウィンドウ幅をPCサイズとモバイルサイズの間でリサイズし、UIがフリーズせずに他のボタンなどが継続して操作可能であることをご確認ください。

<!-- I want to review in Japanese. -->
