### PR TITLE
fix(ui): 長いサービス名によるレイアウト崩れを修正

### DIFF
--- a/web/src/pages/Status/PTeamServiceDetails.jsx
+++ b/web/src/pages/Status/PTeamServiceDetails.jsx
@@ -110,22 +110,41 @@ export function PTeamServiceDetails(props) {
           <PTeamServiceDetailsSettings pteamId={pteamId} service={service} />
           <CardMedia image={image} sx={{ aspectRatio: "4 / 3" }} />
           <Divider orientation="vertical" variant="middle" flexItem />
-          <CardContent sx={{ flex: 1 }}>
-            <Stack direction="row" spacing={1}>
-              {keywords.map((keyword) => (
-                <Chip key={keyword} label={keyword} size="small" />
-              ))}
-            </Stack>
-            <Typography variant="h5">
-              {serviceName}
-              <ServiceIDCopyButton ServiceId={service.service_id} />
-            </Typography>
-            <Typography variant="body2" sx={{ wordBreak: "break-all" }}>
-              {description}
-            </Typography>
-            <Typography variant="caption" color="textSecondary">
-              {`Default safety impact: ${service.service_safety_impact}`}
-            </Typography>
+          <CardContent sx={{ display: "flex", flex: 1, minWidth: 0 }}>
+            <Box sx={{ display: "flex", flexDirection: "column", minWidth: 0 }}>
+              <Stack
+                direction="row"
+                spacing={0.5}
+                useFlexGap
+                sx={{ maxWidth: "90%", flexWrap: "wrap" }}
+              >
+                {keywords.map((keyword) => (
+                  <Chip key={keyword} label={keyword} size="small" />
+                ))}
+              </Stack>
+              <Box sx={{ display: "flex", alignItems: "center" }}>
+                <Box sx={{ display: "flex", minWidth: 0, maxWidth: "90%" }}>
+                  <Typography
+                    variant="h5"
+                    sx={{
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                    title={serviceName}
+                  >
+                    {serviceName}
+                  </Typography>
+                  <ServiceIDCopyButton ServiceId={service.service_id} />
+                </Box>
+              </Box>
+              <Typography variant="body2" sx={{ wordBreak: "break-all" }}>
+                {description}
+              </Typography>
+              <Typography variant="caption" color="textSecondary">
+                {`Default safety impact: ${service.service_safety_impact}`}
+              </Typography>
+            </Box>
           </CardContent>
         </Card>
         <Box sx={{ mt: 1 }}>

--- a/web/src/pages/Status/PTeamServiceDetails.jsx
+++ b/web/src/pages/Status/PTeamServiceDetails.jsx
@@ -116,14 +116,23 @@ export function PTeamServiceDetails(props) {
                 direction="row"
                 spacing={0.5}
                 useFlexGap
-                sx={{ maxWidth: "90%", flexWrap: "wrap" }}
+                sx={{
+                  maxWidth: "90%", // Limit width to 90% to avoid overlapping with the absolutely positioned settings button.
+                  flexWrap: "wrap",
+                }}
               >
                 {keywords.map((keyword) => (
                   <Chip key={keyword} label={keyword} size="small" />
                 ))}
               </Stack>
               <Box sx={{ display: "flex", alignItems: "center" }}>
-                <Box sx={{ display: "flex", minWidth: 0, maxWidth: "90%" }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    minWidth: 0,
+                    maxWidth: "90%", // Limit width to 90% to avoid overlapping with the absolutely positioned settings button.
+                  }}
+                >
                   <Typography
                     variant="h5"
                     sx={{

--- a/web/src/pages/Status/PTeamServiceTabs.jsx
+++ b/web/src/pages/Status/PTeamServiceTabs.jsx
@@ -1,5 +1,5 @@
 import { UploadFile } from "@mui/icons-material";
-import { Tabs, Tab, Tooltip } from "@mui/material";
+import { Tabs, Tab, Tooltip, Box } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 import { useState } from "react";
@@ -24,19 +24,20 @@ export function PTeamServiceTabs(props) {
           <Tooltip key={service.service_id} title={service.service_name}>
             <Tab
               label={
-                <span
-                  style={{
+                <Box
+                  sx={(theme) => ({
                     display: "block",
                     width: "100%",
                     overflow: "hidden",
                     whiteSpace: "nowrap",
                     textOverflow: "ellipsis",
-                    paddingLeft: "10px",
-                    paddingRight: "10px",
-                  }}
+                    paddingLeft: theme.spacing(1),
+                    paddingRight: theme.spacing(1),
+                  })}
+                  component="span"
                 >
                   {service.service_name}
-                </span>
+                </Box>
               }
               onClick={() => {
                 onChangeService(service.service_id);

--- a/web/src/pages/Status/PTeamServiceTabs.jsx
+++ b/web/src/pages/Status/PTeamServiceTabs.jsx
@@ -23,7 +23,21 @@ export function PTeamServiceTabs(props) {
         {services.map((service) => (
           <Tooltip key={service.service_id} title={service.service_name}>
             <Tab
-              label={service.service_name}
+              label={
+                <span
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    overflow: "hidden",
+                    whiteSpace: "nowrap",
+                    textOverflow: "ellipsis",
+                    paddingLeft: "10px",
+                    paddingRight: "10px",
+                  }}
+                >
+                  {service.service_name}
+                </span>
+              }
               onClick={() => {
                 onChangeService(service.service_id);
                 setIsActiveUploadMode(0);
@@ -34,6 +48,8 @@ export function PTeamServiceTabs(props) {
                 borderRadius: "0.5rem 0.5rem 0 0",
                 width: "20%",
                 mt: 1,
+                minWidth: 0,
+                padding: 0,
               }}
             />
           </Tooltip>

--- a/web/src/pages/Status/PTeamServicesListModal.jsx
+++ b/web/src/pages/Status/PTeamServicesListModal.jsx
@@ -57,8 +57,21 @@ function ServiceCard(props) {
       }}
     >
       <CardMedia image={image} sx={{ aspectRatio: "4 / 3" }} />
-      <CardContent sx={{ flex: 1 }}>
-        <CardHeader title={service.service_name} sx={{ px: 0 }}></CardHeader>
+      <CardContent sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          variant="h5"
+          noWrap
+          title={service.service_name}
+          sx={(theme) => ({
+            width: "100%",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            display: "block",
+            p: theme.spacing(0, 0, 1, 0),
+          })}
+        >
+          {service.service_name}
+        </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-all" }}>
           {service.description}
         </Typography>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

サービス名が長い場合に、サービス詳細カード、サービス選択タブ、およびサービス一覧モーダルでUIのレイアウトが崩れる不具合を修正します。

## 経緯・意図・意思決定

### 経緯
現状の実装では、サービス名の長さに応じてコンポーネントの幅が変動してしまい、テキストがコンテナを突き抜けて他の要素に重なったり、画面からはみ出したりする問題が確認されました。これにより、特にサービス名が長い場合にUIの見た目と一貫性が損なわれていました。

### 意図・実装内容
この問題に対処するため、CSSの `text-overflow: ellipsis` を利用し、一行に収まらない長いサービス名を「...」で省略表示するようにUIを改善しました。ユーザビリティを考慮し、省略されたテキストはマウスホバー時のツールチップで全文を確認できるようにしています。

具体的な修正点は以下の通りです。

-   **サービス詳細カード (`PTeamServiceDetails.jsx`)**
    -   長いサービス名を省略表示するように修正しました。
    -   関連して、キーワードのチップもコンテナをはみ出す可能性があったため、`flexWrap: "wrap"` を適用して折り返すように改善しました。

-   **サービス選択タブ (`PTeamServiceTabs.jsx`)**
    -   タブのラベルが長くなった場合に省略表示されるよう修正しました。

-   **サービス一覧モーダル (`PTeamServicesListModal.jsx`)**
    -   サービスカードのタイトルを省略表示するように修正しました。
<!-- I want to review in Japanese. -->
