### PR TITLE
fix affected_name

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 
 export function PackageView(props) {
   const { vulnPackage } = props;
-  const nameWithEcosystem = `${vulnPackage.name}:${vulnPackage.ecosystem}`;
+  const nameWithEcosystem = `${vulnPackage.affected_name}:${vulnPackage.ecosystem}`;
   const affectedVersions = vulnPackage?.affected_versions ?? [];
   const fixedVersions = vulnPackage?.fixed_versions ?? [];
 

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -32,7 +32,7 @@ export function VulnTableRowView(props) {
   const actionByFixedVersions = createActionByFixedVersions(
     affectedVersions,
     patchedVersions,
-    vulnerable_package.name,
+    vulnerable_package.affected_name,
   );
 
   return (

--- a/web/src/utils/vulnUtils.js
+++ b/web/src/utils/vulnUtils.js
@@ -26,7 +26,7 @@ export function getActions(vuln, vulnActions) {
     const action = createActionByFixedVersions(
       vulnerable_package.affected_versions,
       vulnerable_package.fixed_versions,
-      vulnerable_package.name,
+      vulnerable_package.affected_name,
     );
     if (action != null) {
       actionsByFixedVersions.push(action);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- TcUI上の以下の問題を修正する
  - Vuln詳細ページにおいて、Package欄の「affected_name:ecosystem」におけるaffected_name部分が常にundefinedと表示される
  - Vuln詳細ページにおいて、アクション文字列に「Update undefined ・・・」 と表示される
  - PackageページからチケットをConpleteする際に表示されるアクション文字列に「Update undefined ・・・」 と表示される

## 経緯・意図・意思決定
Vulnerabilityページにも同じ問題があるが、別問題のため動作確認できないため、別問題と合わせて別PRで対応する

<!-- I want to review in Japanese. -->
