### PR TITLE
Fix the error that appears when the DETAIL button on the package page is clicked

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -10,7 +10,12 @@ export function PackageView(props) {
   const fixedVersions = vulnPackage?.fixed_versions ?? [];
 
   return (
-    <Card key={vulnPackage.package_id} variant="outlined" display="flex" sx={{ m: 1, p: 2 }}>
+    <Card
+      key={vulnPackage.affected_name + vulnPackage.ecosystem}
+      variant="outlined"
+      display="flex"
+      sx={{ m: 1, p: 2 }}
+    >
       {/* Title -- package name */}
       <Typography variant="h5">{nameWithEcosystem}</Typography>
       <Box display="flex" flexDirection="row" justifyContent="center">

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -9,7 +9,7 @@ import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
 import { useGetDependenciesQuery } from "../../../services/tcApi";
 import { APIError } from "../../../utils/APIError";
 import { ssvcPriorityProps } from "../../../utils/const.js";
-import { errorToString , searchWorstSSVC } from "../../../utils/func";
+import { errorToString, searchWorstSSVC } from "../../../utils/func";
 import { createActionByFixedVersions, findMatchedVulnPackage } from "../../../utils/vulnUtils.js";
 import { VulnerabilityDrawer } from "../../Vulnerability/VulnerabilityDrawer.jsx";
 

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -5,10 +5,11 @@ import { Button, Collapse, IconButton, TableCell, TableRow } from "@mui/material
 import PropTypes from "prop-types";
 import { useState } from "react";
 
-import { ssvcPriorityProps } from "../../../utils/const.js";
-import { searchWorstSSVC } from "../../../utils/func.js";
-import { useGetDependenciesQuery } from "../../../services/tcApi";
 import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
+import { useGetDependenciesQuery } from "../../../services/tcApi";
+import { APIError } from "../../../utils/APIError";
+import { ssvcPriorityProps } from "../../../utils/const.js";
+import { errorToString , searchWorstSSVC } from "../../../utils/func";
 import { createActionByFixedVersions, findMatchedVulnPackage } from "../../../utils/vulnUtils.js";
 import { VulnerabilityDrawer } from "../../Vulnerability/VulnerabilityDrawer.jsx";
 

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -7,7 +7,9 @@ import { useState } from "react";
 
 import { ssvcPriorityProps } from "../../../utils/const.js";
 import { searchWorstSSVC } from "../../../utils/func.js";
-import { createActionByFixedVersions } from "../../../utils/vulnUtils.js";
+import { useGetDependenciesQuery } from "../../../services/tcApi";
+import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
+import { createActionByFixedVersions, findMatchedVulnPackage } from "../../../utils/vulnUtils.js";
 import { VulnerabilityDrawer } from "../../Vulnerability/VulnerabilityDrawer.jsx";
 
 import { TicketTable } from "./TicketTable.jsx";
@@ -18,15 +20,35 @@ export function VulnTableRowView(props) {
     props;
   const [ticketOpen, setTicketOpen] = useState(true);
   const [vulnDrawerOpen, setVulnDrawerOpen] = useState(false);
+  const skip = useSkipUntilAuthUserIsReady();
+  const getDependenciesReady = !skip && pteamId && serviceId;
 
-  const { package_source_name, package_name, ecosystem } = references[0];
-  const vulnerable_package = vuln.vulnerable_packages.find(
-    (vulnerable_package) =>
-      vulnerable_package.ecosystem === ecosystem &&
-      (package_source_name != null
-        ? vulnerable_package.affected_name === package_source_name
-        : vulnerable_package.affected_name === package_name),
+  const offset = 0;
+  const limit = 10000;
+  const {
+    data: serviceDependencies,
+    error: serviceDependenciesError,
+    isLoading: serviceDependenciesIsLoading,
+  } = useGetDependenciesQuery(
+    { pteamId, serviceId, offset, limit },
+    { skip: !getDependenciesReady },
   );
+
+  if (skip) return <></>;
+  if (serviceDependenciesError)
+    throw new APIError(errorToString(serviceDependenciesError), { api: "getDependencies" });
+  if (serviceDependenciesIsLoading) return <>Now loading Service Dependencies...</>;
+  const currentPackageDependencies = (serviceDependencies ?? []).filter(
+    (dependency) => dependency.package_id === packageId,
+  );
+  const currentPackage = {
+    package_name: currentPackageDependencies[0].package_name,
+    package_source_name: currentPackageDependencies[0].package_source_name,
+    ecosystem: currentPackageDependencies[0].package_ecosystem,
+  };
+
+  // Get the matched vulnerable package from vulnerable_packages and currentPackage
+  const vulnerable_package = findMatchedVulnPackage(vuln.vulnerable_packages, currentPackage);
   const affectedVersions = vulnerable_package.affected_versions;
   const patchedVersions = vulnerable_package.fixed_versions;
   const actionByFixedVersions = createActionByFixedVersions(
@@ -125,7 +147,7 @@ export function VulnTableRowView(props) {
         serviceId={serviceId}
         servicePackageId={packageId}
         vulnId={vulnId}
-        references={references}
+        currentPackage={currentPackage}
       />
     </>
   );

--- a/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
+++ b/web/src/pages/Package/VulnTables/VulnTableRowView.jsx
@@ -125,6 +125,7 @@ export function VulnTableRowView(props) {
         serviceId={serviceId}
         servicePackageId={packageId}
         vulnId={vulnId}
+        references={references}
       />
     </>
   );

--- a/web/src/pages/VulnDetail/VulnDetailView.jsx
+++ b/web/src/pages/VulnDetail/VulnDetailView.jsx
@@ -33,7 +33,10 @@ export function VulnDetailView(props) {
             {vuln.vulnerable_packages
               .filter((_, index) => (showAllPackages ? true : index === 0))
               .map((vulnPackage) => (
-                <PackageView key={vulnPackage.package_id} vulnPackage={vulnPackage} />
+                <PackageView
+                  key={vulnPackage.affected_name + vulnPackage.ecosystem}
+                  vulnPackage={vulnPackage}
+                />
               ))}
             {/* hide or more button if needed */}
             {vuln.vulnerable_packages.length > 1 && (

--- a/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
@@ -18,7 +18,7 @@ function SimpleCell(value = "") {
 }
 
 export function VulnerabilityDrawer(props) {
-  const { open, setOpen, pteamId, serviceId, servicePackageId, vulnId, references } = props;
+  const { open, setOpen, pteamId, serviceId, servicePackageId, vulnId, currentPackage } = props;
 
   const fullPageParams = new URLSearchParams();
   fullPageParams.set("pteamId", pteamId);
@@ -65,7 +65,7 @@ export function VulnerabilityDrawer(props) {
       vuln={vuln}
       vulnActions={vulnActions}
       service={service}
-      references={references}
+      currentPackage={currentPackage}
     />
   );
 }
@@ -76,5 +76,5 @@ VulnerabilityDrawer.propTypes = {
   serviceId: PropTypes.string.isRequired,
   servicePackageId: PropTypes.string.isRequired,
   vulnId: PropTypes.string.isRequired,
-  references: PropTypes.array.isRequired,
+  currentPackage: PropTypes.object.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawer.jsx
@@ -18,7 +18,7 @@ function SimpleCell(value = "") {
 }
 
 export function VulnerabilityDrawer(props) {
-  const { open, setOpen, pteamId, serviceId, servicePackageId, vulnId } = props;
+  const { open, setOpen, pteamId, serviceId, servicePackageId, vulnId, references } = props;
 
   const fullPageParams = new URLSearchParams();
   fullPageParams.set("pteamId", pteamId);
@@ -65,6 +65,7 @@ export function VulnerabilityDrawer(props) {
       vuln={vuln}
       vulnActions={vulnActions}
       service={service}
+      references={references}
     />
   );
 }
@@ -75,4 +76,5 @@ VulnerabilityDrawer.propTypes = {
   serviceId: PropTypes.string.isRequired,
   servicePackageId: PropTypes.string.isRequired,
   vulnId: PropTypes.string.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
@@ -7,7 +7,8 @@ import { useNavigate } from "react-router-dom";
 import { VulnerabilityView } from "./VulnerabilityView";
 
 export function VulnerabilityDrawerView(props) {
-  const { open, setOpen, hrefToFullPage, packageId, vuln, vulnActions, service } = props;
+  const { open, setOpen, hrefToFullPage, packageId, vuln, vulnActions, service, references } =
+    props;
 
   const navigate = useNavigate();
 
@@ -37,6 +38,7 @@ export function VulnerabilityDrawerView(props) {
             vuln={vuln}
             vulnActions={vulnActions}
             service={service}
+            references={references}
           />
         </Stack>
       </Box>
@@ -51,4 +53,5 @@ VulnerabilityDrawerView.propTypes = {
   vuln: PropTypes.object.isRequired,
   vulnActions: PropTypes.array.isRequired,
   service: PropTypes.object.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityDrawerView.jsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { VulnerabilityView } from "./VulnerabilityView";
 
 export function VulnerabilityDrawerView(props) {
-  const { open, setOpen, hrefToFullPage, packageId, vuln, vulnActions, service, references } =
+  const { open, setOpen, hrefToFullPage, packageId, vuln, vulnActions, service, currentPackage } =
     props;
 
   const navigate = useNavigate();
@@ -38,7 +38,7 @@ export function VulnerabilityDrawerView(props) {
             vuln={vuln}
             vulnActions={vulnActions}
             service={service}
-            references={references}
+            currentPackage={currentPackage}
           />
         </Stack>
       </Box>
@@ -53,5 +53,5 @@ VulnerabilityDrawerView.propTypes = {
   vuln: PropTypes.object.isRequired,
   vulnActions: PropTypes.array.isRequired,
   service: PropTypes.object.isRequired,
-  references: PropTypes.array.isRequired,
+  currentPackage: PropTypes.object.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -1,12 +1,18 @@
 import { useLocation } from "react-router-dom";
 
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
-import { useGetPTeamQuery, useGetVulnQuery, useGetVulnActionsQuery } from "../../services/tcApi";
+import {
+  useGetDependenciesQuery,
+  useGetPTeamQuery,
+  useGetVulnQuery,
+  useGetVulnActionsQuery,
+} from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { rootPrefix } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
 import { VulnerabilityPageView } from "./VulnerabilityPageView";
+import { ContentCutOutlined } from "@mui/icons-material";
 
 export function Vulnerability() {
   const location = useLocation();
@@ -17,6 +23,19 @@ export function Vulnerability() {
   const vulnId = params.get("vulnId");
 
   const skip = useSkipUntilAuthUserIsReady();
+  const getDependenciesReady = !skip && pteamId && serviceId;
+
+  const offset = 0;
+  const limit = 10000;
+  const {
+    data: serviceDependencies,
+    error: serviceDependenciesError,
+    isLoading: serviceDependenciesIsLoading,
+  } = useGetDependenciesQuery(
+    { pteamId, serviceId, offset, limit },
+    { skip: !getDependenciesReady },
+  );
+  console.log("serviceDependencies", serviceDependencies);
   const {
     data: pteam,
     error: pteamError,
@@ -34,10 +53,13 @@ export function Vulnerability() {
   } = useGetVulnActionsQuery(vulnId, { skip });
 
   if (skip) return <></>;
+  if (serviceDependenciesError)
+    throw new APIError(errorToString(serviceDependenciesError), { api: "getDependencies" });
   if (pteamError) throw new APIError(errorToString(pteamError), { api: "getPTeam" });
   if (vulnError) throw new APIError(errorToString(vulnError), { api: "getVuln" });
   if (vulnActionsError)
     throw new APIError(errorToString(vulnActionsError), { api: "getVulnActions" });
+  if (serviceDependenciesIsLoading) return <>Now loading Service Dependencies...</>;
   if (pteamIsLoading) return <>Now loading PTeam...</>;
   if (vulnIsLoading) return <>Now loading Vuln...</>;
   if (vulnActionsIsLoading) return <>Now loading VulnActions...</>;
@@ -52,6 +74,21 @@ export function Vulnerability() {
   const hrefToServicePage = `${rootPrefix}/?` + pteamServiceParams.toString();
   const hrefToPackagePage = `${rootPrefix}/packages/${packageId}?` + pteamServiceParams.toString();
 
+  const serviceDict = pteam.services.find((service) => service.service_id === serviceId);
+  console.log("serviceDict", serviceDict);
+  const currentPackageDependencies = (serviceDependencies ?? []).filter(
+    (dependency) => dependency.package_id === packageId,
+  );
+  const references = currentPackageDependencies.map((dependency) => ({
+    dependencyId: dependency.dependency_id,
+    target: dependency.target,
+    version: dependency.package_version,
+    service: serviceDict.service_name,
+    package_name: dependency.package_name,
+    package_source_name: dependency.package_source_name,
+    ecosystem: dependency.package_ecosystem,
+  }));
+
   return (
     <VulnerabilityPageView
       packageId={packageId}
@@ -60,6 +97,7 @@ export function Vulnerability() {
       service={service}
       hrefToServicePage={hrefToServicePage}
       hrefToPackagePage={hrefToPackagePage}
+      references={references}
     />
   );
 }

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -73,16 +73,10 @@ export function Vulnerability() {
   const hrefToServicePage = `${rootPrefix}/?` + pteamServiceParams.toString();
   const hrefToPackagePage = `${rootPrefix}/packages/${packageId}?` + pteamServiceParams.toString();
 
-  const serviceDict = pteam.services.find((service) => service.service_id === serviceId);
-
   const currentPackageDependencies = (serviceDependencies ?? []).filter(
     (dependency) => dependency.package_id === packageId,
   );
   const references = currentPackageDependencies.map((dependency) => ({
-    dependencyId: dependency.dependency_id,
-    target: dependency.target,
-    version: dependency.package_version,
-    service: serviceDict.service_name,
     package_name: dependency.package_name,
     package_source_name: dependency.package_source_name,
     ecosystem: dependency.package_ecosystem,

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -91,7 +91,6 @@ export function Vulnerability() {
 
   return (
     <VulnerabilityPageView
-      packageId={packageId}
       vuln={vuln}
       vulnActions={vulnActions}
       service={service}

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -12,7 +12,6 @@ import { rootPrefix } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
 import { VulnerabilityPageView } from "./VulnerabilityPageView";
-import { ContentCutOutlined } from "@mui/icons-material";
 
 export function Vulnerability() {
   const location = useLocation();

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -35,7 +35,7 @@ export function Vulnerability() {
     { pteamId, serviceId, offset, limit },
     { skip: !getDependenciesReady },
   );
-  console.log("serviceDependencies", serviceDependencies);
+
   const {
     data: pteam,
     error: pteamError,
@@ -75,7 +75,7 @@ export function Vulnerability() {
   const hrefToPackagePage = `${rootPrefix}/packages/${packageId}?` + pteamServiceParams.toString();
 
   const serviceDict = pteam.services.find((service) => service.service_id === serviceId);
-  console.log("serviceDict", serviceDict);
+
   const currentPackageDependencies = (serviceDependencies ?? []).filter(
     (dependency) => dependency.package_id === packageId,
   );

--- a/web/src/pages/Vulnerability/VulnerabilityPage.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPage.jsx
@@ -76,11 +76,11 @@ export function Vulnerability() {
   const currentPackageDependencies = (serviceDependencies ?? []).filter(
     (dependency) => dependency.package_id === packageId,
   );
-  const references = currentPackageDependencies.map((dependency) => ({
-    package_name: dependency.package_name,
-    package_source_name: dependency.package_source_name,
-    ecosystem: dependency.package_ecosystem,
-  }));
+  const currentPackage = {
+    package_name: currentPackageDependencies[0].package_name,
+    package_source_name: currentPackageDependencies[0].package_source_name,
+    ecosystem: currentPackageDependencies[0].package_ecosystem,
+  };
 
   return (
     <VulnerabilityPageView
@@ -89,7 +89,7 @@ export function Vulnerability() {
       service={service}
       hrefToServicePage={hrefToServicePage}
       hrefToPackagePage={hrefToPackagePage}
-      references={references}
+      currentPackage={currentPackage}
     />
   );
 }

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -6,15 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { VulnerabilityView } from "./VulnerabilityView";
 
 export function VulnerabilityPageView(props) {
-  const {
-    packageId,
-    vuln,
-    vulnActions,
-    service,
-    hrefToServicePage,
-    hrefToPackagePage,
-    references,
-  } = props;
+  const { vuln, vulnActions, service, hrefToServicePage, hrefToPackagePage, references } = props;
 
   window.scrollTo({ top: 0, behavior: "instant" });
 
@@ -52,19 +44,13 @@ export function VulnerabilityPageView(props) {
       </Typography>
       <Box>
         <Stack spacing={2} sx={{ mb: 3 }}>
-          <VulnerabilityView
-            packageId={packageId}
-            vuln={vuln}
-            vulnActions={vulnActions}
-            references={references}
-          />
+          <VulnerabilityView vuln={vuln} vulnActions={vulnActions} references={references} />
         </Stack>
       </Box>
     </>
   );
 }
 VulnerabilityPageView.propTypes = {
-  packageId: PropTypes.string.isRequired,
   vuln: PropTypes.object.isRequired,
   vulnActions: PropTypes.array.isRequired,
   service: PropTypes.object.isRequired,

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -28,7 +28,7 @@ export function VulnerabilityPageView(props) {
       (vulnerable_package.affected_name === package_source_name ||
         vulnerable_package.affected_name === package_name),
   );
-  if (!matchedVulnPackage) throw new Error("No packageId for the vuln.");
+  if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 
   return (
     <>

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -17,8 +17,9 @@ export function VulnerabilityPageView(props) {
   const matchedVulnPackage = vuln.vulnerable_packages.find(
     (vulnerable_package) =>
       vulnerable_package.ecosystem === ecosystem &&
-      (vulnerable_package.affected_name === package_source_name ||
-        vulnerable_package.affected_name === package_name),
+      (package_source_name != null
+        ? vulnerable_package.affected_name === package_source_name
+        : vulnerable_package.affected_name === package_name),
   );
   if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -6,14 +6,28 @@ import { useNavigate } from "react-router-dom";
 import { VulnerabilityView } from "./VulnerabilityView";
 
 export function VulnerabilityPageView(props) {
-  const { packageId, vuln, vulnActions, service, hrefToServicePage, hrefToPackagePage } = props;
+  const {
+    packageId,
+    vuln,
+    vulnActions,
+    service,
+    hrefToServicePage,
+    hrefToPackagePage,
+    references,
+  } = props;
 
   window.scrollTo({ top: 0, behavior: "instant" });
 
   const navigate = useNavigate();
 
   // matchedVulnPackage: package obtained by packageId
-  const matchedVulnPackage = vuln.vulnerable_packages.find((pkg) => pkg.package_id === packageId);
+  const { package_source_name, package_name, ecosystem } = references[0];
+  const matchedVulnPackage = vuln.vulnerable_packages.find(
+    (vulnerable_package) =>
+      vulnerable_package.ecosystem === ecosystem &&
+      (vulnerable_package.affected_name === package_source_name ||
+        vulnerable_package.affected_name === package_name),
+  );
   if (!matchedVulnPackage) throw new Error("No packageId for the vuln.");
 
   return (
@@ -38,7 +52,12 @@ export function VulnerabilityPageView(props) {
       </Typography>
       <Box>
         <Stack spacing={2} sx={{ mb: 3 }}>
-          <VulnerabilityView packageId={packageId} vuln={vuln} vulnActions={vulnActions} />
+          <VulnerabilityView
+            packageId={packageId}
+            vuln={vuln}
+            vulnActions={vulnActions}
+            references={references}
+          />
         </Stack>
       </Box>
     </>
@@ -51,4 +70,5 @@ VulnerabilityPageView.propTypes = {
   service: PropTypes.object.isRequired,
   hrefToServicePage: PropTypes.string.isRequired,
   hrefToPackagePage: PropTypes.string.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -2,6 +2,7 @@ import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { Box, Breadcrumbs, Link, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
+
 import { findMatchedVulnPackage } from "../../utils/vulnUtils.js";
 
 import { VulnerabilityView } from "./VulnerabilityView";

--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -2,25 +2,20 @@ import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 import { Box, Breadcrumbs, Link, Stack, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
+import { findMatchedVulnPackage } from "../../utils/vulnUtils.js";
 
 import { VulnerabilityView } from "./VulnerabilityView";
 
 export function VulnerabilityPageView(props) {
-  const { vuln, vulnActions, service, hrefToServicePage, hrefToPackagePage, references } = props;
+  const { vuln, vulnActions, service, hrefToServicePage, hrefToPackagePage, currentPackage } =
+    props;
 
   window.scrollTo({ top: 0, behavior: "instant" });
 
   const navigate = useNavigate();
 
-  // matchedVulnPackage: package obtained by packageId
-  const { package_source_name, package_name, ecosystem } = references[0];
-  const matchedVulnPackage = vuln.vulnerable_packages.find(
-    (vulnerable_package) =>
-      vulnerable_package.ecosystem === ecosystem &&
-      (package_source_name != null
-        ? vulnerable_package.affected_name === package_source_name
-        : vulnerable_package.affected_name === package_name),
-  );
+  // Get the matched vulnerable package from vulnerable_packages and currentPackage
+  const matchedVulnPackage = findMatchedVulnPackage(vuln.vulnerable_packages, currentPackage);
   if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 
   return (
@@ -45,7 +40,11 @@ export function VulnerabilityPageView(props) {
       </Typography>
       <Box>
         <Stack spacing={2} sx={{ mb: 3 }}>
-          <VulnerabilityView vuln={vuln} vulnActions={vulnActions} references={references} />
+          <VulnerabilityView
+            vuln={vuln}
+            vulnActions={vulnActions}
+            currentPackage={currentPackage}
+          />
         </Stack>
       </Box>
     </>
@@ -57,5 +56,5 @@ VulnerabilityPageView.propTypes = {
   service: PropTypes.object.isRequired,
   hrefToServicePage: PropTypes.string.isRequired,
   hrefToPackagePage: PropTypes.string.isRequired,
-  references: PropTypes.array.isRequired,
+  currentPackage: PropTypes.object.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -21,8 +21,9 @@ export function VulnerabilityView(props) {
   const matchedVulnPackage = vuln.vulnerable_packages.find(
     (vulnerable_package) =>
       vulnerable_package.ecosystem === ecosystem &&
-      (vulnerable_package.affected_name === package_source_name ||
-        vulnerable_package.affected_name === package_name),
+      (package_source_name != null
+        ? vulnerable_package.affected_name === package_source_name
+        : vulnerable_package.affected_name === package_name),
   );
   if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -12,19 +12,12 @@ import PropTypes from "prop-types";
 
 import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { PackageView } from "../../components/PackageView";
-import { createActionByFixedVersions } from "../../utils/vulnUtils.js";
+import { createActionByFixedVersions, findMatchedVulnPackage } from "../../utils/vulnUtils.js";
 
 export function VulnerabilityView(props) {
-  const { vuln, vulnActions, references } = props;
-  const { package_source_name, package_name, ecosystem } = references[0];
-  // matchedVulnPackage: package obtained by packageId
-  const matchedVulnPackage = vuln.vulnerable_packages.find(
-    (vulnerable_package) =>
-      vulnerable_package.ecosystem === ecosystem &&
-      (package_source_name != null
-        ? vulnerable_package.affected_name === package_source_name
-        : vulnerable_package.affected_name === package_name),
-  );
+  const { vuln, vulnActions, currentPackage } = props;
+  // Get the matched vulnerable package from vulnerable_packages and currentPackage
+  const matchedVulnPackage = findMatchedVulnPackage(vuln.vulnerable_packages, currentPackage);
   if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 
   const affectedVersions = matchedVulnPackage?.affected_versions ?? [];
@@ -107,5 +100,5 @@ export function VulnerabilityView(props) {
 VulnerabilityView.propTypes = {
   vuln: PropTypes.object.isRequired,
   vulnActions: PropTypes.array.isRequired,
-  references: PropTypes.array.isRequired,
+  currentPackage: PropTypes.object.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -15,9 +15,15 @@ import { PackageView } from "../../components/PackageView";
 import { createActionByFixedVersions } from "../../utils/vulnUtils.js";
 
 export function VulnerabilityView(props) {
-  const { packageId, vuln, vulnActions } = props;
+  const { vuln, vulnActions, references } = props;
+  const { package_source_name, package_name, ecosystem } = references[0];
   // matchedVulnPackage: package obtained by packageId
-  const matchedVulnPackage = vuln.vulnerable_packages.find((pkg) => pkg.package_id === packageId);
+  const matchedVulnPackage = vuln.vulnerable_packages.find(
+    (vulnerable_package) =>
+      vulnerable_package.ecosystem === ecosystem &&
+      (vulnerable_package.affected_name === package_source_name ||
+        vulnerable_package.affected_name === package_name),
+  );
   if (!matchedVulnPackage) throw new Error("No packageId for the vuln.");
 
   const affectedVersions = matchedVulnPackage?.affected_versions ?? [];
@@ -98,7 +104,7 @@ export function VulnerabilityView(props) {
   );
 }
 VulnerabilityView.propTypes = {
-  packageId: PropTypes.string.isRequired,
   vuln: PropTypes.object.isRequired,
   vulnActions: PropTypes.array.isRequired,
+  references: PropTypes.array.isRequired,
 };

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -24,7 +24,7 @@ export function VulnerabilityView(props) {
       (vulnerable_package.affected_name === package_source_name ||
         vulnerable_package.affected_name === package_name),
   );
-  if (!matchedVulnPackage) throw new Error("No packageId for the vuln.");
+  if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 
   const affectedVersions = matchedVulnPackage?.affected_versions ?? [];
   const patchedVersions = matchedVulnPackage?.fixed_versions ?? [];

--- a/web/src/utils/vulnUtils.js
+++ b/web/src/utils/vulnUtils.js
@@ -35,3 +35,14 @@ export function getActions(vuln, vulnActions) {
 
   return [...actionsByFixedVersions, ...vulnActions];
 }
+
+export function findMatchedVulnPackage(vulnerable_packages, currentPackage) {
+  const { package_source_name, package_name, ecosystem } = currentPackage;
+  return vulnerable_packages.find(
+    (vulnerable_package) =>
+      vulnerable_package.ecosystem === ecosystem &&
+      (package_source_name != null
+        ? vulnerable_package.affected_name === package_source_name
+        : vulnerable_package.affected_name === package_name),
+  );
+}


### PR DESCRIPTION
## PR の目的
- PackageページからDETAILボタンを押すとエラーが表示される（Error occurred: No packageId for the vuln.）
   - UIでpackageId見ずに名前でフィルタするの修正を https://github.com/nttcom/threatconnectome/pull/794 で行ったが同様の対応をVulnerabilityページ全体でも適応

## 経緯・意図・意思決定
- packageIdではなく名前でフィルタすべきところが漏れており、持ってないpackage_idを参照してエラーが発生

