### PR TITLE
Fix the issue where affected_name is always displayed as undefined on the Vulnerability page.

### DIFF
--- a/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityPageView.jsx
@@ -29,7 +29,7 @@ export function VulnerabilityPageView(props) {
           onClick={() => navigate(hrefToPackagePage)}
           sx={{ color: "text.primary", cursor: "pointer" }}
         >
-          {`${matchedVulnPackage.name}:${matchedVulnPackage.ecosystem}`}
+          {`${matchedVulnPackage.affected_name}:${matchedVulnPackage.ecosystem}`}
         </Link>
         <Typography sx={{ color: "text.primary" }}>{vuln.title}</Typography>
       </Breadcrumbs>

--- a/web/src/pages/Vulnerability/VulnerabilityView.jsx
+++ b/web/src/pages/Vulnerability/VulnerabilityView.jsx
@@ -25,7 +25,7 @@ export function VulnerabilityView(props) {
   const actionByFixedVersions = createActionByFixedVersions(
     affectedVersions,
     patchedVersions,
-    matchedVulnPackage?.name ?? "",
+    matchedVulnPackage?.affected_name ?? "",
   );
   const actions = [actionByFixedVersions, ...vulnActions];
 


### PR DESCRIPTION
## PR の目的
- VulnerabilityPageView.jsx、VulnerabilityView.jsxにおいて、matchedVulnPackage.affected_nameを参照するように修正（挙動確認済み）

## 経緯・意図・意思決定
- Vulnerabilityページにおいてaffected_name:ecosystemのaffected_name部分が常にundefinedと表示されていたため。
