### PR TITLE
fix-os-lang-package-detection and test code

### DIFF
--- a/api/app/sbom/parser/os_purl_utils.py
+++ b/api/app/sbom/parser/os_purl_utils.py
@@ -1,0 +1,42 @@
+"""
+Utility functions for handling and identifying OS-related Package URLs.
+
+This module provides functions to determine if a package URL (purl) is associated with
+an operating system package, and defines the recognized OS package types (apk, deb, rpm).
+"""
+
+from packageurl import PackageURL
+
+"""
+Common OS package PURL.type:
+- apk: Alpine Linux, Chainguard, Minimos, Wolfi
+- deb: Debian, Ubuntu, Echo
+- rpm: Alma, Amazon, AzureLinux, CentOS, Fedora, Oracle, RedHat, Rocky, openSUSE,
+      openSUSE-leap, openSUSE-tumbleweed, SLEM, SLES, Bottlerocket, CBL-Mariner, Photon
+"""
+
+OS_TYPE_PURL_TYPES = ["apk", "deb", "rpm"]
+
+
+def is_os_purl(purl: PackageURL | None) -> bool:
+    """
+    Determines whether a package URL represents an OS package.
+
+    Args:
+        purl: PackageURL object to evaluate
+
+    Returns:
+        True if the package is an OS package, False otherwise
+
+    Notes:
+        - Returns True if purl.type is in OS_TYPE_PURL_TYPES (apk, deb, rpm)
+        - Returns False if purl is None
+    """
+    if not purl:
+        return False
+
+    # Check if the package URL type matches any known OS package type
+    if purl.type in OS_TYPE_PURL_TYPES:
+        return True
+    else:
+        return False

--- a/api/app/sbom/parser/trivy_cdx_parser.py
+++ b/api/app/sbom/parser/trivy_cdx_parser.py
@@ -10,6 +10,7 @@ from packageurl import PackageURL
 
 from app.sbom.parser.artifact import Artifact
 from app.sbom.parser.debug_info_outputer import error_message
+from app.sbom.parser.os_purl_utils import is_os_purl
 from app.sbom.parser.sbom_info import SBOMInfo
 from app.sbom.parser.sbom_parser import (
     SBOM,
@@ -90,17 +91,18 @@ class TrivyCDXParser(SBOMParser):
 
             pkg_info = self.purl.type
             pkg_mgr = ""
+
             if self.targets:
                 mgr = self._find_pkg_mgr(components_map, [t.ref for t in self.targets])
                 if not mgr:
                     pass
-                elif mgr.trivy_class == "os-pkgs":
+                elif is_os_purl(self.purl):
                     distro = (
                         self.purl.qualifiers.get("distro")
                         if isinstance(self.purl.qualifiers, dict)
                         else ""
                     )
-                    pkg_info = self._fix_distro(distro) if distro else ""
+                    pkg_info = self._fix_distro(distro) if distro else self.purl.type
                 else:
                     pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
 

--- a/api/app/sbom/parser/trivy_cdx_parser.py
+++ b/api/app/sbom/parser/trivy_cdx_parser.py
@@ -92,19 +92,18 @@ class TrivyCDXParser(SBOMParser):
             pkg_info = self.purl.type
             pkg_mgr = ""
 
-            if self.targets:
-                mgr = self._find_pkg_mgr(components_map, [t.ref for t in self.targets])
-                if not mgr:
-                    pass
-                elif is_os_purl(self.purl):
-                    distro = (
-                        self.purl.qualifiers.get("distro")
-                        if isinstance(self.purl.qualifiers, dict)
-                        else ""
-                    )
-                    pkg_info = self._fix_distro(distro) if distro else self.purl.type
-                else:
-                    pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
+            if is_os_purl(self.purl):
+                distro = (
+                    self.purl.qualifiers.get("distro")
+                    if isinstance(self.purl.qualifiers, dict)
+                    else ""
+                )
+                pkg_info = self._fix_distro(distro) if distro else self.purl.type
+
+            elif self.targets and (
+                mgr := self._find_pkg_mgr(components_map, [t.ref for t in self.targets])
+            ):
+                pkg_mgr = mgr.properties.get("aquasecurity:trivy:Type", "")
 
             return {
                 "pkg_name": pkg_name,

--- a/api/app/sbom/parser/trivy_cdx_parser.py
+++ b/api/app/sbom/parser/trivy_cdx_parser.py
@@ -89,7 +89,7 @@ class TrivyCDXParser(SBOMParser):
                     source_name = str(value).casefold()
                     break
 
-            pkg_info = self.purl.type
+            ecosystem = str(self.purl.type).casefold()
             pkg_mgr = ""
 
             if is_os_purl(self.purl):
@@ -98,20 +98,17 @@ class TrivyCDXParser(SBOMParser):
                     if isinstance(self.purl.qualifiers, dict)
                     else ""
                 )
-                pkg_info = self._fix_distro(distro) if distro else self.purl.type
-                pkg_info = str(pkg_info).casefold()
+                ecosystem = str(self._fix_distro(distro) if distro else self.purl.type).casefold()
 
             elif self.targets and (
                 mgr := self._find_pkg_mgr(components_map, [t.ref for t in self.targets])
             ):
                 pkg_mgr = str(mgr.properties.get("aquasecurity:trivy:Type", "")).casefold()
 
-            pkg_info = str(pkg_info).casefold()
-
             return {
                 "pkg_name": pkg_name,
                 "source_name": source_name,
-                "ecosystem": pkg_info,
+                "ecosystem": ecosystem,
                 "pkg_mgr": pkg_mgr,
             }
 

--- a/api/app/tests/unittests/test_os_purl_utils.py
+++ b/api/app/tests/unittests/test_os_purl_utils.py
@@ -73,4 +73,3 @@ class TestOsPurlUtils:
 
         # Then
         assert result is False
-        assert result is False

--- a/api/app/tests/unittests/test_os_purl_utils.py
+++ b/api/app/tests/unittests/test_os_purl_utils.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for os_purl_utils.py module.
+
+This module tests the functionality for identifying OS-related Package URLs.
+"""
+
+import pytest
+from packageurl import PackageURL
+
+from app.sbom.parser.os_purl_utils import is_os_purl
+
+
+class TestOsPurlUtils:
+
+    def test_it_should_return_false_when_input_is_none(self):
+
+        # Given
+        input_value = None
+
+        # When
+        result = is_os_purl(input_value)
+
+        # Then
+        assert result is False
+
+    def test_it_should_return_true_for_apk_package_type(self):
+
+        # Given
+        purl = PackageURL.from_string("pkg:apk/alpine/alpine-keys@2.5-r0?arch=x86_64&distro=3.22.0")
+
+        # When
+        result = is_os_purl(purl)
+
+        # Then
+        assert result is True
+
+    def test_it_should_return_true_for_deb_package_type(self):
+        # Given
+        purl = PackageURL.from_string("pkg:deb/ubuntu/apt@2.8.3?arch=amd64&distro=ubuntu-24.04")
+
+        # When
+        result = is_os_purl(purl)
+
+        # Then
+        assert result is True
+
+    def test_it_should_return_true_for_rpm_package_type(self):
+        # Given
+        purl = PackageURL.from_string(
+            "pkg:rpm/rocky/alternatives@1.24-1.el9?arch=x86_64&distro=rocky-9.3"
+        )
+
+        # When
+        result = is_os_purl(purl)
+
+        # Then
+        assert result is True
+
+    @pytest.mark.parametrize(
+        "purl_str",
+        [
+            "pkg:npm/web@0.1.0",
+            "pkg:pypi/markupsafe@2.0.1",
+            "pkg:golang/github.com/chai2010/gettext-go@v1.0.2",
+        ],
+    )
+    def test_it_should_return_false_for_non_os_package_types(self, purl_str: str):
+        # Given
+        purl = PackageURL.from_string(purl_str)
+
+        # When
+        result = is_os_purl(purl)
+
+        # Then
+        assert result is False
+        assert result is False


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- SBOM解析時にOS PackageをLangと誤判定するケースの対策として、SBOMアップロード時のOSpackage判定をpurl.typeで行うように修正
- purl.typeがOS_TYPEのものと一致するか判定するos_purl_utils.pyを追加
- また、distroがないOS Packageに関してはecosystemをpurl.typeから取得するように修正

<!-- I want to review in Japanese. -->
