### PR TITLE
refresh package_version in upload sbom

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1292,6 +1292,7 @@ def apply_service_packages(
             db, package_version_id
         )
         for threat in threats:
+            db.refresh(threat.package_version)
             ticket_business.fix_ticket_by_threat(db, threat)
     db.flush()
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- 同じSBOM「misp-cycclondx.json」をTCに2回アップロードした際、1回目アップロードした時のチケット数が、アップロード直後よい2回目アップロード後の方が多い問題を修正する
  - [原因]
dependencyをDBに格納後にTicketを生成する際、ORMマッピングによりPackageVersionからdependencyを取得しようとしたが、取得できなかった。
  - [対策]
問題となる処理の前に、PackageVersionに対して`db.refresh()`を実行することで、PackageVersionオブジェクトに追加したdependencyを読み込んでおく

## 経緯・意図・意思決定


<!-- I want to review in Japanese. -->
