### PR TITLE
fix syft_cdx_parser.py and add test

### DIFF
--- a/api/app/sbom/parser/syft_cdx_parser.py
+++ b/api/app/sbom/parser/syft_cdx_parser.py
@@ -97,14 +97,14 @@ class SyftCDXParser(SBOMParser):
                 return None
             pkg_name = (
                 self.group + "/" + self.name if self.group else self.name
-            )  # given by syft. may include namespace in some case.
+            ).casefold()  # given by syft. may include namespace in some case.
             distro = (
                 self.purl.qualifiers.get("distro")
                 if self.purl and isinstance(self.purl.qualifiers, dict)
                 else None
             )
-            pkg_info = distro if distro else self.purl.type
-            pkg_mgr = self.mgr_info.name if self.mgr_info else ""
+            pkg_info = str(distro).casefold() if distro else str(self.purl.type).casefold()
+            pkg_mgr = (self.mgr_info.name).casefold() if self.mgr_info else ""
 
             return {"pkg_name": pkg_name, "ecosystem": pkg_info, "pkg_mgr": pkg_mgr}
 

--- a/api/app/tests/unittests/test_syft_cdx_parser.py
+++ b/api/app/tests/unittests/test_syft_cdx_parser.py
@@ -1,0 +1,102 @@
+from app.sbom.parser.sbom_info import SBOMInfo
+from app.sbom.parser.syft_cdx_parser import SyftCDXParser
+
+
+class TestSyftCDXParser:
+    def test_it_should_unescape_purl_and_extract_correct_package_name_and_ecosystem(self):
+        sbom = {
+            "metadata": {
+                "component": {
+                    "bom-ref": "root-app",
+                    "type": "application",
+                    "name": "sample target1",
+                }
+            },
+            "components": [
+                {
+                    "bom-ref": "root-app",
+                    "type": "application",
+                    "name": "sample target1",
+                    "properties": [
+                        {"name": "syft:package:type", "value": "npm"},
+                        {"name": "syft:package:class", "value": "lang-pkgs"},
+                    ],
+                },
+                {
+                    "bom-ref": "pkg:npm/%40babel/code-frame@7.0.0",
+                    "type": "library",
+                    "name": "@babel/code-frame",
+                    "version": "7.0.0",
+                    "purl": "pkg:npm/%40babel/code-frame@7.0.0",
+                    "group": "",
+                    "properties": [
+                        {"name": "syft:package:id", "value": "@babel/code-frame@7.0.0"},
+                        {"name": "syft:package:type", "value": "npm"},
+                    ],
+                },
+            ],
+            "dependencies": [
+                {
+                    "ref": "root-app",
+                    "dependsOn": ["pkg:npm/%40babel/code-frame@7.0.0"],
+                }
+            ],
+        }
+        sbom_info = SBOMInfo(
+            spec_name="CycloneDX",
+            spec_version="1.5",
+            tool_name="syft",
+            tool_version="1.0.0",
+        )
+        artifacts = SyftCDXParser.parse_sbom(sbom, sbom_info)
+        assert len(artifacts) == 1
+        artifact = artifacts[0]
+        assert artifact.package_name == "@babel/code-frame"
+
+    def make_sbom_pyjwt(self):
+        return {
+            "metadata": {
+                "component": {
+                    "bom-ref": "root-app",
+                    "type": "application",
+                    "name": "sample target1",
+                }
+            },
+            "components": [
+                {
+                    "bom-ref": "app1",
+                    "type": "application",
+                    "name": "APP1",
+                    "properties": [
+                        {"name": "syft:package:type", "value": "pipenv"},
+                        {"name": "syft:package:class", "value": "lang-pkgs"},
+                    ],
+                },
+                {
+                    "bom-ref": "lib1",
+                    "type": "library",
+                    "name": "PyJWT",
+                    "version": "1.5.3",
+                    "purl": "pkg:pypi/PyJWT@1.5.3",
+                },
+            ],
+            "dependencies": [
+                {"ref": "root-app", "dependsOn": ["app1"]},
+                {"ref": "app1", "dependsOn": ["lib1"]},
+            ],
+        }
+
+    def test_it_should_lowercase_package_name_and_ecosystem_from_sbom_pyjwt(self):
+        sbom = self.make_sbom_pyjwt()
+        sbom_info = SBOMInfo(
+            spec_name="CycloneDX",
+            spec_version="1.5",
+            tool_name="syft",
+            tool_version="1.0.0",
+        )
+        artifacts = SyftCDXParser.parse_sbom(sbom, sbom_info)
+        assert len(artifacts) == 1
+        artifact = artifacts[0]
+        # package name and ecosystem name are lowercased
+        assert artifact.package_name == "pyjwt"
+        assert artifact.ecosystem == "pypi"


### PR DESCRIPTION
## PR の目的
- api/app/sbom/parser/syft_cdx_parser.pyに以下の修正を実施
   - pkg_name、pkg_info、pkg_mgrにcasefold()を適用
- api/app/tests/unittests/test_syft_cdx_parser.pyに単体テストを実装
   - SBOM（Software Bill of Materials）内のpurlがエスケープされている場合でも、正しくパッケージ名（@babel/code-frame）を抽出できることを検証
   - SBOM内のパッケージ名やエコシステム名（例: PyJWT, pypi）が大文字・小文字混在でも、パーサーが小文字に正規化して返すことを検証

## 経緯・意図・意思決定
- SBOMファイルのmisp-cyclonedx.json内のpypiのpackageで脆弱性を検知できていないものが存在したため
- SBOM投入時のpurl解釈において、エスケープ文字がどうなるか未確認であったため

## 参考文献
- 下記でtrivy_cdx_parser.pyに行った修正と同様の修正を実施
   - https://github.com/nttcom/threatconnectome/pull/814
   - https://github.com/nttcom/threatconnectome/pull/816