### PR TITLE
fix schemas DependencyResponse

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -525,6 +525,7 @@ def get_dependencies(
             ),
             package_version=dependency.package_version.version,
             package_ecosystem=dependency.package_version.package.ecosystem,
+            vuln_matching_ecosystem=dependency.package_version.package.vuln_matching_ecosystem,
         )
         dependency_responses.append(dependency_response)
 
@@ -568,6 +569,7 @@ def get_dependency(
         ),
         package_version=dependency.package_version.version,
         package_ecosystem=dependency.package_version.package.ecosystem,
+        vuln_matching_ecosystem=dependency.package_version.package.vuln_matching_ecosystem,
     )
 
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -391,3 +391,4 @@ class DependencyResponse(ORMModel):
     package_source_name: str | None = None
     package_version: str
     package_ecosystem: str
+    vuln_matching_ecosystem: str

--- a/api/app/tests/requests/pteams/test_pteam_dependencies.py
+++ b/api/app/tests/requests/pteams/test_pteam_dependencies.py
@@ -57,6 +57,7 @@ class TestGetDependency:
         assert data["package_source_name"] == self.dependency1["package_source_name"]
         assert data["package_version"] == self.dependency1["package_version"]
         assert data["package_ecosystem"] == self.dependency1["package_ecosystem"]
+        assert data["vuln_matching_ecosystem"] == self.dependency1["vuln_matching_ecosystem"]
 
     def test_it_should_return_404_when_pteam_id_does_not_exist(self):
         # Given
@@ -182,6 +183,7 @@ class TestGetDependencies:
                 "package_source_name": None,
                 "package_version": self.package_version1.version,
                 "package_ecosystem": self.package1.ecosystem,
+                "vuln_matching_ecosystem": self.package1.vuln_matching_ecosystem,
             },
             {
                 "dependency_id": str(self.dependency2.dependency_id),
@@ -195,6 +197,7 @@ class TestGetDependencies:
                 "package_source_name": None,
                 "package_version": self.package_version1.version,
                 "package_ecosystem": self.package1.ecosystem,
+                "vuln_matching_ecosystem": self.package1.vuln_matching_ecosystem,
             },
             {
                 "dependency_id": str(self.dependency3.dependency_id),
@@ -208,6 +211,7 @@ class TestGetDependencies:
                 "package_source_name": self.package2.source_name,
                 "package_version": self.package_version2.version,
                 "package_ecosystem": self.package2.ecosystem,
+                "vuln_matching_ecosystem": self.package2.vuln_matching_ecosystem,
             },
         ]
 
@@ -237,6 +241,7 @@ class TestGetDependencies:
             "package_source_name": None,
             "package_version": self.package_version1.version,
             "package_ecosystem": self.package1.ecosystem,
+            "vuln_matching_ecosystem": self.package1.vuln_matching_ecosystem,
         }
 
         # When
@@ -268,6 +273,7 @@ class TestGetDependencies:
                 "package_source_name": None,
                 "package_version": self.package_version1.version,
                 "package_ecosystem": self.package1.ecosystem,
+                "vuln_matching_ecosystem": self.package1.vuln_matching_ecosystem,
             },
             {
                 "dependency_id": str(self.dependency2.dependency_id),
@@ -281,6 +287,7 @@ class TestGetDependencies:
                 "package_source_name": None,
                 "package_version": self.package_version1.version,
                 "package_ecosystem": self.package1.ecosystem,
+                "vuln_matching_ecosystem": self.package1.vuln_matching_ecosystem,
             },
             {
                 "dependency_id": str(self.dependency3.dependency_id),
@@ -294,6 +301,7 @@ class TestGetDependencies:
                 "package_source_name": self.package2.source_name,
                 "package_version": self.package_version2.version,
                 "package_ecosystem": self.package2.ecosystem,
+                "vuln_matching_ecosystem": self.package2.vuln_matching_ecosystem,
             },
         ]
 
@@ -332,6 +340,7 @@ class TestGetDependencies:
                 "package_source_name": None,
                 "package_version": package_version.version,
                 "package_ecosystem": package.ecosystem,
+                "vuln_matching_ecosystem": package.vuln_matching_ecosystem,
             }
             expected_dependencies.append(expected_dependency)
 


### PR DESCRIPTION
## PR の目的
- ユーザーからどのエコシステムを用いてマッチングしているかを下記APIで確認できるように修正
   - Get /pteam/{pteam_id}/dependencies
   - Get /pteam/{pteam_id}/dependencies/{dependency_id}

- 上記スキーマ変更に伴い下記ファイルのテスト修正（テストpass確認済み）
   - test_pteam_dependensies.py

## 経緯・意図・意思決定
- 従来のecosystemとは別に、脆弱性とマッチングするためのvuln_matching_ecosystemを内部的に作成したため


