### PR TITLE
fix(drawer): モバイルでナビゲーション項目クリック後にドロワーが閉じない問題を修正

### DIFF
--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -8,6 +8,7 @@ import {
   Typography,
   useMediaQuery,
   useTheme,
+  Box,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { useEffect } from "react";
@@ -101,8 +102,14 @@ export function Drawer() {
           {drawerTitle}
         </Typography>
       </DrawerHeader>
-      <List>
-        <>
+      <Box
+        onClick={() => {
+          if (isSmDown) {
+            dispatch(setDrawerOpen(false));
+          }
+        }}
+      >
+        <List>
           <StyledListItemButton
             onClick={() => navigate("/?" + queryParams)}
             selected={locationReader.isStatusPage()}
@@ -121,19 +128,19 @@ export function Drawer() {
             </StyledListItemIcon>
             <ListItemText>Team</ListItemText>
           </StyledListItemButton>
-        </>
-        {/* Vulns */}
-        <StyledListItemButton
-          onClick={() => navigate("/vulns?" + queryParams)}
-          selected={locationReader.isVulnsPage()}
-        >
-          <StyledListItemIcon>
-            <TopicIcon />
-          </StyledListItemIcon>
-          <ListItemText>Vulns</ListItemText>
-        </StyledListItemButton>
-        {/* Vulnerabilities -- not listed on drawer, currently */}
-      </List>
+          {/* Vulns */}
+          <StyledListItemButton
+            onClick={() => navigate("/vulns?" + queryParams)}
+            selected={locationReader.isVulnsPage()}
+          >
+            <StyledListItemIcon>
+              <TopicIcon />
+            </StyledListItemIcon>
+            <ListItemText>Vulns</ListItemText>
+          </StyledListItemButton>
+          {/* Vulnerabilities -- not listed on drawer, currently */}
+        </List>
+      </Box>
     </MuiDrawer>
   );
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

モバイルデバイス（スマートフォンなど）でのユーザー体験を向上させるため、ナビゲーションドロワー内の項目をクリックした際に、ドロワーが自動的に閉じるようにします。

## 経緯・意図・意思決定

### 経緯

現状の実装では、モバイル表示時にドロワー内のナビゲーション項目をクリックしてページが遷移しても、ドロワーが開いたままになっていました。これにより、ユーザーは手動でドロワーを閉じる必要があり、操作性が低い状態でした。

### 意図・意思決定

この問題を解決し、より直感的なモバイル体験を提供することを目的として今回の修正を行いました。

実装にあたり、Reactのイベント伝播（イベントバブリング）を利用するアプローチを採用しました。

  - ドロワー内の`<List>`全体を`<Box>`コンポーネントで囲み、その`<Box>`にドロワーを閉じる共通の`onClick`処理を設定します。
  - 各`<ListItemButton>`は、ページ遷移という固有の`onClick`処理を保持します。

これにより、クリックイベントはまず各ボタンのページ遷移処理を実行し、その後、親要素の`<Box>`へ伝播してドロワーを閉じる処理を実行します。

この方法は、「同じコードを何度も書く」ことを避けつつ（DRY原則）、「共通の関心事」と「個別の関心事」をうまく分離できるため、保守性の観点から最適であると判断しました。

## 参考文献

  * **Material-UI Drawer Component (Temporary drawer)**: このPRで採用したイベントハンドリングの考え方の参考元です。
      * [https://mui.com/material-ui/react-drawer/\#temporary-drawer](https://www.google.com/search?q=https://mui.com/material-ui/react-drawer/%23temporary-drawer)
<!-- I want to review in Japanese. -->