### PR TITLE
feat: Vulnsページのレスポンシブ対応とUI改善

### DIFF
--- a/web/src/pages/VulnManagement/VulnManagementCardList.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementCardList.jsx
@@ -2,6 +2,7 @@ import UpdateIcon from "@mui/icons-material/Update";
 import { Card, CardContent, Chip, Box, Typography, Stack } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
 
 import { cvssProps } from "../../utils/const";
 import { cvssConvertToName } from "../../utils/func";
@@ -9,6 +10,7 @@ import { cvssConvertToName } from "../../utils/func";
 import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 
 export function VulnManagementCardList({ vulns }) {
+  const navigate = useNavigate();
   return (
     <Stack spacing={2} sx={{ mt: 1 }}>
       {vulns?.length > 0 ? (
@@ -30,7 +32,7 @@ export function VulnManagementCardList({ vulns }) {
                 cursor: "pointer",
                 "&:hover": { bgcolor: grey[100] },
               }}
-              onClick={() => window.location.assign(`/vulns/${vuln.vuln_id}`)}
+              onClick={() => navigate(`/vulns/${vuln.vuln_id}`)}
             >
               <CardContent>
                 <Chip label={cveId} size="small" sx={{ borderRadius: 0.5, mr: 1 }} />

--- a/web/src/pages/VulnManagement/VulnManagementCardList.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementCardList.jsx
@@ -1,0 +1,64 @@
+import UpdateIcon from "@mui/icons-material/Update";
+import { Card, CardContent, Chip, Box, Typography, Stack } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import PropTypes from "prop-types";
+
+import { cvssProps } from "../../utils/const";
+import { cvssConvertToName } from "../../utils/func";
+
+import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
+
+export function VulnManagementCardList({ vulns }) {
+  return (
+    <Stack spacing={2} sx={{ mt: 1 }}>
+      {vulns?.length > 0 ? (
+        vulns.map((vuln) => {
+          const cvssScore =
+            vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null
+              ? "N/A"
+              : vuln.cvss_v3_score;
+
+          const cvss = cvssConvertToName(cvssScore);
+          return (
+            <Card
+              key={vuln.vuln_id}
+              variant="outlined"
+              sx={{
+                borderLeft: `solid 5px ${cvssProps[cvss].cvssBgcolor}`,
+                cursor: "pointer",
+                "&:hover": { bgcolor: grey[100] },
+              }}
+              onClick={() => window.location.assign(`/vulns/${vuln.vuln_id}`)}
+            >
+              <CardContent>
+                <Chip
+                  label={vuln.cve_id === null ? "No Known CVE" : vuln.cve_id}
+                  size="small"
+                  sx={{ borderRadius: 0.5 }}
+                />
+                <Box display="flex" alignItems="center" mb={1}>
+                  <Typography
+                    variant="subtitle1"
+                    sx={{ overflowWrap: "anywhere", fontWeight: "bold" }}
+                  >
+                    {vuln.title}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  <UpdateIcon sx={{ mr: 1 }} />
+                  <FormattedDateTimeWithTooltip utcString={vuln.updated_at} />
+                </Box>
+              </CardContent>
+            </Card>
+          );
+        })
+      ) : (
+        <Typography>No vulns</Typography>
+      )}
+    </Stack>
+  );
+}
+
+VulnManagementCardList.propTypes = {
+  vulns: PropTypes.array.isRequired,
+};

--- a/web/src/pages/VulnManagement/VulnManagementCardList.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementCardList.jsx
@@ -19,6 +19,8 @@ export function VulnManagementCardList({ vulns }) {
               : vuln.cvss_v3_score;
 
           const cvss = cvssConvertToName(cvssScore);
+          const cveId = vuln.cve_id === null ? "No Known CVE" : vuln.cve_id;
+
           return (
             <Card
               key={vuln.vuln_id}
@@ -31,19 +33,13 @@ export function VulnManagementCardList({ vulns }) {
               onClick={() => window.location.assign(`/vulns/${vuln.vuln_id}`)}
             >
               <CardContent>
-                <Chip
-                  label={vuln.cve_id === null ? "No Known CVE" : vuln.cve_id}
-                  size="small"
-                  sx={{ borderRadius: 0.5 }}
-                />
-                <Box display="flex" alignItems="center" mb={1}>
-                  <Typography
-                    variant="subtitle1"
-                    sx={{ overflowWrap: "anywhere", fontWeight: "bold" }}
-                  >
-                    {vuln.title}
-                  </Typography>
-                </Box>
+                <Chip label={cveId} size="small" sx={{ borderRadius: 0.5, mr: 1 }} />
+                <Typography
+                  variant="subtitle1"
+                  sx={{ overflowWrap: "anywhere", fontWeight: "bold" }}
+                >
+                  {vuln.title}
+                </Typography>
                 <Box sx={{ display: "flex", alignItems: "center" }}>
                   <UpdateIcon sx={{ mr: 1 }} />
                   <FormattedDateTimeWithTooltip utcString={vuln.updated_at} />

--- a/web/src/pages/VulnManagement/VulnManagementPage.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementPage.jsx
@@ -20,6 +20,7 @@ import { useGetVulnsQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
+import { VulnManagementCardList } from "./VulnManagementCardList";
 import { VulnManagementTable } from "./VulnManagementTable";
 import { VulnSearchModal } from "./VulnSearchModal";
 
@@ -149,7 +150,12 @@ export function VulnManagement() {
           </Button>
         </Box>
       </Box>
-      <VulnManagementTable vulns={vulnsList.vulns} />
+      {isMdDown ? (
+        <VulnManagementCardList vulns={vulnsList.vulns} />
+      ) : (
+        <VulnManagementTable vulns={vulnsList.vulns} />
+      )}
+      {/* <VulnManagementTable vulns={vulnsList.vulns} /> */}
       {filterRow}
       <VulnSearchModal show={searchMenuOpen} onSearch={handleSearch} onCancel={handleCancel} />
     </>

--- a/web/src/pages/VulnManagement/VulnManagementPage.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementPage.jsx
@@ -4,13 +4,12 @@ import {
   Button,
   FormControlLabel,
   Select,
-  TableContainer,
   Typography,
   MenuItem,
   Pagination,
-  Paper,
+  useTheme,
+  useMediaQuery,
 } from "@mui/material";
-import { grey } from "@mui/material/colors";
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -50,6 +49,9 @@ export function VulnManagement() {
     error: vulnsError,
     isLoading: vulnsIsLoading,
   } = useGetVulnsQuery(getVulnsParams, { skip, refetchOnMountOrArgChange: true });
+
+  const theme = useTheme();
+  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
 
   if (skip) return <>Now loading auth token...</>;
   if (vulnsError)
@@ -99,6 +101,8 @@ export function VulnManagement() {
         shape="rounded"
         page={page}
         count={pageMax}
+        siblingCount={isMdDown ? 1 : undefined}
+        boundaryCount={isMdDown ? 0 : undefined}
         onChange={(event, value) => setPage(value)}
       />
       <Select

--- a/web/src/pages/VulnManagement/VulnManagementPage.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementPage.jsx
@@ -155,7 +155,6 @@ export function VulnManagement() {
       ) : (
         <VulnManagementTable vulns={vulnsList.vulns} />
       )}
-      {/* <VulnManagementTable vulns={vulnsList.vulns} /> */}
       {filterRow}
       <VulnSearchModal show={searchMenuOpen} onSearch={handleSearch} onCancel={handleCancel} />
     </>

--- a/web/src/pages/VulnManagement/VulnManagementTable.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementTable.jsx
@@ -1,4 +1,5 @@
 import { Info as InfoIcon } from "@mui/icons-material";
+import UpdateIcon from "@mui/icons-material/Update";
 import {
   Box,
   Table,
@@ -10,14 +11,77 @@ import {
   Tooltip,
   Typography,
   Paper,
+  Card,
+  CardContent,
+  Chip,
+  useTheme,
+  useMediaQuery,
+  Stack,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
+import { cvssProps } from "../../utils/const";
+import { cvssConvertToName } from "../../utils/func";
+
+import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 import { VulnManagementTableRow } from "./VulnManagementTableRow";
 
 export function VulnManagementTable(props) {
   const { vulns } = props;
+  const theme = useTheme();
+  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
+
+  if (isMdDown) {
+    return (
+      <Stack spacing={2} sx={{ mt: 1 }}>
+        {vulns?.length > 0 ? (
+          vulns.map((vuln) => {
+            const cvssScore =
+              vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null
+                ? "N/A"
+                : vuln.cvss_v3_score;
+
+            const cvss = cvssConvertToName(cvssScore);
+            return (
+              <Card
+                key={vuln.vuln_id}
+                variant="outlined"
+                sx={{
+                  borderLeft: `solid 5px ${cvssProps[cvss].cvssBgcolor}`,
+                  cursor: "pointer",
+                  "&:hover": { bgcolor: grey[100] },
+                }}
+                onClick={() => window.location.assign(`/vulns/${vuln.vuln_id}`)}
+              >
+                <CardContent>
+                  <Chip
+                    label={vuln.cve_id === null ? "No Known CVE" : vuln.cve_id}
+                    size="small"
+                    sx={{ borderRadius: 0.5 }}
+                  />
+                  <Box display="flex" alignItems="center" mb={1}>
+                    <Typography
+                      variant="subtitle1"
+                      sx={{ overflowWrap: "anywhere", fontWeight: "bold" }}
+                    >
+                      {vuln.title}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <UpdateIcon sx={{ mr: 1 }} />
+                    <FormattedDateTimeWithTooltip utcString={vuln.updated_at} />
+                  </Box>
+                </CardContent>
+              </Card>
+            );
+          })
+        ) : (
+          <Typography>No vulns</Typography>
+        )}
+      </Stack>
+    );
+  }
 
   return (
     <TableContainer

--- a/web/src/pages/VulnManagement/VulnManagementTable.jsx
+++ b/web/src/pages/VulnManagement/VulnManagementTable.jsx
@@ -1,5 +1,4 @@
 import { Info as InfoIcon } from "@mui/icons-material";
-import UpdateIcon from "@mui/icons-material/Update";
 import {
   Box,
   Table,
@@ -11,77 +10,14 @@ import {
   Tooltip,
   Typography,
   Paper,
-  Card,
-  CardContent,
-  Chip,
-  useTheme,
-  useMediaQuery,
-  Stack,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import PropTypes from "prop-types";
 
-import { cvssProps } from "../../utils/const";
-import { cvssConvertToName } from "../../utils/func";
-
-import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 import { VulnManagementTableRow } from "./VulnManagementTableRow";
 
 export function VulnManagementTable(props) {
   const { vulns } = props;
-  const theme = useTheme();
-  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
-
-  if (isMdDown) {
-    return (
-      <Stack spacing={2} sx={{ mt: 1 }}>
-        {vulns?.length > 0 ? (
-          vulns.map((vuln) => {
-            const cvssScore =
-              vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null
-                ? "N/A"
-                : vuln.cvss_v3_score;
-
-            const cvss = cvssConvertToName(cvssScore);
-            return (
-              <Card
-                key={vuln.vuln_id}
-                variant="outlined"
-                sx={{
-                  borderLeft: `solid 5px ${cvssProps[cvss].cvssBgcolor}`,
-                  cursor: "pointer",
-                  "&:hover": { bgcolor: grey[100] },
-                }}
-                onClick={() => window.location.assign(`/vulns/${vuln.vuln_id}`)}
-              >
-                <CardContent>
-                  <Chip
-                    label={vuln.cve_id === null ? "No Known CVE" : vuln.cve_id}
-                    size="small"
-                    sx={{ borderRadius: 0.5 }}
-                  />
-                  <Box display="flex" alignItems="center" mb={1}>
-                    <Typography
-                      variant="subtitle1"
-                      sx={{ overflowWrap: "anywhere", fontWeight: "bold" }}
-                    >
-                      {vuln.title}
-                    </Typography>
-                  </Box>
-                  <Box sx={{ display: "flex", alignItems: "center" }}>
-                    <UpdateIcon sx={{ mr: 1 }} />
-                    <FormattedDateTimeWithTooltip utcString={vuln.updated_at} />
-                  </Box>
-                </CardContent>
-              </Card>
-            );
-          })
-        ) : (
-          <Typography>No vulns</Typography>
-        )}
-      </Stack>
-    );
-  }
 
   return (
     <TableContainer


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
**タイトル:** feat: 脆弱性管理画面のレスポンシブ対応とUI改善

## PR の目的
脆弱性管理ページ（`/vulns`）のユーザー体験を向上させるため、レスポンシブデザインを導入します。
これにより、PCだけでなくスマートフォンやタブレットなどのモバイル端末でも、画面が最適化され、操作性が向上します。

## 経緯・意図・意思決定

### 経緯
従来の脆弱性管理ページはPCでの閲覧を前提としたテーブルレイアウトで実装されていました。そのため、スマートフォンなどの画面幅が狭いデバイスでは、横スクロールが発生し、一覧性が著しく低いという課題がありました。

### 意図
このプルリクエストは、モバイルファーストの観点からUIを見直し、あらゆるデバイスで快適に脆弱性情報を確認できるようにすることを目的としています。

### 意思決定
* **レスポンシブ対応の実装:**
    * Material-UIの `useMediaQuery` フックを利用して、クライアントの画面幅を判定するロジックを導入しました。
    * 画面幅が中サイズ (`md`) 以下の場合は、今回新規で作成したカード形式のコンポーネント `VulnManagementCardList` を表示します。カード形式にすることで、縦長のモバイル画面でも情報を簡潔に表示できます。
    * 画面幅がそれより大きい場合は、従来通り詳細な情報を一覧できる `VulnManagementTable` を表示します。
<!-- I want to review in Japanese. -->