### PR TITLE
fix multi-target

### DIFF
--- a/api/app/tests/unittests/test_trivy_cdx_parser.py
+++ b/api/app/tests/unittests/test_trivy_cdx_parser.py
@@ -254,5 +254,6 @@ class TestTrivyCDXParser:
         artifact4 = artifacts[1]
         assert artifact4.package_name == "test4_name"
         assert artifact4.package_manager == "pipenv"
-        assert len(artifact4.targets) == 1
-        assert list(artifact4.targets)[0] == ("test2_name", "39.0.2")
+        assert len(artifact4.targets) == 2
+        assert list(artifact4.targets)[0] in {("test1_name", "39.0.2"), ("test2_name", "39.0.2")}
+        assert list(artifact4.targets)[1] in {("test1_name", "39.0.2"), ("test2_name", "39.0.2")}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- SBOMの1件のcomponentに対して複数Targetがある場合、1件しかTargetを表示しない問題を修正する

## 経緯・意図・意思決定
https://github.com/nttcom/threatconnectome/pull/840
において下記仕様とした。
- metadataのcomponentを除外する
- 1つのcomponentに対し、複数のtargetが見つかった場合、依存関係が最も近い１件のみ適用する

しかし、2点目の仕様が誤っていたため、2点目のみ元のロジックに戻す

<!-- I want to review in Japanese. -->
