### PR TITLE
lazy joined PackageVersion

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -374,7 +374,9 @@ class Dependency(Base):
     )
 
     service = relationship("Service", back_populates="dependencies")
-    package_version = relationship("PackageVersion", uselist=False, back_populates="dependencies")
+    package_version = relationship(
+        "PackageVersion", uselist=False, back_populates="dependencies", lazy="joined"
+    )
     tickets = relationship("Ticket", back_populates="dependency", cascade="all, delete-orphan")
 
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- UIでStasusページからPackageページを開くのが、データによっては10秒などかかるため、性能対策する
  - DependencyテーブルからPackageVersionへのrelationshipにおいて、lazy="joined"を指定することにより、Dependency取得時にPackageVersionもJOINして取得するよう変更する。

## 経緯・意図・意思決定




<!-- I want to review in Japanese. -->
