### PR TITLE
fix URL param logic

### DIFF
--- a/web/src/pages/App/Drawer.jsx
+++ b/web/src/pages/App/Drawer.jsx
@@ -33,6 +33,27 @@ export function Drawer() {
   const locationReader = new LocationReader(location);
   const navigate = useNavigate();
 
+  const preserveToggleParams = (currentParams) => {
+    const newParams = new URLSearchParams(currentParams);
+    for (let key of [
+      "page",
+      "perPage",
+      "word",
+      "priorityFilter",
+      "titleWords",
+      "cveIds",
+      "vulnIds",
+      "creatorIds",
+      "updatedAfter",
+      "updatedBefore",
+      "minCvssV3Score",
+      "maxCvssV3Score",
+    ]) {
+      newParams.delete(key);
+    }
+    return newParams;
+  };
+
   const system = useSelector((state) => state.system);
 
   const StyledListItemIcon = styled(ListItemIcon)({
@@ -52,6 +73,7 @@ export function Drawer() {
   });
 
   const queryParams = new URLSearchParams(location.search).toString();
+  const cleanedQueryParams = preserveToggleParams(location.search).toString();
 
   const handleNavigateTop = () => {
     navigate("/?" + queryParams);
@@ -121,7 +143,7 @@ export function Drawer() {
             <ListItemText>Status</ListItemText>
           </StyledListItemButton>
           <StyledListItemButton
-            onClick={() => navigate("/pteam?" + queryParams)}
+            onClick={() => navigate("/pteam?" + cleanedQueryParams)}
             selected={locationReader.isPTeamPage()}
           >
             <StyledListItemIcon>
@@ -131,7 +153,7 @@ export function Drawer() {
           </StyledListItemButton>
           {/* Vulns */}
           <StyledListItemButton
-            onClick={() => navigate("/vulns?" + queryParams)}
+            onClick={() => navigate("/vulns?" + cleanedQueryParams)}
             selected={locationReader.isVulnsPage()}
           >
             <StyledListItemIcon>
@@ -142,7 +164,7 @@ export function Drawer() {
           {/* Vulnerabilities -- not listed on drawer, currently */}
           {/* ToDo */}
           <StyledListItemButton
-            onClick={() => navigate("/todo?" + queryParams)}
+            onClick={() => navigate("/todo?" + cleanedQueryParams)}
             selected={locationReader.isToDoPage()}
           >
             <StyledListItemIcon>

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -329,7 +329,7 @@ export function Status() {
   };
 
   function navigatePackagePage(packageId) {
-    for (let key of ["priorityFilter", "word", "perPage", "page", "allservices"]) {
+    for (let key of ["priorityFilter", "word", "perPage", "page"]) {
       params.delete(key);
     }
     navigate(`/packages/${packageId}?${params.toString()}`);

--- a/web/src/pages/ToDo/ToDoPage.jsx
+++ b/web/src/pages/ToDo/ToDoPage.jsx
@@ -17,6 +17,10 @@ export function ToDo() {
   const params = new URLSearchParams(location.search);
   const myTasks = params.get("mytasks") === "off" ? false : true;
 
+  // ページング情報をクエリパラメータから取得
+  const page = parseInt(params.get("page")) || 0;
+  const rowsPerPage = parseInt(params.get("perPage")) || 10;
+
   const skip = useSkipUntilAuthUserIsReady();
   const {
     data: userMe,
@@ -33,6 +37,18 @@ export function ToDo() {
   if (userMeIsLoading) return <>Now loading UserInfo...</>;
   const pteamIds = userMe?.pteam_roles.map((role) => role.pteam.pteam_id) ?? [];
 
+  const updateParams = (newParams) => {
+    const updatedParams = new URLSearchParams(location.search);
+    Object.entries(newParams).forEach(([key, value]) => {
+      if (value === null || value === undefined || value === "") {
+        updatedParams.delete(key);
+      } else {
+        updatedParams.set(key, value);
+      }
+    });
+    navigate(location.pathname + "?" + updatedParams.toString());
+  };
+
   const handleMyTasksChange = (event) => {
     const newParams = new URLSearchParams(location.search);
 
@@ -42,6 +58,7 @@ export function ToDo() {
       newParams.set("mytasks", "off");
     }
 
+    newParams.delete("page");
     navigate(location.pathname + "?" + newParams.toString());
   };
 
@@ -52,7 +69,13 @@ export function ToDo() {
         <Typography>My tasks</Typography>
       </Box>
 
-      <ToDoTable myTasks={myTasks} pteamIds={pteamIds} />
+      <ToDoTable
+        myTasks={myTasks}
+        pteamIds={pteamIds}
+        page={page}
+        rowsPerPage={rowsPerPage}
+        onPageChange={updateParams}
+      />
     </>
   );
 }

--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -17,9 +17,7 @@ import { errorToString, utcStringToLocalDate } from "../../utils/func";
 
 import { ToDoTableRow } from "./ToDoTableRow";
 
-export function ToDoTable({ myTasks, pteamIds }) {
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
+export function ToDoTable({ myTasks, pteamIds, page, rowsPerPage, onPageChange }) {
   const skip = useSkipUntilAuthUserIsReady();
 
   const {
@@ -60,17 +58,20 @@ export function ToDoTable({ myTasks, pteamIds }) {
   }, [tickets]);
 
   const handleChangePage = (event, newPage) => {
-    setPage(newPage);
+    onPageChange({ page: newPage });
   };
 
   const handleChangeRowsPerPage = (event) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
+    const newRowsPerPage = parseInt(event.target.value, 10);
+    onPageChange({
+      perPage: newRowsPerPage,
+      page: 0, // reset page
+    });
   };
 
-  useEffect(() => {
-    setPage(0);
-  }, [myTasks]);
+  // useEffect(() => {
+  //   setPage(0);
+  // }, [myTasks]);
 
   if (skip) return <></>;
 
@@ -127,4 +128,7 @@ export function ToDoTable({ myTasks, pteamIds }) {
 ToDoTable.propTypes = {
   myTasks: PropTypes.bool.isRequired,
   pteamIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  page: PropTypes.number.isRequired,
+  rowsPerPage: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## PR の目的
- Statusページ、Vulnsページ、ToDoページにて、以下の修正を実施
   - **Statusページ**
      - クエリパラメータに追加するもの -> 無し（現状のまま）
      - Status画面からPackage画面に移動した時に、allservicesをURL上に残すようにする
      - Statusページのトグルボタン（allservices）以外のクエリパラメータ(page、perPage, word)については、Drawerで別画面(Vuln、Team、ToDo画面)に移動するとき、URLから消えるようにする
   - **Vulnsページ**
      - クエリパラメータに追加するもの -> トグルボタン(Related vulns)、ページング処理、Vuln Search
   - **ToDo画面**
      - クエリパラメータに追加するもの -> ページング処理
   - **全部の画面共通**
      - トグルボタン
         - Drawerで別画面(Status、Vuln、Team、ToDo画面)に移動してもクエリパラメータに残す
      - トグルボタン以外のクエリパラメータ
         - Drawerで別画面(Status、Vuln、Team、ToDo画面)に移動した時、消えるようにする

## 経緯・意図・意思決定
- Drawerの各ページのクエリパラメータの仕様が統一されていなかったため