### PR TITLE
feat(Package): レイアウト崩れ修正とそれに伴うChipのTooltip対応

### DIFF
--- a/web/src/pages/Package/PackagePage.jsx
+++ b/web/src/pages/Package/PackagePage.jsx
@@ -1,4 +1,15 @@
-import { Box, Divider, Tab, Tabs, Typography, Chip } from "@mui/material";
+import {
+  Box,
+  Divider,
+  Tab,
+  Tabs,
+  Typography,
+  Chip,
+  Tooltip,
+  ClickAwayListener,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
 import { grey } from "@mui/material/colors";
 import { useState } from "react";
 import { useParams, useLocation } from "react-router-dom";
@@ -81,6 +92,18 @@ export function Package() {
     { skip: !getVulnIdsReady },
   );
 
+  const [open, setOpen] = useState(false);
+
+  const theme = useTheme();
+  const isMdUp = useMediaQuery(theme.breakpoints.up("md"));
+
+  const handleTooltipOpen = () => {
+    if (!isMdUp) setOpen(true);
+  };
+  const handleTooltipClose = () => {
+    if (!isMdUp) setOpen(false);
+  };
+
   if (!pteamId) return <>{noPTeamMessage}</>;
   if (!getVulnIdsReady) return <></>;
   if (pteamError) throw new APIError(errorToString(pteamError), { api: "getPTeam" });
@@ -136,17 +159,45 @@ export function Package() {
       <Box alignItems="center" display="flex" flexDirection="row" mt={3} mb={2}>
         <Box display="flex" flexDirection="column" sx={{ width: "100%" }}>
           <Box>
-            <Chip
-              label={serviceDict.service_name}
-              variant="outlined"
-              sx={{
-                borderRadius: "2px",
-                border: `1px solid ${grey[700]}`,
-                borderLeft: `5px solid ${grey[700]}`,
-                mr: 1,
-                mb: 1,
-              }}
-            />
+            {isMdUp ? (
+              <Tooltip title={serviceDict.service_name}>
+                <Chip
+                  label={serviceDict.service_name}
+                  variant="outlined"
+                  sx={{
+                    borderRadius: "2px",
+                    border: `1px solid ${grey[700]}`,
+                    borderLeft: `5px solid ${grey[700]}`,
+                    mr: 1,
+                    mb: 1,
+                  }}
+                />
+              </Tooltip>
+            ) : (
+              <ClickAwayListener onClickAway={handleTooltipClose}>
+                <Tooltip
+                  onClose={handleTooltipClose}
+                  open={open}
+                  disableFocusListener
+                  disableHoverListener
+                  disableTouchListener
+                  title={serviceDict.service_name}
+                >
+                  <Chip
+                    label={serviceDict.service_name}
+                    variant="outlined"
+                    sx={{
+                      borderRadius: "2px",
+                      border: `1px solid ${grey[700]}`,
+                      borderLeft: `5px solid ${grey[700]}`,
+                      mr: 1,
+                      mb: 1,
+                    }}
+                    onClick={handleTooltipOpen}
+                  />
+                </Tooltip>
+              </ClickAwayListener>
+            )}
           </Box>
           <Box display="flex" alignItems="center" sx={{ mb: 1 }}>
             <Typography variant="h4" sx={{ fontWeight: 900 }}>

--- a/web/src/pages/Package/PackagePage.jsx
+++ b/web/src/pages/Package/PackagePage.jsx
@@ -134,7 +134,7 @@ export function Package() {
   return (
     <>
       <Box alignItems="center" display="flex" flexDirection="row" mt={3} mb={2}>
-        <Box display="flex" flexDirection="column" flexGrow={1}>
+        <Box display="flex" flexDirection="column" sx={{ width: "100%" }}>
           <Box>
             <Chip
               label={serviceDict.service_name}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

パッケージ詳細ページにて、サービスのタイトルが長い場合に発生していたレイアウト崩れ（横スクロール）を修正します。

また、その修正に伴って新たに発生しうる「サービス名`Chip`の省略表示」という課題に対応するため、ツールチップによる全文表示機能を追加します。

## 経緯・意図・意思決定

### 経緯
このコンポーネントの主たる課題は、パッケージタイトルが非常に長い場合にレイアウトが崩れ、ページ全体で横スクロールが発生してしまう点でした。

この問題を解決するため、コンポーネントを囲む`Box`のスタイルを`flexGrow={1}`から`sx={{ width: "100%" }}`に変更しました。これにより、コンポーネントの幅が親要素に制限され、横スクロールは解消されます。

**しかし、この修正により、今度は`Chip`に表示されるサービス名が長い場合に省略表示（`...`）される可能性が新たに生じました。**

### 意図・意思決定
そこでこのPRでは、レイアウト崩れの修正を主目的としつつ、その副作用で低下しかねないユーザビリティを先んじて改善します。

#### 1. レイアウト崩れの修正 (主目的)
長いタイトルでもレイアウトが崩れないよう、`Box`コンポーネントのスタイルを`flexGrow={1}`から`sx={{ width: "100%" }}`へ変更しました。これにより、コンポーネントの幅が親要素の100%に固定され、意図しない横スクロールの発生を防ぎます。

#### 2. サービス名`Chip`の全文表示 (副作用への対応)
レイアウト修正の結果、省略されうるようになったサービス名の全文を確認できるよう、ツールチップ機能を追加しました。

* **PC (画面幅 `md` 以上):** マウスホバーでツールチップを表示します。
* **モバイル (画面幅 `md` 未満):** タップでツールチップの表示/非表示を切り替えます。

### このPRの対象外
* **長押し（ロングプレス）での表示**: 実装が複雑になる点と、ユーザーが機能に気づきにくい可能性がある点を考慮し、今回はよりシンプルなタップ方式を採用しました。
* **`Chip`の複数行表示**: `Chip`の高さを可変にすると、周囲の要素とのレイアウトに不整合が生じる可能性があるため、採用を見送りました。
<!-- I want to review in Japanese. -->