### PR TITLE
Topic/add sort function to get tickets api

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -499,7 +499,7 @@ def get_sorted_paginated_tickets_for_pteams(
         filters.append(models.TicketStatus.vuln_status.notin_(exclude_statuses))
 
     # join with Threat and Vuln tables if needed
-    if fixed_cve_ids or "cve_id" in sort_keys:
+    if fixed_cve_ids or ("cve_id" in sort_keys):
         select_stmt = select_stmt.join(
             models.Threat, models.Threat.threat_id == models.Ticket.threat_id
         ).join(models.Vuln, models.Vuln.vuln_id == models.Threat.vuln_id)

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -54,7 +54,7 @@ def get_tickets(
     - `cve_ids`: List of CVE IDs to filter tickets by.
 
     ### Sorting:
-    - `sort_key`: Sort key for the results.
+    - `sort_keys`: Sort key for the results.
       - Supported values:
         - ssvc_deployer_priority
         - created_at

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -35,7 +35,7 @@ def get_tickets(
     pteam_ids: list[UUID] | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    sort_key: schemas.TicketSortKey = Query(schemas.TicketSortKey.SSVC_DEPLOYER_PRIORITY_DESC),
+    sort_keys: list = Query(default=[]),
     exclude_statuses: list[models.VulnStatusType] | None = Query(None),
     cve_ids: list[str] | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
@@ -54,12 +54,18 @@ def get_tickets(
     - `cve_ids`: List of CVE IDs to filter tickets by.
 
     ### Sorting:
-    - `sort_key`: Sort key for the results. Default is `SSVC_DEPLOYER_PRIORITY_DESC`.
-      Supported values:
-        - `SSVC_DEPLOYER_PRIORITY`: Sort by SSVC deployer priority (ascending).
-        - `SSVC_DEPLOYER_PRIORITY_DESC`: Sort by SSVC deployer priority (descending).
-        - `CREATED_AT`: Sort by created_at (ascending).
-        - `CREATED_AT_DESC`: Sort by created_at (descending).
+    - `sort_key`: Sort key for the results.
+      - Supported values:
+        - ssvc_deployer_priority
+        - created_at
+        - scheduled_at
+        - cve_id
+        - package_name
+        - pteam_name
+        - service_name
+    - If a minus sign is added, the order is descending. if not, the order is ascending.
+        - Example: -ssvc_deployer_priority, -created_at, -scheduled_at etc.
+
 
     ### Pagination:
     - `offset`: Number of items to skip before starting to collect the result set.
@@ -106,7 +112,7 @@ def get_tickets(
             assigned_user_id=assigned_user_id,
             offset=offset,
             limit=limit,
-            sort_key=sort_key,
+            sort_keys=sort_keys,
             exclude_statuses=exclude_statuses,
             cve_ids=cve_ids,
         )

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -35,7 +35,7 @@ def get_tickets(
     pteam_ids: list[UUID] | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
-    sort_keys: list = Query(default=[]),
+    sort_keys: list = Query(["-ssvc_deployer_priority", "-created_at"]),
     exclude_statuses: list[models.VulnStatusType] | None = Query(None),
     cve_ids: list[str] | None = Query(None),
     current_user: models.Account = Depends(get_current_user),

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -347,13 +347,6 @@ class TicketUpdateRequest(ORMModel):
     ticket_safety_impact_change_reason: str | None = None
 
 
-class TicketSortKey(str, Enum):
-    SSVC_DEPLOYER_PRIORITY = "ssvc_deployer_priority"
-    SSVC_DEPLOYER_PRIORITY_DESC = "ssvc_deployer_priority_desc"
-    CREATED_AT = "created_at"
-    CREATED_AT_DESC = "created_at_desc"
-
-
 class PTeamPackagesSummary(ORMModel):
     class PTeamPackageSummary(ORMModel):
         package_id: UUID

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from uuid import uuid4
 
 import pytest

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -352,7 +352,6 @@ class TestGetTickets:
         # Then
         assert response.status_code == 200
         tickets = response.json()["tickets"]
-        print(tickets)
 
         # SSVC priority ascending
         sorted_tickets = sorted(
@@ -361,7 +360,7 @@ class TestGetTickets:
         )
         assert tickets == sorted_tickets
 
-    def test_it_should_sort_decs(self, ticket_setup):
+    def test_it_should_sort_desc(self, ticket_setup):
         # Given
         pteam1 = ticket_setup["pteam1"]
         pteam2 = ticket_setup["pteam2"]

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -433,10 +433,6 @@ class TestGetTickets:
                     t["ssvc_deployer_priority"],
                     99,
                 )
-                - datetime.fromisoformat(t["created_at"].replace("Z", "+00:00")).timestamp(),
-                float("-inf")
-                if t["ticket_status"]["scheduled_at"] is None
-                else datetime.fromisoformat(t["scheduled_at"].replace("Z", "+00:00")).timestamp(),
             ),
         )
         assert tickets == sorted_tickets

--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -29,7 +29,7 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
     pteamIds,
     offset: page * rowsPerPage,
     limit: rowsPerPage,
-    sortKey: "-ssvc_deployer_priority",
+    sortKeys: ["-ssvc_deployer_priority", "-created_at"],
     assignedToMe: myTasks,
     excludeStatuses: ["completed"],
     cveIds: cveIds,

--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -29,7 +29,7 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
     pteamIds,
     offset: page * rowsPerPage,
     limit: rowsPerPage,
-    sortKey: "ssvc_deployer_priority_desc",
+    sortKey: "-ssvc_deployer_priority",
     assignedToMe: myTasks,
     excludeStatuses: ["completed"],
     cveIds: cveIds,

--- a/web/src/services/tcApi.js
+++ b/web/src/services/tcApi.js
@@ -312,7 +312,7 @@ export const tcApi = createApi({
 
     /* Ticket */
     getTickets: builder.query({
-      query: ({ assignedToMe, pteamIds, offset, limit, sortKey, excludeStatuses, cveIds }) => ({
+      query: ({ assignedToMe, pteamIds, offset, limit, sortKeys, excludeStatuses, cveIds }) => ({
         url: "tickets",
         method: "GET",
         params: {
@@ -320,7 +320,7 @@ export const tcApi = createApi({
           pteam_ids: pteamIds,
           offset: offset,
           limit: limit,
-          sort_key: sortKey,
+          sort_keys: sortKeys,
           exclude_statuses: excludeStatuses,
           cve_ids: cveIds,
         },


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
### API
- get_tickets APIに[CVE、パッケージ名、チーム名、サービス名、SSVC、ticket.created_at、 ticketStatus.scheduled_at]でソートできる機能を追加しました
- 配列にソートする文字列を入れ、入れた順番にソートするようにしています
- ソートの文字列の先頭に「-」を入れることで降順ができるようにしています
- 入れることができるソートキーと「-」を入れることの説明をAPIの説明欄に追加しました
- 該当しない文字列が入った時、エラーが出るようにしています

### テスト
- テストを3つ追加しました
- 昇順、降順、複数ソートキー指定のテストを追加しました。


### UI
- web/src/pages/ToDo/ToDoTable.jsx
  - APIの修正に伴い、UI部分も修正しました


<!-- I want to review in Japanese. -->
