### PR TITLE
feat: ToDoテーブルから期日列を削除しパッケージ列を追加

### DIFF
--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -87,7 +87,7 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
                 <TableCell>CVE-ID</TableCell>
                 <TableCell>Team</TableCell>
                 <TableCell>Service</TableCell>
-                <TableCell>Due date</TableCell>
+                <TableCell>Package</TableCell>
                 <TableCell>Assignee</TableCell>
                 <TableCell>SSVC</TableCell>
                 <TableCell />

--- a/web/src/pages/ToDo/ToDoTableRow.jsx
+++ b/web/src/pages/ToDo/ToDoTableRow.jsx
@@ -86,7 +86,8 @@ export function ToDoTableRow(props) {
     return restCount > 0 ? `${first} +${restCount}` : first;
   }, [row.assignee, pteamMembers]);
 
-  const pteamName = pteam?.pteam_name || "";
+  const cveId = vuln?.cve_id || "-";
+  const pteamName = pteam?.pteam_name || "-";
   const matchedService = pteamServices?.find?.((service) => service.service_id === row.service_id);
   const serviceName = matchedService?.service_name || "-";
   const packageName = serviceDependency?.package_name || "-";
@@ -123,9 +124,9 @@ export function ToDoTableRow(props) {
   return (
     <>
       <TableRow hover sx={{ cursor: "pointer" }} onClick={handleRowClick}>
-        <TableCell>{vuln?.cve_id || "-"}</TableCell>
-        <TableCell>{pteamName || "-"}</TableCell>
-        <TableCell>{serviceName || "-"}</TableCell>
+        <TableCell>{cveId}</TableCell>
+        <TableCell>{pteamName}</TableCell>
+        <TableCell>{serviceName}</TableCell>
         <TableCell>{packageName}</TableCell>
         <TableCell>
           <Box sx={{ display: "flex", alignItems: "center" }}>

--- a/web/src/pages/ToDo/ToDoTableRow.jsx
+++ b/web/src/pages/ToDo/ToDoTableRow.jsx
@@ -89,6 +89,7 @@ export function ToDoTableRow(props) {
   const pteamName = pteam?.pteam_name || "";
   const matchedService = pteamServices?.find?.((service) => service.service_id === row.service_id);
   const serviceName = matchedService?.service_name || "-";
+  const packageName = serviceDependency?.package_name || "-";
 
   const handleRowClick = () => {
     if (!serviceDependency) {
@@ -125,7 +126,7 @@ export function ToDoTableRow(props) {
         <TableCell>{vuln?.cve_id || "-"}</TableCell>
         <TableCell>{pteamName || "-"}</TableCell>
         <TableCell>{serviceName || "-"}</TableCell>
-        <TableCell>{row?.dueDate || "-"}</TableCell>
+        <TableCell>{packageName}</TableCell>
         <TableCell>
           <Box sx={{ display: "flex", alignItems: "center" }}>
             <Typography sx={{ pl: 0.5 }}>{assigneeEmails}</Typography>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

ToDoリストのテーブル表示において、一覧性向上のため「期日 (Due date)」列を削除し、新たに対応が必要な「パッケージ (Package)」列を追加します。

## 経緯・意図・意思決定

### 経緯
現在のToDoテーブルにはタスクの期日が表示されていますが、この期日情報はタスク選択後の詳細画面（ドロワーメニュー）でも確認可能です。

一覧画面においては、期日よりも「どのパッケージに脆弱性があるか」という情報の方が、ユーザーが対応すべきタスクを特定する上で優先度が高いと判断しました。
そこで、テーブルの限られたスペースを有効活用し、ユーザーのタスク特定と対応の迅速化を促すため、期日列を削除してパッケージ列を追加することにしました。

### 実装の意思決定
* **表示列の変更:**
    * `ToDoTable.jsx` (テーブルヘッダー) と `ToDoTableRow.jsx` (テーブルの各行) を修正し、「期日」列を削除し、代わりに「パッケージ」列を追加しました。
* **データ取得:**
    * 新たに追加した列に表示するパッケージ名は `serviceDependency` オブジェクトから取得します。データが存在しない場合は、"-" (ハイフン) を表示するフォールバック処理を加えています。
* **リファクタリング:**
    * 可読性向上のため、`ToDoTableRow.jsx` 内で表示する値を一度変数に格納するよう、軽微なリファクタリングを合わせて実施しました。

### 対象外としたこと
* このPRはフロントエンドの表示変更のみを対象としています。APIのレスポンスやデータ構造の変更は含みません。
* **パッケージ名によるソート機能の実装は、本PRの対象外とします（次のPRで対応予定です）。**
<!-- I want to review in Japanese. -->
