### PR TITLE
add syft cdx1.6 support

### DIFF
--- a/api/app/sbom/parser/syft_cdx_parser.py
+++ b/api/app/sbom/parser/syft_cdx_parser.py
@@ -112,13 +112,14 @@ class SyftCDXParser(SBOMParser):
     def parse_sbom(cls, sbom: SBOM, sbom_info: SBOMInfo) -> list[Artifact]:
         if (
             sbom_info.spec_name != "CycloneDX"
-            or sbom_info.spec_version not in {"1.4", "1.5"}
+            or sbom_info.spec_version not in {"1.4", "1.5", "1.6"}
             or sbom_info.tool_name != "syft"
         ):
             raise ValueError(f"Not supported: {sbom_info}")
         actual_parse_func = {
             "1.4": cls.parse_func_1_4,
             "1.5": cls.parse_func_1_4,
+            "1.6": cls.parse_func_1_4,
         }.get(sbom_info.spec_version)
         if not actual_parse_func:
             raise ValueError("Internal error: actual_parse_func not found")

--- a/api/app/tests/unittests/test_syft_cdx_parser.py
+++ b/api/app/tests/unittests/test_syft_cdx_parser.py
@@ -100,3 +100,17 @@ class TestSyftCDXParser:
         # package name and ecosystem name are lowercased
         assert artifact.package_name == "pyjwt"
         assert artifact.ecosystem == "pypi"
+
+    def test_it_should_parse_sbom_with_spec_version_1_6(self):
+        sbom = self.make_sbom_pyjwt()
+        sbom_info = SBOMInfo(
+            spec_name="CycloneDX",
+            spec_version="1.6",
+            tool_name="syft",
+            tool_version="1.0.0",
+        )
+        artifacts = SyftCDXParser.parse_sbom(sbom, sbom_info)
+        assert len(artifacts) == 1
+        artifact = artifacts[0]
+        assert artifact.package_name == "pyjwt"
+        assert artifact.ecosystem == "pypi"


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- syftで作成したcdxのバージョン1.6に対応
- 調査の結果1.5とのTCで扱う上の差分はないことがわかったため、従来のparse用関数を適用している。

<!-- I want to review in Japanese. -->
