### PR TITLE
feat(ToDo): ToDoテーブルにソート機能のUIを追加

### DIFF
--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -80,6 +80,16 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
     setPage(0);
   };
 
+  const headCells = [
+    { id: "cve", label: "CVE", isSortable: false },
+    { id: "team", label: "Team", isSortable: false },
+    { id: "service", label: "Service", isSortable: false },
+    { id: "package", label: "Package", isSortable: false },
+    { id: "assignee", label: "Assignee", isSortable: false },
+    { id: "ssvc", label: "SSVC", isSortable: true },
+    { id: "actions", label: "", isSortable: false },
+  ];
+
   useEffect(() => {
     setPage(0);
   }, [myTasks, setPage]);
@@ -95,26 +105,29 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
           <Table size="small">
             <TableHead>
               <TableRow>
-                <TableCell>CVE-ID</TableCell>
-                <TableCell>Team</TableCell>
-                <TableCell>Service</TableCell>
-                <TableCell>Package</TableCell>
-                <TableCell>Assignee</TableCell>
-                <TableCell>
-                  <TableSortLabel
-                    active={orderBy === "ssvc"}
-                    direction={orderBy === "ssvc" ? order : "asc"}
-                    onClick={(event) => handleRequestSort(event, "ssvc")}
+                {headCells.map((headCell) => (
+                  <TableCell
+                    key={headCell.id}
+                    sortDirection={orderBy === headCell.id ? order : false}
                   >
-                    SSVC
-                    {orderBy === "ssvc" ? (
-                      <Box component="span" sx={visuallyHidden}>
-                        {order === "desc" ? "sorted descending" : "sorted ascending"}
-                      </Box>
-                    ) : null}
-                  </TableSortLabel>
-                </TableCell>
-                <TableCell />
+                    {headCell.isSortable ? (
+                      <TableSortLabel
+                        active={orderBy === headCell.id}
+                        direction={orderBy === headCell.id ? order : "asc"}
+                        onClick={(event) => handleRequestSort(event, headCell.id)}
+                      >
+                        {headCell.label}
+                        {orderBy === headCell.id ? (
+                          <Box component="span" sx={visuallyHidden}>
+                            {order === "desc" ? "sorted descending" : "sorted ascending"}
+                          </Box>
+                        ) : null}
+                      </TableSortLabel>
+                    ) : (
+                      headCell.label
+                    )}
+                  </TableCell>
+                ))}
               </TableRow>
             </TableHead>
             <TableBody>

--- a/web/src/pages/ToDo/ToDoTable.jsx
+++ b/web/src/pages/ToDo/ToDoTable.jsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import Paper from "@mui/material/Paper";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -6,6 +7,8 @@ import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import { visuallyHidden } from "@mui/utils";
 import PropTypes from "prop-types";
 import { useState, useMemo, useEffect } from "react";
 
@@ -19,6 +22,9 @@ import { ToDoTableRow } from "./ToDoTableRow";
 
 export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [order, setOrder] = useState("asc");
+  const [orderBy, setOrderBy] = useState("ssvc");
+
   const skip = useSkipUntilAuthUserIsReady();
 
   const {
@@ -59,6 +65,12 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
     }));
   }, [tickets]);
 
+  const handleRequestSort = (event, property) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
+  };
+
   const handleChangePage = (event, newPage) => {
     setPage(newPage);
   };
@@ -73,7 +85,6 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
   }, [myTasks, setPage]);
 
   if (skip) return <></>;
-
   if (ticketsError) throw new APIError(errorToString(ticketsError), { api: "getTickets" });
   if (ticketsIsLoading) return <>Now loading Tickets...</>;
 
@@ -89,7 +100,20 @@ export function ToDoTable({ myTasks, pteamIds, cveIds, page, setPage }) {
                 <TableCell>Service</TableCell>
                 <TableCell>Package</TableCell>
                 <TableCell>Assignee</TableCell>
-                <TableCell>SSVC</TableCell>
+                <TableCell>
+                  <TableSortLabel
+                    active={orderBy === "ssvc"}
+                    direction={orderBy === "ssvc" ? order : "asc"}
+                    onClick={(event) => handleRequestSort(event, "ssvc")}
+                  >
+                    SSVC
+                    {orderBy === "ssvc" ? (
+                      <Box component="span" sx={visuallyHidden}>
+                        {order === "desc" ? "sorted descending" : "sorted ascending"}
+                      </Box>
+                    ) : null}
+                  </TableSortLabel>
+                </TableCell>
                 <TableCell />
               </TableRow>
             </TableHead>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 目的
ToDoリストのテーブルに、昇順・降順で並び替えるためのソート機能UIを追加します。

## 概要
一覧性を向上させるソート機能のUIを先行して実装しました。

実装にあたり、将来の保守性を高めるため、テーブルヘッダーを **`headCells`** という設定配列から動的に生成するようにリファクタリングしています。

現在ソート表示は「SSVC」列のみですが、他の列（例：「Service」）にソート機能を追加する場合は、`ToDoTable.jsx`内の`headCells`配列で、対象オブジェクトの **`isSortable`** プロパティを **`true`** に変更するだけで対応できます。

## 引き継ぎ事項
このPRはUIの先行実装（モック）のため、**データの並び替えロジックは対象外**です。そのため、UIを操作しても実際には行はソートされません。

後続のタスクとして、UIの状態である `order` と `orderBy` に連動するデータ並び替え処理の実装をお願いいたします。

## 参考文献
- [[Material-UI Table | Sorting](https://mui.com/material-ui/react-table/#sorting-amp-selecting)]

<!-- I want to review in Japanese. -->