### PR TITLE
bugfix/fix upload tab

### DIFF
--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -188,6 +188,10 @@ export function Status() {
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [pteamId, pteam, serviceId, isActiveAllServicesMode]);
 
+  useEffect(() => {
+    setIsActiveUploadMode(0); // reset upload mode
+  }, [pteamId])
+
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
   const isSmDown = useMediaQuery(theme.breakpoints.down("sm"));

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -190,7 +190,7 @@ export function Status() {
 
   useEffect(() => {
     setIsActiveUploadMode(0); // reset upload mode
-  }, [pteamId])
+  }, [pteamId]);
 
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down("md"));


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- Statusページにおいて、Uploadタブを開いた状態で別のチームに切り替えると、タブヘッダはサービスを選択しているがタブの内容はUploadの表示となる問題について修正しました
- `isActiveUploadMode`の値が1の時、「Drop SBOM file here」を表示し、0の時は表示しません。URLから取得するpteamIdが変わった時にsetIsActiveUploadMode()に0を入れて「Drop SBOM file here」を表示しないようにしました

<!-- I want to review in Japanese. -->
