### PR TITLE
fix truncation of long version strings in package details

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -19,22 +19,34 @@ export function PackageView(props) {
       <Typography variant="h5">{nameWithEcosystem}</Typography>
       <Grid container>
         {/* affected versions */}
-        <Grid item xs={12} md={6} sx={{ display: "flex", alignItems: "center" }}>
+        <Grid
+          item
+          xs={12}
+          md={6.5}
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+          }}
+        >
           {affectedVersions.length > 0 ? (
             affectedVersions.map((affectedVersion) => (
               <Box
                 key={affectedVersion}
-                sx={{ display: "flex", alignItems: "center", minWidth: 0 }}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  mb: 1,
+                  minWidth: 0,
+                  height: "48px",
+                }}
               >
-                <WarningIcon sx={{ fontSize: 32, color: yellow[900] }} />
+                <WarningIcon sx={{ fontSize: 32, color: yellow[900], mr: 1 }} />
                 <Tooltip title={affectedVersion} placement="right">
                   <Typography
-                    noWrap
                     sx={{
                       fontSize: 32,
-                      mx: 2,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
+                      overflowWrap: "break-word",
                       display: "block",
                     }}
                   >
@@ -53,13 +65,31 @@ export function PackageView(props) {
           )}
         </Grid>
         {/* patched versions */}
-        <Grid item xs={12} md={6} sx={{ display: "flex", alignItems: "center" }}>
+        <Grid
+          item
+          xs={12}
+          md={5.5}
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-start",
+          }}
+        >
           {fixedVersions.length > 0 ? (
             fixedVersions.map((fixedVersion) => (
-              <Box key={fixedVersion} sx={{ display: "flex", alignItems: "center" }}>
-                <RecommendIcon sx={{ fontSize: 32, color: green[500] }} />
+              <Box
+                key={fixedVersion}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  mb: 1,
+                  minWidth: 0,
+                  height: "48px",
+                }}
+              >
+                <RecommendIcon sx={{ fontSize: 32, color: green[500], mr: 1 }} />
                 <Tooltip title={fixedVersion} placement="right">
-                  <Typography noWrap sx={{ fontSize: 32, mx: 2 }}>
+                  <Typography sx={{ fontSize: 32, overflowWrap: "break-word", display: "block" }}>
                     {fixedVersion}
                   </Typography>
                 </Tooltip>


### PR DESCRIPTION
## PR の目的
- package画面にてAffected versionやPatched versionが長い場合にdetailsボタン内の表示を下のように列で表示するように修正
<img width="1885" height="889" alt="image" src="https://github.com/user-attachments/assets/ecdd5774-b784-490c-af07-5bf4d12cbcac" />
<img width="1883" height="885" alt="image" src="https://github.com/user-attachments/assets/c1d58806-3375-4328-9d36-8fba097906f6" />

## 経緯・意図・意思決定
- package画面にてAffected versionやPatched versionが長い場合にdetailsボタン内の表示が下記画面のように表示されていたため
<img width="1873" height="920" alt="image" src="https://github.com/user-attachments/assets/67070525-89ba-4e95-967b-d4f74c285686" />
<img width="1880" height="916" alt="image" src="https://github.com/user-attachments/assets/52a83015-75d9-423a-8cbd-fb429567d22d" />