### PR TITLE
fix the Grid component in PackageView

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -22,7 +22,7 @@ export function PackageView(props) {
         <Grid
           item
           xs={12}
-          md={6.5}
+          md={7}
           sx={{
             display: "flex",
             flexDirection: "column",
@@ -68,7 +68,7 @@ export function PackageView(props) {
         <Grid
           item
           xs={12}
-          md={5.5}
+          md={5}
           sx={{
             display: "flex",
             flexDirection: "column",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- PackageView.jsxのGridコンポーネントにてmdの値を整数に修正

## 経緯・意図・意思決定
- https://github.com/nttcom/threatconnectome/pull/873 で修正したPackageView.jsxのGridコンポーネントにてmdの値を小数点にしていたため（整数推奨）

## 参考文献
https://v5.mui.com/material-ui/react-grid/#how-it-works
<!-- I want to review in Japanese. -->
