### PR TITLE
Fix for UI becoming unresponsive when deleting services with many tickets

### DIFF
--- a/web/src/pages/Status/DeleteServiceIcon.jsx
+++ b/web/src/pages/Status/DeleteServiceIcon.jsx
@@ -24,10 +24,10 @@ export function DeleteServiceIcon(props) {
     setModalOpen(false);
   };
 
-  const handleServiceDeleted = (deletedServiceIds, wasCurrentServiceDeleted) => {
+  const handleServiceDeleted = () => {
     setModalOpen(false);
     if (onServiceDeleted) {
-      onServiceDeleted(deletedServiceIds, wasCurrentServiceDeleted);
+      onServiceDeleted();
     }
   };
 

--- a/web/src/pages/Status/DeleteServiceIcon.jsx
+++ b/web/src/pages/Status/DeleteServiceIcon.jsx
@@ -16,12 +16,19 @@ import dialogStyle from "../../cssModule/dialog.module.css";
 import { PTeamServiceDelete } from "./PTeamServiceDelete";
 
 export function DeleteServiceIcon(props) {
-  const { pteamId } = props;
+  const { pteamId, onServiceDeleted } = props;
 
   const [modalOpen, setModalOpen] = useState(false);
 
   const handleModalClose = () => {
     setModalOpen(false);
+  };
+
+  const handleServiceDeleted = (deletedServiceIds, wasCurrentServiceDeleted) => {
+    setModalOpen(false);
+    if (onServiceDeleted) {
+      onServiceDeleted(deletedServiceIds, wasCurrentServiceDeleted);
+    }
   };
 
   return (
@@ -49,7 +56,7 @@ export function DeleteServiceIcon(props) {
           </Box>
         </DialogTitle>
         <DialogContent>
-          <PTeamServiceDelete pteamId={pteamId} />
+          <PTeamServiceDelete pteamId={pteamId} onServiceDeleted={handleServiceDeleted} />
         </DialogContent>
       </Dialog>
     </>
@@ -57,4 +64,5 @@ export function DeleteServiceIcon(props) {
 }
 DeleteServiceIcon.propTypes = {
   pteamId: PropTypes.string.isRequired,
+  onServiceDeleted: PropTypes.func,
 };

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -81,8 +81,6 @@ export function PTeamServiceDelete(props) {
 
       const deletedServiceIds = new Set(checked.map((service) => service.service_id));
 
-      setChecked([]);
-
       if (wasCurrentServiceDeleted) {
         const remainingServices = services.filter(
           (service) => !deletedServiceIds.has(service.service_id),
@@ -95,6 +93,7 @@ export function PTeamServiceDelete(props) {
         }
         navigate(location.pathname + "?" + params.toString());
       }
+      setChecked([]);
     } catch (error) {
       const serviceCount = checked.length;
       const failureMessage =

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -77,10 +77,21 @@ export function PTeamServiceDelete(props) {
 
       enqueueSnackbar(message, { variant: "success" });
 
+      const wasCurrentServiceDeleted = checked.find((service) => service.service_id === serviceId);
+
       setChecked([]);
 
-      if (checked.find((service) => service.service_id === serviceId)) {
-        params.delete("serviceId");
+      if (wasCurrentServiceDeleted) {
+        const remainingServices = services.filter(
+          (service) =>
+            !checked.some((deletedService) => deletedService.service_id === service.service_id),
+        );
+
+        if (remainingServices.length > 0) {
+          params.set("serviceId", remainingServices[0].service_id);
+        } else {
+          params.delete("serviceId");
+        }
         navigate(location.pathname + "?" + params.toString());
       }
     } catch (error) {

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -22,7 +22,7 @@ import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 
 export function PTeamServiceDelete(props) {
-  const { pteamId } = props;
+  const { pteamId, onServiceDeleted } = props;
   const [checked, setChecked] = useState([]);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -93,6 +93,11 @@ export function PTeamServiceDelete(props) {
         }
         navigate(location.pathname + "?" + params.toString());
       }
+
+      if (onServiceDeleted) {
+        onServiceDeleted(deletedServiceIds, wasCurrentServiceDeleted);
+      }
+
       setChecked([]);
     } catch (error) {
       const serviceCount = checked.length;
@@ -163,4 +168,5 @@ export function PTeamServiceDelete(props) {
 }
 PTeamServiceDelete.propTypes = {
   pteamId: PropTypes.string.isRequired,
+  onServiceDeleted: PropTypes.func,
 };

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -95,7 +95,7 @@ export function PTeamServiceDelete(props) {
       }
 
       if (onServiceDeleted) {
-        onServiceDeleted(deletedServiceIds, wasCurrentServiceDeleted);
+        onServiceDeleted();
       }
 
       setChecked([]);

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -79,11 +79,11 @@ export function PTeamServiceDelete(props) {
 
       const wasCurrentServiceDeleted = checked.find((service) => service.service_id === serviceId);
 
+      const deletedServiceIds = new Set(checked.map((service) => service.service_id));
+
       setChecked([]);
 
       if (wasCurrentServiceDeleted) {
-        const deletedServiceIds = new Set(checked.map((service) => service.service_id));
-
         const remainingServices = services.filter(
           (service) => !deletedServiceIds.has(service.service_id),
         );

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -124,13 +124,19 @@ export function PTeamServiceDelete(props) {
           const labelId = `checkbox-list-label-${service.service_name}`;
           return (
             <ListItem key={service.service_id} disablePadding>
-              <ListItemButton role={undefined} onClick={handleToggle(service)} dense>
+              <ListItemButton
+                role={undefined}
+                onClick={handleToggle(service)}
+                dense
+                disabled={isDeleting}
+              >
                 <ListItemIcon>
                   <Checkbox
                     edge="start"
                     checked={checked.indexOf(service) !== -1}
                     tabIndex={-1}
                     disableRipple
+                    disabled={isDeleting}
                     inputProps={{ "aria-labelledby": labelId }}
                   />
                 </ListItemIcon>

--- a/web/src/pages/Status/PTeamServiceDelete.jsx
+++ b/web/src/pages/Status/PTeamServiceDelete.jsx
@@ -82,9 +82,10 @@ export function PTeamServiceDelete(props) {
       setChecked([]);
 
       if (wasCurrentServiceDeleted) {
+        const deletedServiceIds = new Set(checked.map((service) => service.service_id));
+
         const remainingServices = services.filter(
-          (service) =>
-            !checked.some((deletedService) => deletedService.service_id === service.service_id),
+          (service) => !deletedServiceIds.has(service.service_id),
         );
 
         if (remainingServices.length > 0) {

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -198,7 +198,7 @@ export function Status() {
     setIsActiveUploadMode(0); // reset upload mode
   }, [pteamId]);
 
-  const handleServiceDeleted = (deletedServiceIds, wasCurrentServiceDeleted) => {
+  const handleServiceDeleted = () => {
     // If upload mode is active when service deletion occurs, disable upload mode
     if (isActiveUploadMode === 1) {
       setIsActiveUploadMode(0);

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -198,6 +198,13 @@ export function Status() {
     setIsActiveUploadMode(0); // reset upload mode
   }, [pteamId]);
 
+  const handleServiceDeleted = (deletedServiceIds, wasCurrentServiceDeleted) => {
+    // If upload mode is active when service deletion occurs, disable upload mode
+    if (isActiveUploadMode === 1) {
+      setIsActiveUploadMode(0);
+    }
+  };
+
   const theme = useTheme();
   const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
   const isSmDown = useMediaQuery(theme.breakpoints.down("sm"));
@@ -473,7 +480,7 @@ export function Status() {
         <Box flexGrow={1} />
       </Box>
       <Box display="flex" flexDirection="row-reverse" sx={{ marginTop: 0 }}>
-        <DeleteServiceIcon pteamId={pteamId} />
+        <DeleteServiceIcon pteamId={pteamId} onServiceDeleted={handleServiceDeleted} />
         <FormControlLabel
           control={
             <Android12Switch checked={isActiveAllServicesMode} onChange={handleAllServices} />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- サービス削除処理を下記のように修正
   - 削除するサービスを何も選択していない場合Deleteボタンのアイコンは押せない（非活性状態になっている）
   - １つでもサービスを選択することでDeleteボタンが押せるようになる（活性状態になる）
   - Deleteボタンを押したらDelete処理が終了するまでDeleting文字とくるくる回る進行中のインジケータを表示（MUIのCircularProgressコンポーネントを利用）
   - 複数サービスを選択している場合は、選択したサービス全てが削除されるまで上記状態を継続（Deleting文字とくるくる回る進行中のインジケータ）
   - 選択したすべてのサービスが削除終了したらモーダル閉じて"Remove service(s) succeeded"のSnackbarが出現

## 経緯・意図・意思決定
- サービス削除の際、チケットが多すぎるとUIがビジー状態となり、Deleteボタンを押してもリクエストが発行されたかどうかがUI上では分からなかったため

<!-- I want to review in Japanese. -->
