### PR TITLE
fix params in navigate package page

### DIFF
--- a/web/src/pages/Status/PTeamServicesListModal.jsx
+++ b/web/src/pages/Status/PTeamServicesListModal.jsx
@@ -27,6 +27,7 @@ import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetPTeamServiceThumbnailQuery, useGetPTeamQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
+import { preserveParams } from "../../utils/urlUtils";
 
 const noImageAvailableUrl = "images/no-image-available-720x480.png";
 
@@ -159,11 +160,9 @@ export function PTeamServicesListModal(props) {
   );
 
   const handleNavigatePackage = (serviceId) => {
-    for (let key of ["packageId", "impactFilter", "word", "perPage", "page"]) {
-      params.delete(key);
-    }
-    params.set("serviceId", serviceId);
-    navigate(`/packages/${packageId}?${params.toString()}`);
+    const preservedParams = preserveParams(location.search);
+    preservedParams.set("serviceId", serviceId);
+    navigate(`/packages/${packageId}?${preservedParams.toString()}`);
   };
 
   return (

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -39,7 +39,7 @@ import { useGetPTeamQuery, useGetPTeamPackagesSummaryQuery } from "../../service
 import { APIError } from "../../utils/APIError";
 import { noPTeamMessage, sortedSSVCPriorities, ssvcPriorityProps } from "../../utils/const";
 import { errorToString } from "../../utils/func";
-import { preserveMyTasksParam } from "../../utils/urlUtils";
+import { preserveMyTasksParam, preserveParams } from "../../utils/urlUtils";
 
 import { DeleteServiceIcon } from "./DeleteServiceIcon";
 import { PTeamServiceDetailsResponsive } from "./PTeamServiceDetails/PTeamServiceDetailsResponsive";
@@ -352,10 +352,8 @@ export function Status() {
   };
 
   function navigatePackagePage(packageId) {
-    for (let key of ["priorityFilter", "word", "perPage", "page"]) {
-      params.delete(key);
-    }
-    navigate(`/packages/${packageId}?${params.toString()}`);
+    const preservedParams = preserveParams(location.search);
+    navigate(`/packages/${packageId}?${preservedParams.toString()}`);
   }
 
   const handleNavigateServiceList = (packageId, packageName, serviceIds) => {

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -351,15 +351,18 @@ export function Status() {
     navigate(location.pathname + "?" + params.toString());
   };
 
-  function navigatePackagePage(packageId) {
+  function navigatePackagePage(targetServiceId, packageId) {
     const preservedParams = preserveParams(location.search);
+    preservedParams.set("serviceId", targetServiceId);
+    if (params.get("page")) {
+      preservedParams.set("page", params.get("page"));
+    }
     navigate(`/packages/${packageId}?${preservedParams.toString()}`);
   }
 
   const handleNavigateServiceList = (packageId, packageName, serviceIds) => {
     if (serviceIds.length === 1) {
-      params.set("serviceId", serviceIds[0]);
-      navigatePackagePage(packageId);
+      navigatePackagePage(serviceIds[0], packageId);
     } else {
       setSelectedPackageInfo({
         packageId: packageId,
@@ -370,7 +373,7 @@ export function Status() {
     }
   };
 
-  const handleNavigatePackage = (packageId) => navigatePackagePage(packageId);
+  const handleNavigatePackage = (packageId) => navigatePackagePage(serviceId, packageId);
 
   const handleAllServices = () => {
     setIsActiveUploadMode(0);

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -370,7 +370,8 @@ export function Status() {
     }
   };
 
-  const handleNavigatePackage = (packageId) => navigatePackagePage(serviceId, packageId);
+  const handleNavigatePackage = (targetServiceId, packageId) =>
+    navigatePackagePage(targetServiceId, packageId);
 
   const handleAllServices = () => {
     setIsActiveUploadMode(0);
@@ -572,7 +573,9 @@ export function Status() {
                     >
                       <PTeamStatusCard
                         key={packageInfo.package_id}
-                        onHandleClick={() => handleNavigatePackage(packageInfo.package_id)}
+                        onHandleClick={() =>
+                          handleNavigatePackage(serviceId, packageInfo.package_id)
+                        }
                         pteam={pteam}
                         packageInfo={packageInfo}
                       />

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -354,9 +354,6 @@ export function Status() {
   function navigatePackagePage(targetServiceId, packageId) {
     const preservedParams = preserveParams(location.search);
     preservedParams.set("serviceId", targetServiceId);
-    if (params.get("page")) {
-      preservedParams.set("page", params.get("page"));
-    }
     navigate(`/packages/${packageId}?${preservedParams.toString()}`);
   }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- StatusページでSSVCフィルタを指定した後、ページ遷移でURLからpriorityFilterが消えない場合がある不具合を修正する
  - [現象]
    - StatusページでpriorityFilterを設定した後、All Services ONでサービス2件以上ある行をクリックして表示するサービス選択画面で、さらに1サービス選択すると、priorityFilterが消えない。
  - [原因]
    - PTeamServicesListModal.jsx handleNavigatePackageにおいて、ページ遷移時に不要なURLパラムを削除する際、priorityFilterを指定すべきところを誤ってimpactFilterを指定している
    - 仕様変更に伴いimpactFilterからpriorityFilterに名称変更したが、ここだけ修正が漏れていた。
  - [修正内容]
    - 下記2箇所において、packageページにナビゲートする際、不要になるURLパラムを削除していたが、共通関数preserveParamsを用いて必要なURLパラムだけを残す方式に変更する
      - PTeamServicesListModal.jsx handleNavigatePackage 
      - StatusPage.jsx navigatePackagePage

<!-- I want to review in Japanese. -->
