### PR TITLE
add get insight api

### DIFF
--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -231,7 +231,7 @@ def get_insight(
         ],
         "affected_objects": [
             {
-                "object_category": obj.object_category.value,
+                "object_category": obj.object_category,
                 "name": obj.name,
                 "description": obj.description,
             }

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -198,6 +198,57 @@ def create_insight(
     return schemas.InsightResponse(**insight_base)
 
 
+@router.get("/{ticket_id}/insight", response_model=schemas.InsightResponse)
+def get_insight(
+    ticket_id: UUID,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(database.get_db),
+):
+    if not (ticket := persistence.get_ticket_by_id(db, ticket_id)):
+        raise NO_SUCH_TICKET
+    if not check_pteam_membership(ticket.dependency.service.pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+    if ticket.insight is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No insight found for this ticket"
+        )
+
+    insight = ticket.insight
+
+    response_data = {
+        "ticket_id": ticket_id,
+        "description": insight.description,
+        "reasoning_and_planning": insight.reasoning_and_planning,
+        "created_at": insight.created_at,
+        "updated_at": insight.updated_at,
+        "threat_scenarios": [
+            {
+                "impact_category": scenario.impact_category,
+                "title": scenario.title,
+                "description": scenario.description,
+            }
+            for scenario in insight.threat_scenarios
+        ],
+        "affected_objects": [
+            {
+                "object_category": obj.object_category.value,
+                "name": obj.name,
+                "description": obj.description,
+            }
+            for obj in insight.affected_objects
+        ],
+        "insight_references": [
+            {
+                "link_text": ref.link_text,
+                "url": ref.url,
+            }
+            for ref in insight.insight_references
+        ],
+    }
+
+    return schemas.InsightResponse(**response_data)
+
+
 @router.delete("/{ticket_id}/insight", status_code=status.HTTP_204_NO_CONTENT)
 def delete_insight(
     ticket_id: UUID,

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -671,6 +671,159 @@ class TestCreateInsight:
         assert response.json()["detail"] == "Insight is already registered for this ticket"
 
 
+class TestGetInsight:
+    def test_it_should_get_insight(self, ticket_setup):
+        # Given
+        ticket1 = ticket_setup["ticket1"]
+        ticket_id = ticket1["ticket_id"]
+
+        insight_request = {
+            "description": "Detailed insight description",
+            "reasoning_and_planning": "Comprehensive reasoning and planning",
+            "threat_scenarios": [
+                {
+                    "impact_category": "denial_of_control",
+                    "title": "Scenario 1",
+                    "description": "Description 1",
+                },
+                {
+                    "impact_category": "manipulation_of_view",
+                    "title": "Scenario 2",
+                    "description": "Description 2",
+                },
+            ],
+            "affected_objects": [
+                {
+                    "object_category": "person",
+                    "name": "Object 1",
+                    "description": "Object Description 1",
+                },
+                {
+                    "object_category": "mobile_device",
+                    "name": "Object 2",
+                    "description": "Object Description 2",
+                },
+            ],
+            "insight_references": [
+                {
+                    "link_text": "Reference 1",
+                    "url": "https://example1.com",
+                },
+                {
+                    "link_text": "Reference 2",
+                    "url": "https://example2.com",
+                },
+            ],
+        }
+
+        # Create insight
+        client.post(
+            f"/tickets/{ticket_id}/insight",
+            headers=headers(USER1),
+            json=insight_request,
+        )
+
+        # When
+        response = client.get(
+            f"/tickets/{ticket_id}/insight",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 200
+        response_data = response.json()
+
+        assert response_data["ticket_id"] == ticket_id
+        assert response_data["description"] == insight_request["description"]
+        assert response_data["reasoning_and_planning"] == insight_request["reasoning_and_planning"]
+
+        # Verify threat scenarios
+        assert len(response_data["threat_scenarios"]) == 2
+        for i, scenario in enumerate(response_data["threat_scenarios"]):
+            expected = insight_request["threat_scenarios"][i]
+            assert scenario["impact_category"] == expected["impact_category"]
+            assert scenario["title"] == expected["title"]
+            assert scenario["description"] == expected["description"]
+
+        # Verify affected objects
+        assert len(response_data["affected_objects"]) == 2
+        for i, obj in enumerate(response_data["affected_objects"]):
+            expected = insight_request["affected_objects"][i]
+            assert obj["object_category"] == expected["object_category"]
+            assert obj["name"] == expected["name"]
+            assert obj["description"] == expected["description"]
+
+        # Verify insight references
+        assert len(response_data["insight_references"]) == 2
+        for i, ref in enumerate(response_data["insight_references"]):
+            expected = insight_request["insight_references"][i]
+            assert ref["link_text"] == expected["link_text"]
+            assert ref["url"] == expected["url"]
+
+    def test_it_should_return_404_when_insight_not_exists(self, ticket_setup):
+        # Given
+        ticket1 = ticket_setup["ticket1"]
+        ticket_id = ticket1["ticket_id"]
+
+        # When - get Insight for a ticket that does not have one
+        response = client.get(
+            f"/tickets/{ticket_id}/insight",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        error_data = response.json()
+        assert error_data["detail"] == "No insight found for this ticket"
+
+    def test_it_should_return_403_when_not_pteam_member(self, ticket_setup):
+        # Given
+        ticket1 = ticket_setup["ticket1"]
+        ticket_id = ticket1["ticket_id"]
+
+        # Create insight as USER1 (pteam member)
+        insight_request = {
+            "description": "example insight description",
+            "reasoning_and_planning": "example reasoning and planning",
+            "threat_scenarios": [],
+            "affected_objects": [],
+            "insight_references": [],
+        }
+
+        create_response = client.post(
+            f"/tickets/{ticket_id}/insight",
+            headers=headers(USER1),
+            json=insight_request,
+        )
+        assert create_response.status_code == 200
+
+        # When - USER2 (not a pteam member) tries to get insight
+        response = client.get(
+            f"/tickets/{ticket_id}/insight",
+            headers=headers(USER2),
+        )
+
+        # Then
+        assert response.status_code == 403
+        error_data = response.json()
+        assert error_data["detail"] == "Not a pteam member"
+
+    def test_it_should_return_404_when_ticket_not_exists(self, ticket_setup):
+        # Given
+        non_existent_ticket_id = str(uuid4())
+
+        # When
+        response = client.get(
+            f"/tickets/{non_existent_ticket_id}/insight",
+            headers=headers(USER1),
+        )
+
+        # Then
+        assert response.status_code == 404
+        error_data = response.json()
+        assert error_data["detail"] == "No such ticket"
+
+
 class TestDeleteInsight:
     @pytest.fixture(scope="function", autouse=True)
     def common_setup(self, ticket_setup):


### PR DESCRIPTION
## PR の目的
- Get /tickets/{ticket_id}/insight API の実装
- TestGetInsightの実装
   - test_it_should_get_insight
      - 正常にInsightを取得できることを確認
   - test_it_should_return_404_when_insight_not_exists
      - Insightが存在しないチケットに対して適切なエラーを返すことを確認
   - test_it_should_return_403_when_not_pteam_member
      - PTeamメンバーでないユーザーがアクセスした場合の権限チェックを確認
   - test_it_should_return_404_when_ticket_not_exists
      - 存在しないチケットIDに対して適切なエラーを返すことを確認
