### PR TITLE
Topic/put insight

### DIFF
--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -132,6 +132,27 @@ def create_insight_reference(db: Session, insight_reference: models.InsightRefer
     db.flush()
 
 
+def delete_insight_reference(db: Session, insight_reference: models.InsightReference) -> None:
+    db.delete(insight_reference)
+    db.flush()
+
+
+### AffectedObject
+
+
+def delete_affected_object(db: Session, affected_object: models.AffectedObject) -> None:
+    db.delete(affected_object)
+    db.flush()
+
+
+### ThreatScenarios
+
+
+def delete_threat_scenario(db: Session, threat_scenario: models.ThreatScenario) -> None:
+    db.delete(threat_scenario)
+    db.flush()
+
+
 ### PTeam
 
 

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -136,6 +136,39 @@ def get_tickets(
     )
 
 
+def _create_insight_response(db: Session, insight: models.Insight, ticket_id: UUID):
+    return schemas.InsightResponse(
+        insight_id=UUID(insight.insight_id),
+        ticket_id=ticket_id,
+        description=insight.description,
+        reasoning_and_planning=insight.reasoning_and_planning,
+        created_at=insight.created_at,
+        updated_at=insight.updated_at,
+        threat_scenarios=[
+            schemas.ThreatScenario(
+                impact_category=threat_scenario.impact_category,
+                title=threat_scenario.title,
+                description=threat_scenario.description,
+            )
+            for threat_scenario in insight.threat_scenarios
+        ],
+        affected_objects=[
+            schemas.AffectedObject(
+                object_category=affected_object.object_category,
+                name=affected_object.name,
+                description=affected_object.description,
+            )
+            for affected_object in insight.affected_objects
+        ],
+        insight_references=[
+            schemas.InsightReference(
+                link_text=insight_reference.link_text, url=insight_reference.url
+            )
+            for insight_reference in insight.insight_references
+        ],
+    )
+
+
 @router.post("/{ticket_id}/insight", response_model=schemas.InsightResponse)
 def create_insight(
     ticket_id: UUID,
@@ -190,12 +223,84 @@ def create_insight(
         persistence.create_insight_reference(db, insight_reference_model)
 
     db.commit()
+    db.refresh(insight)
+    response = _create_insight_response(db, insight, ticket_id)
 
-    insight_base = request.model_dump()
-    insight_base["ticket_id"] = ticket_id
-    insight_base["created_at"] = now
-    insight_base["updated_at"] = now
-    return schemas.InsightResponse(**insight_base)
+    return response
+
+
+@router.put("/{ticket_id}/insight", response_model=schemas.InsightResponse)
+def update_insight(
+    ticket_id: UUID,
+    request: schemas.InsightUpdatetRequest,
+    current_user: models.Account = Depends(get_current_user),
+    db: Session = Depends(database.get_db),
+):
+    """ """
+    if not (ticket := persistence.get_ticket_by_id(db, ticket_id)):
+        raise NO_SUCH_TICKET
+
+    if not ticket.insight:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No insight associated with this ticket",
+        )
+
+    if not check_pteam_membership(ticket.dependency.service.pteam, current_user):
+        raise NOT_A_PTEAM_MEMBER
+
+    update_request = request.model_dump(exclude_unset=True)
+    insight = ticket.insight
+
+    if "description" in update_request.keys() and request.description is not None:
+        insight.description = request.description
+    if "reasoning_and_planning" in update_request.keys() and request.reasoning_and_planning:
+        insight.reasoning_and_planning = request.reasoning_and_planning
+    if "threat_scenarios" in update_request.keys() and request.threat_scenarios:
+        for threat_scenario in insight.threat_scenarios:
+            persistence.delete_threat_scenario(db, threat_scenario)
+
+        for threat_scenario_request in request.threat_scenarios:
+            threat_scenario_model = models.ThreatScenario(
+                insight_id=str(insight.insight_id),
+                impact_category=threat_scenario_request.impact_category,
+                title=threat_scenario_request.title,
+                description=threat_scenario_request.description,
+            )
+            persistence.create_threat_scenario(db, threat_scenario_model)
+
+    if "affected_objects" in update_request.keys() and request.affected_objects:
+        for affected_object in insight.affected_objects:
+            persistence.delete_affected_object(db, affected_object)
+
+        for affected_object in request.affected_objects:
+            affected_object_model = models.AffectedObject(
+                insight_id=str(insight.insight_id),
+                object_category=affected_object.object_category,
+                name=affected_object.name,
+                description=affected_object.description,
+            )
+            persistence.create_affected_object(db, affected_object_model)
+
+    if "insight_references" in update_request.keys() and request.insight_references:
+        for insight_reference in insight.insight_references:
+            persistence.delete_insight_reference(db, insight_reference)
+
+        for insight_reference_request in request.insight_references:
+            insight_reference_model = models.InsightReference(
+                insight_id=str(insight.insight_id),
+                link_text=insight_reference_request.link_text,
+                url=insight_reference_request.url,
+            )
+            persistence.create_insight_reference(db, insight_reference_model)
+
+    insight.updated_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(insight)
+    response = _create_insight_response(db, insight, ticket_id)
+
+    return response
 
 
 @router.get("/{ticket_id}/insight", response_model=schemas.InsightResponse)
@@ -214,39 +319,9 @@ def get_insight(
         )
 
     insight = ticket.insight
+    response = _create_insight_response(db, insight, ticket_id)
 
-    response_data = {
-        "ticket_id": ticket_id,
-        "description": insight.description,
-        "reasoning_and_planning": insight.reasoning_and_planning,
-        "created_at": insight.created_at,
-        "updated_at": insight.updated_at,
-        "threat_scenarios": [
-            {
-                "impact_category": scenario.impact_category,
-                "title": scenario.title,
-                "description": scenario.description,
-            }
-            for scenario in insight.threat_scenarios
-        ],
-        "affected_objects": [
-            {
-                "object_category": obj.object_category,
-                "name": obj.name,
-                "description": obj.description,
-            }
-            for obj in insight.affected_objects
-        ],
-        "insight_references": [
-            {
-                "link_text": ref.link_text,
-                "url": ref.url,
-            }
-            for ref in insight.insight_references
-        ],
-    }
-
-    return schemas.InsightResponse(**response_data)
+    return response
 
 
 @router.delete("/{ticket_id}/insight", status_code=status.HTTP_204_NO_CONTENT)

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -791,7 +791,7 @@ class TestUpdateInsight:
         assert response.status_code == 404
         assert response.json()["detail"] == "No such ticket"
 
-    def test_it_should_return_404_When_there_is_no_insight_associated_with_ticket_id(self):
+    def test_it_should_return_404_when_there_is_no_insight_associated_with_ticket_id(self):
         # Given
         client.delete(
             f"/tickets/{self.response_insight['ticket_id']}/insight", headers=headers(USER1)
@@ -819,6 +819,26 @@ class TestUpdateInsight:
         # Then
         assert response.status_code == 403
         assert response.json()["detail"] == "Not a pteam member"
+
+    def test_it_should_return_400_when_None_in_the_request(self):
+        # Given
+        invalid_update_request = {
+            "description": None,
+        }
+
+        # When
+        response = client.put(
+            f"/tickets/{self.response_insight['ticket_id']}/insight",
+            headers=headers(USER1),
+            json=invalid_update_request,
+        )
+
+        # Then
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == f"Cannot specify None for {next(iter(invalid_update_request))}"
+        )
 
 
 class TestGetInsight:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- Put /tickets/{ticket_id}/insight API を追加しました
- api/app/routers/tickets.py
  - _create_insight_response関数を作成しinsightのpost, get, putのresponseにおいて共通化しました
  - postはrequestの内容をresponseに使用していましたが、DBから取ってきたinsightテーブルの情報をresponseに含めるように変更しました
- threat_scenarios, affected_objects, nsight_referencesについて完全置換しているため、一度削除しています。

<!-- I want to review in Japanese. -->
