### PR TITLE
rename from VulnStatus to TicketHandlingStatus

### DIFF
--- a/api/app/alembic/versions/2025_08_25_0510-9dac8976dadb_ticket_handling_status.py
+++ b/api/app/alembic/versions/2025_08_25_0510-9dac8976dadb_ticket_handling_status.py
@@ -20,7 +20,7 @@ depends_on = None
 def upgrade() -> None:
     connection = op.get_bind()
     ticket_handling_status_type = sa.Enum(
-        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatus"
+        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatustype"
     )
     ticket_handling_status_type.create(connection)
     op.add_column(
@@ -35,7 +35,7 @@ def upgrade() -> None:
         sa.text(
             """
             UPDATE ticketstatus
-            SET ticket_handling_status = vuln_status::text::tickethandlingstatus
+            SET ticket_handling_status = vuln_status::text::tickethandlingstatustype
             """
         )
     )
@@ -74,6 +74,6 @@ def downgrade() -> None:
     op.alter_column("ticketstatus", "vuln_status", nullable=False)
     op.drop_column("ticketstatus", "ticket_handling_status")
     ticket_handling_status = sa.Enum(
-        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatus"
+        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatustype"
     )
     ticket_handling_status.drop(op.get_bind())

--- a/api/app/alembic/versions/2025_08_25_0510-9dac8976dadb_ticket_handling_status.py
+++ b/api/app/alembic/versions/2025_08_25_0510-9dac8976dadb_ticket_handling_status.py
@@ -1,0 +1,79 @@
+"""ticket_handling_status
+
+Revision ID: 9dac8976dadb
+Revises: 393003f456f5
+Create Date: 2025-08-25 05:10:33.968787
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "9dac8976dadb"
+down_revision = "393003f456f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    ticket_handling_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatus"
+    )
+    ticket_handling_status_type.create(connection)
+    op.add_column(
+        "ticketstatus",
+        sa.Column(
+            "ticket_handling_status",
+            ticket_handling_status_type,
+            nullable=True,
+        ),
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE ticketstatus
+            SET ticket_handling_status = vuln_status::text::tickethandlingstatus
+            """
+        )
+    )
+    op.alter_column("ticketstatus", "ticket_handling_status", nullable=False)
+
+    op.drop_column("ticketstatus", "vuln_status")
+    vuln_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="vulnstatustype"
+    )
+    vuln_status_type.drop(op.get_bind())
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    vuln_status_type = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="vulnstatustype"
+    )
+    vuln_status_type.create(connection)
+    op.add_column(
+        "ticketstatus",
+        sa.Column(
+            "vuln_status",
+            vuln_status_type,
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    connection.execute(
+        sa.text(
+            """
+            UPDATE ticketstatus
+            SET vuln_status = ticket_handling_status::text::vulnstatustype
+            """
+        )
+    )
+    op.alter_column("ticketstatus", "vuln_status", nullable=False)
+    op.drop_column("ticketstatus", "ticket_handling_status")
+    ticket_handling_status = sa.Enum(
+        "alerted", "acknowledged", "scheduled", "completed", name="tickethandlingstatus"
+    )
+    ticket_handling_status.drop(op.get_bind())

--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -44,7 +44,7 @@ def _get_vuln_ids_dict_by_service(
     package_id: UUID | str | None,
     related_ticket_status: str | None,
 ) -> dict:
-    _completed = models.TicketHandlingStatus.completed
+    _completed = models.TicketHandlingStatusType.completed
     vuln_ids_dict = {}
     dependencies = dependency_business.get_dependencies_by_service(db, service, package_id)
 
@@ -137,7 +137,7 @@ def _get_ticket_counts_by_service(
 ) -> dict:
     ticket_counts_dict: dict = _create_initial_ticket_counts_dict()
 
-    _completed = models.TicketHandlingStatus.completed
+    _completed = models.TicketHandlingStatusType.completed
 
     dependencies = dependency_business.get_dependencies_by_service(db, service, package_id)
     for dependency in dependencies:

--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -44,7 +44,7 @@ def _get_vuln_ids_dict_by_service(
     package_id: UUID | str | None,
     related_ticket_status: str | None,
 ) -> dict:
-    _completed = models.VulnStatusType.completed
+    _completed = models.TicketHandlingStatus.completed
     vuln_ids_dict = {}
     dependencies = dependency_business.get_dependencies_by_service(db, service, package_id)
 
@@ -52,11 +52,14 @@ def _get_vuln_ids_dict_by_service(
         for ticket in dependency.tickets:
             ssvc_priority = ticket.ssvc_deployer_priority or models.SSVCDeployerPriorityEnum.DEFER
 
-            if related_ticket_status == "solved" and ticket.ticket_status.vuln_status != _completed:
+            if (
+                related_ticket_status == "solved"
+                and ticket.ticket_status.ticket_handling_status != _completed
+            ):
                 continue
             elif (
                 related_ticket_status == "unsolved"
-                and ticket.ticket_status.vuln_status == _completed
+                and ticket.ticket_status.ticket_handling_status == _completed
             ):
                 continue
 
@@ -134,7 +137,7 @@ def _get_ticket_counts_by_service(
 ) -> dict:
     ticket_counts_dict: dict = _create_initial_ticket_counts_dict()
 
-    _completed = models.VulnStatusType.completed
+    _completed = models.TicketHandlingStatus.completed
 
     dependencies = dependency_business.get_dependencies_by_service(db, service, package_id)
     for dependency in dependencies:
@@ -143,11 +146,14 @@ def _get_ticket_counts_by_service(
         for ticket in dependency.tickets:
             ssvc_priority = ticket.ssvc_deployer_priority or models.SSVCDeployerPriorityEnum.DEFER
 
-            if related_ticket_status == "solved" and ticket.ticket_status.vuln_status != _completed:
+            if (
+                related_ticket_status == "solved"
+                and ticket.ticket_status.ticket_handling_status != _completed
+            ):
                 continue
             elif (
                 related_ticket_status == "unsolved"
-                and ticket.ticket_status.vuln_status == _completed
+                and ticket.ticket_status.ticket_handling_status == _completed
             ):
                 continue
 

--- a/api/app/business/ticket_business.py
+++ b/api/app/business/ticket_business.py
@@ -44,7 +44,7 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     if ticket.ssvc_deployer_priority is None:
         return False
 
-    if ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.completed:
+    if ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatusType.completed:
         return False
 
     pteam = ticket.dependency.service.pteam
@@ -73,7 +73,7 @@ def create_ticket_internal(
         status_id=None,
         ticket_id=ticket.ticket_id,
         user_id=None,
-        ticket_handling_status=models.TicketHandlingStatus.alerted,
+        ticket_handling_status=models.TicketHandlingStatusType.alerted,
         note=None,
         logging_ids=[],
         assignees=[],

--- a/api/app/business/ticket_business.py
+++ b/api/app/business/ticket_business.py
@@ -44,7 +44,7 @@ def ticket_meets_condition_to_create_alert(ticket: models.Ticket) -> bool:
     if ticket.ssvc_deployer_priority is None:
         return False
 
-    if ticket.ticket_status.vuln_status == models.VulnStatusType.completed:
+    if ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.completed:
         return False
 
     pteam = ticket.dependency.service.pteam
@@ -73,7 +73,7 @@ def create_ticket_internal(
         status_id=None,
         ticket_id=ticket.ticket_id,
         user_id=None,
-        vuln_status=models.VulnStatusType.alerted,
+        ticket_handling_status=models.TicketHandlingStatus.alerted,
         note=None,
         logging_ids=[],
         assignees=[],

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -307,7 +307,8 @@ def get_packages_summary(
             models.TicketStatus,
             and_(
                 models.TicketStatus.ticket_id == models.Ticket.ticket_id,
-                models.TicketStatus.ticket_handling_status != models.TicketHandlingStatus.completed,
+                models.TicketStatus.ticket_handling_status
+                != models.TicketHandlingStatusType.completed,
             ),
         )
         .join(models.Threat)
@@ -399,7 +400,7 @@ def get_packages_summary(
             "service_ids": row.service_ids,
             "status_count": {
                 status_type.value: status_count_dict.get((row.package_id, status_type.value), 0)
-                for status_type in list(models.TicketHandlingStatus)
+                for status_type in list(models.TicketHandlingStatusType)
             },
         }
         for row in db.execute(summarize_stmt).all()
@@ -492,7 +493,7 @@ def get_sorted_paginated_tickets_for_pteams(
     assigned_user_id: UUID | None = None,
     offset: int = 0,
     limit: int = 100,
-    exclude_statuses: list[models.TicketHandlingStatus] | None = None,
+    exclude_statuses: list[models.TicketHandlingStatusType] | None = None,
     cve_ids: list[str] | None = None,
 ) -> tuple[int, Sequence[models.Ticket]]:
     fixed_cve_ids: set[str] = set()

--- a/api/app/command.py
+++ b/api/app/command.py
@@ -307,7 +307,7 @@ def get_packages_summary(
             models.TicketStatus,
             and_(
                 models.TicketStatus.ticket_id == models.Ticket.ticket_id,
-                models.TicketStatus.vuln_status != models.VulnStatusType.completed,
+                models.TicketStatus.ticket_handling_status != models.TicketHandlingStatus.completed,
             ),
         )
         .join(models.Threat)
@@ -361,8 +361,8 @@ def get_packages_summary(
     count_status_stmt = (
         select(
             models.Package.package_id,
-            models.TicketStatus.vuln_status,
-            func.count(models.TicketStatus.vuln_status).label("num_status"),
+            models.TicketStatus.ticket_handling_status,
+            func.count(models.TicketStatus.ticket_handling_status).label("num_status"),
         )
         .join(models.PackageVersion)
         .join(models.Dependency)
@@ -377,7 +377,7 @@ def get_packages_summary(
         .join(models.TicketStatus)
         .group_by(
             models.Package.package_id,
-            models.TicketStatus.vuln_status,
+            models.TicketStatus.ticket_handling_status,
         )
     )
 
@@ -385,7 +385,7 @@ def get_packages_summary(
         count_status_stmt = count_status_stmt.where(models.Dependency.service_id == str(service_id))
 
     status_count_dict = {
-        (row.package_id, row.vuln_status): row.num_status
+        (row.package_id, row.ticket_handling_status): row.num_status
         for row in db.execute(count_status_stmt).all()
     }
     summary = [
@@ -399,7 +399,7 @@ def get_packages_summary(
             "service_ids": row.service_ids,
             "status_count": {
                 status_type.value: status_count_dict.get((row.package_id, status_type.value), 0)
-                for status_type in list(models.VulnStatusType)
+                for status_type in list(models.TicketHandlingStatus)
             },
         }
         for row in db.execute(summarize_stmt).all()
@@ -492,7 +492,7 @@ def get_sorted_paginated_tickets_for_pteams(
     assigned_user_id: UUID | None = None,
     offset: int = 0,
     limit: int = 100,
-    exclude_statuses: list[models.VulnStatusType] | None = None,
+    exclude_statuses: list[models.TicketHandlingStatus] | None = None,
     cve_ids: list[str] | None = None,
 ) -> tuple[int, Sequence[models.Ticket]]:
     fixed_cve_ids: set[str] = set()
@@ -520,7 +520,7 @@ def get_sorted_paginated_tickets_for_pteams(
         )
 
     if exclude_statuses:
-        filters.append(models.TicketStatus.vuln_status.notin_(exclude_statuses))
+        filters.append(models.TicketStatus.ticket_handling_status.notin_(exclude_statuses))
 
     # join with Threat and Vuln tables if needed
     if fixed_cve_ids or ("cve_id" in sort_keys) or ("-cve_id" in sort_keys):

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -70,7 +70,7 @@ class PackageType(str, enum.Enum):
     PACKAGE = "package"
 
 
-class VulnStatusType(str, enum.Enum):
+class TicketHandlingStatus(str, enum.Enum):
     alerted = "alerted"
     acknowledged = "acknowledged"
     scheduled = "scheduled"
@@ -538,7 +538,7 @@ class TicketStatus(Base):
     user_id: Mapped[StrUUID | None] = mapped_column(
         ForeignKey("account.user_id", ondelete="SET NULL"), index=True
     )
-    vuln_status: Mapped[VulnStatusType]
+    ticket_handling_status: Mapped[TicketHandlingStatus]
     note: Mapped[str | None]
     logging_ids: Mapped[list[StrUUID]] = mapped_column(default=[])
     assignees: Mapped[list[StrUUID]] = mapped_column(default=[])

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -70,7 +70,7 @@ class PackageType(str, enum.Enum):
     PACKAGE = "package"
 
 
-class TicketHandlingStatus(str, enum.Enum):
+class TicketHandlingStatusType(str, enum.Enum):
     alerted = "alerted"
     acknowledged = "acknowledged"
     scheduled = "scheduled"
@@ -538,7 +538,7 @@ class TicketStatus(Base):
     user_id: Mapped[StrUUID | None] = mapped_column(
         ForeignKey("account.user_id", ondelete="SET NULL"), index=True
     )
-    ticket_handling_status: Mapped[TicketHandlingStatus]
+    ticket_handling_status: Mapped[TicketHandlingStatusType]
     note: Mapped[str | None]
     logging_ids: Mapped[list[StrUUID]] = mapped_column(default=[])
     assignees: Mapped[list[StrUUID]] = mapped_column(default=[])

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -749,7 +749,7 @@ def set_ticket_status(
             detail="Cannot specify None for assignees",
         )
 
-    if data.ticket_handling_status == models.TicketHandlingStatus.alerted:
+    if data.ticket_handling_status == models.TicketHandlingStatusType.alerted:
         # user cannot set alerted
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wrong topic status")
 
@@ -760,12 +760,15 @@ def set_ticket_status(
             detail="Unwise expiration (grant timezone)",
         )
 
-    if data.ticket_handling_status == models.TicketHandlingStatus.scheduled or (
+    if data.ticket_handling_status == models.TicketHandlingStatusType.scheduled or (
         "ticket_handling_status" not in update_data.keys()
-        and ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled
+        and ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatusType.scheduled
     ):
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.ticket_handling_status != models.TicketHandlingStatus.scheduled:
+            if (
+                ticket.ticket_status.ticket_handling_status
+                != models.TicketHandlingStatusType.scheduled
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="If status is scheduled, specify schduled_at",
@@ -783,7 +786,10 @@ def set_ticket_status(
                 )
     else:
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled:
+            if (
+                ticket.ticket_status.ticket_handling_status
+                == models.TicketHandlingStatusType.scheduled
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
@@ -828,9 +834,9 @@ def set_ticket_status(
         ticket.ticket_status.assignees = [UUID(current_user.user_id)]
     if "ticket_handling_status" in update_data.keys():
         ticket.ticket_status.ticket_handling_status = data.ticket_handling_status
-    elif ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.alerted:
+    elif ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatusType.alerted:
         # this is the first update
-        ticket.ticket_status.ticket_handling_status = models.TicketHandlingStatus.acknowledged
+        ticket.ticket_status.ticket_handling_status = models.TicketHandlingStatusType.acknowledged
     if "logging_ids" in update_data.keys() and data.logging_ids is not None:
         ticket.ticket_status.logging_ids = list(map(str, data.logging_ids))
     if "note" in update_data.keys():
@@ -840,7 +846,8 @@ def set_ticket_status(
             ticket.ticket_status.scheduled_at = None
         elif (
             data.scheduled_at > now
-            and ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled
+            and ticket.ticket_status.ticket_handling_status
+            == models.TicketHandlingStatusType.scheduled
         ):
             ticket.ticket_status.scheduled_at = timezone_tool.convert_to_utc_timezone(
                 data.scheduled_at

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -722,7 +722,7 @@ def set_ticket_status(
     Set status of the ticket.
     Current value should be inherited if not specified.
 
-    scheduled_at is necessary to make vuln_status "scheduled".
+    scheduled_at is necessary to make ticket_handling_status "scheduled".
     """
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM
@@ -733,10 +733,10 @@ def set_ticket_status(
 
     update_data = data.model_dump(exclude_unset=True)
 
-    if "vuln_status" in update_data.keys() and data.vuln_status is None:
+    if "ticket_handling_status" in update_data.keys() and data.ticket_handling_status is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot specify None for vuln_status",
+            detail="Cannot specify None for ticket_handling_status",
         )
     if "logging_ids" in update_data.keys() and data.logging_ids is None:
         raise HTTPException(
@@ -749,7 +749,7 @@ def set_ticket_status(
             detail="Cannot specify None for assignees",
         )
 
-    if data.vuln_status == models.VulnStatusType.alerted:
+    if data.ticket_handling_status == models.TicketHandlingStatus.alerted:
         # user cannot set alerted
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Wrong topic status")
 
@@ -760,12 +760,12 @@ def set_ticket_status(
             detail="Unwise expiration (grant timezone)",
         )
 
-    if data.vuln_status == models.VulnStatusType.scheduled or (
-        "vuln_status" not in update_data.keys()
-        and ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled
+    if data.ticket_handling_status == models.TicketHandlingStatus.scheduled or (
+        "ticket_handling_status" not in update_data.keys()
+        and ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled
     ):
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.vuln_status != models.VulnStatusType.scheduled:
+            if ticket.ticket_status.ticket_handling_status != models.TicketHandlingStatus.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="If status is scheduled, specify schduled_at",
@@ -783,7 +783,7 @@ def set_ticket_status(
                 )
     else:
         if "scheduled_at" not in update_data.keys():
-            if ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled:
+            if ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
@@ -826,11 +826,11 @@ def set_ticket_status(
         ticket.ticket_status.assignees = list(map(str, data.assignees))
     elif ticket.ticket_status.assignees == []:
         ticket.ticket_status.assignees = [UUID(current_user.user_id)]
-    if "vuln_status" in update_data.keys():
-        ticket.ticket_status.vuln_status = data.vuln_status
-    elif ticket.ticket_status.vuln_status == models.VulnStatusType.alerted:
+    if "ticket_handling_status" in update_data.keys():
+        ticket.ticket_status.ticket_handling_status = data.ticket_handling_status
+    elif ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.alerted:
         # this is the first update
-        ticket.ticket_status.vuln_status = models.VulnStatusType.acknowledged
+        ticket.ticket_status.ticket_handling_status = models.TicketHandlingStatus.acknowledged
     if "logging_ids" in update_data.keys() and data.logging_ids is not None:
         ticket.ticket_status.logging_ids = list(map(str, data.logging_ids))
     if "note" in update_data.keys():
@@ -840,7 +840,7 @@ def set_ticket_status(
             ticket.ticket_status.scheduled_at = None
         elif (
             data.scheduled_at > now
-            and ticket.ticket_status.vuln_status == models.VulnStatusType.scheduled
+            and ticket.ticket_status.ticket_handling_status == models.TicketHandlingStatus.scheduled
         ):
             ticket.ticket_status.scheduled_at = timezone_tool.convert_to_utc_timezone(
                 data.scheduled_at

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -44,7 +44,7 @@ def get_tickets(
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     sort_keys: list = Query(["-ssvc_deployer_priority", "-created_at"]),
-    exclude_statuses: list[models.VulnStatusType] | None = Query(None),
+    exclude_statuses: list[models.TicketHandlingStatus] | None = Query(None),
     cve_ids: list[str] | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(database.get_db),

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -44,7 +44,7 @@ def get_tickets(
     offset: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     sort_keys: list = Query(["-ssvc_deployer_priority", "-created_at"]),
-    exclude_statuses: list[models.TicketHandlingStatus] | None = Query(None),
+    exclude_statuses: list[models.TicketHandlingStatusType] | None = Query(None),
     cve_ids: list[str] | None = Query(None),
     current_user: models.Account = Depends(get_current_user),
     db: Session = Depends(database.get_db),

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -16,7 +16,7 @@ from app.models import (
     SafetyImpactEnum,
     SSVCDeployerPriorityEnum,
     SystemExposureEnum,
-    VulnStatusType,
+    TicketHandlingStatus,
 )
 
 
@@ -346,7 +346,7 @@ class ActionLogRequest(ORMModel):
 
 
 class TicketStatusRequest(ORMModel):
-    vuln_status: VulnStatusType | None = None
+    ticket_handling_status: TicketHandlingStatus | None = None
     logging_ids: list[UUID] | None = None
     assignees: list[UUID] | None = None
     note: str | None = None
@@ -356,7 +356,7 @@ class TicketStatusRequest(ORMModel):
 class TicketStatusResponse(ORMModel):
     status_id: UUID
     ticket_id: UUID
-    vuln_status: VulnStatusType
+    ticket_handling_status: TicketHandlingStatus
     user_id: UUID | None  # None: auto created when ticket is created
     created_at: datetime
     assignees: list[UUID] = []
@@ -397,7 +397,7 @@ class PTeamPackagesSummary(ORMModel):
         service_ids: list[UUID]
         ssvc_priority: SSVCDeployerPriorityEnum | None
         updated_at: datetime | None
-        status_count: dict[str, int]  # VUlnStatusType.value: tickets count
+        status_count: dict[str, int]  # TicketHandlingStatusType.value: tickets count
 
     ssvc_priority_count: dict[SSVCDeployerPriorityEnum, int]  # priority: packages count
     packages: list[PTeamPackageSummary]

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -16,7 +16,7 @@ from app.models import (
     SafetyImpactEnum,
     SSVCDeployerPriorityEnum,
     SystemExposureEnum,
-    TicketHandlingStatus,
+    TicketHandlingStatusType,
 )
 
 
@@ -346,7 +346,7 @@ class ActionLogRequest(ORMModel):
 
 
 class TicketStatusRequest(ORMModel):
-    ticket_handling_status: TicketHandlingStatus | None = None
+    ticket_handling_status: TicketHandlingStatusType | None = None
     logging_ids: list[UUID] | None = None
     assignees: list[UUID] | None = None
     note: str | None = None
@@ -356,7 +356,7 @@ class TicketStatusRequest(ORMModel):
 class TicketStatusResponse(ORMModel):
     status_id: UUID
     ticket_id: UUID
-    ticket_handling_status: TicketHandlingStatus
+    ticket_handling_status: TicketHandlingStatusType
     user_id: UUID | None  # None: auto created when ticket is created
     created_at: datetime
     assignees: list[UUID] = []

--- a/api/app/tests/integrations/test_alert.py
+++ b/api/app/tests/integrations/test_alert.py
@@ -303,7 +303,7 @@ class TestAlert:
             ).first()
 
             put_ticket_request = {
-                "vuln_status": "completed",
+                "ticket_handling_status": "completed",
             }
             set_ticket_status(
                 USER1,

--- a/api/app/tests/integrations/test_pteams.py
+++ b/api/app/tests/integrations/test_pteams.py
@@ -53,7 +53,7 @@ class TestGetVulnIdsTiedToServicePackage:
             testdb, USER1, PTEAM1, service_name1, VULN1
         )
         json_data = {
-            "vuln_status": "acknowledged",
+            "ticket_handling_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -145,7 +145,7 @@ class TestGetVulnIdsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "vuln_status": "completed",
+            "ticket_handling_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -191,7 +191,7 @@ class TestGetVulnIdsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "vuln_status": "completed",
+            "ticket_handling_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -286,7 +286,7 @@ class TestGetTicketCountsTiedToServicePackage:
             testdb, USER1, PTEAM1, service_name1, VULN1
         )
         json_data = {
-            "vuln_status": "acknowledged",
+            "ticket_handling_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -388,7 +388,7 @@ class TestGetTicketCountsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "vuln_status": "completed",
+            "ticket_handling_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,
@@ -439,7 +439,7 @@ class TestGetTicketCountsTiedToServicePackage:
         # Given
         # Change status of ticket1
         json_data = {
-            "vuln_status": "completed",
+            "ticket_handling_status": "completed",
             "note": "string",
             "assignees": [self.ticket_response1["user_id"]],
             "scheduled_at": None,

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -310,7 +310,7 @@ class TestDeleteUserSideEffects:
 
         # Set ticket status
         status_request1 = {
-            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -322,7 +322,7 @@ class TestDeleteUserSideEffects:
         )
 
         status_request2 = {
-            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatusType.completed.value,
             "assignees": [str(self.user2.user_id)],
             "logging_ids": [self.actionlog2["logging_id"]],
         }
@@ -468,7 +468,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -493,7 +493,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatusType.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }

--- a/api/app/tests/integrations/test_users.py
+++ b/api/app/tests/integrations/test_users.py
@@ -310,7 +310,7 @@ class TestDeleteUserSideEffects:
 
         # Set ticket status
         status_request1 = {
-            "vuln_status": models.VulnStatusType.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -322,7 +322,7 @@ class TestDeleteUserSideEffects:
         )
 
         status_request2 = {
-            "vuln_status": models.VulnStatusType.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
             "assignees": [str(self.user2.user_id)],
             "logging_ids": [self.actionlog2["logging_id"]],
         }
@@ -468,7 +468,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "vuln_status": models.VulnStatusType.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }
@@ -493,7 +493,7 @@ class TestDeleteUserSideEffects:
         self.update_pteam_member(USER1, self.user2.user_id, self.pteam1.pteam_id, True)
 
         status_request = {
-            "vuln_status": models.VulnStatusType.completed.value,
+            "ticket_handling_status": models.TicketHandlingStatus.completed.value,
             "assignees": [str(self.user1.user_id)],
             "logging_ids": [self.actionlog1["logging_id"]],
         }

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -43,7 +43,7 @@ class TestGetTicketCountsTiedToServicePackage:
         )
 
         json_data = {
-            "vuln_status": "acknowledged",
+            "ticket_handling_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,
@@ -253,7 +253,7 @@ class TestTicketStatus:
             expected_status = {
                 "status_id": data["status_id"],  # do not check
                 "ticket_id": str(self.ticket_id1),
-                "vuln_status": models.VulnStatusType.alerted.value,
+                "ticket_handling_status": models.TicketHandlingStatus.alerted.value,
                 "user_id": None,
                 "created_at": data["created_at"],  # check later
                 "assignees": [],
@@ -268,7 +268,7 @@ class TestTicketStatus:
 
         def test_returns_current_status_if_status_created(self):
             status_request = {
-                "vuln_status": models.VulnStatusType.scheduled.value,
+                "ticket_handling_status": models.TicketHandlingStatus.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10Z",
@@ -307,12 +307,14 @@ class TestTicketStatus:
             assert data == expected_status
 
     class TestSet(Common):
-        def common_setup_for_set_ticket_status(self, vuln_status, need_scheduled_at, scheduled_at):
+        def common_setup_for_set_ticket_status(
+            self, ticket_handling_status, need_scheduled_at, scheduled_at
+        ):
             status_request = {
                 "assignees": [str(self.user2.user_id)],
             }
-            if vuln_status is not None:
-                status_request["vuln_status"] = vuln_status
+            if ticket_handling_status is not None:
+                status_request["ticket_handling_status"] = ticket_handling_status
             if need_scheduled_at:
                 status_request["scheduled_at"] = scheduled_at
             url = f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket_id1}/ticketstatuses"
@@ -327,7 +329,7 @@ class TestTicketStatus:
 
         def test_set_requested_status(self):
             status_request = {
-                "vuln_status": models.VulnStatusType.scheduled.value,
+                "ticket_handling_status": models.TicketHandlingStatus.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10Z",
@@ -365,7 +367,7 @@ class TestTicketStatus:
         @pytest.mark.parametrize(
             "field_name, expected_response_detail",
             [
-                ("vuln_status", "Cannot specify None for vuln_status"),
+                ("ticket_handling_status", "Cannot specify None for ticket_handling_status"),
                 ("logging_ids", "Cannot specify None for logging_ids"),
                 ("assignees", "Cannot specify None for assignees"),
             ],
@@ -388,88 +390,92 @@ class TestTicketStatus:
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "vuln_status, scheduled_at, expected_response_detail",
+            "ticket_handling_status, scheduled_at, expected_response_detail",
             [
-                (models.VulnStatusType.alerted.value, None, "Wrong topic status"),
+                (models.TicketHandlingStatus.alerted.value, None, "Wrong topic status"),
                 (
-                    models.VulnStatusType.alerted.value,
+                    models.TicketHandlingStatus.alerted.value,
                     None,
                     "Wrong topic status",
                 ),
                 (
-                    models.VulnStatusType.alerted.value,
+                    models.TicketHandlingStatus.alerted.value,
                     "2000-01-01T00:00:00",
                     "Wrong topic status",
                 ),
                 (
-                    models.VulnStatusType.alerted.value,
+                    models.TicketHandlingStatus.alerted.value,
                     "2345-06-07T08:09:10",
                     "Wrong topic status",
                 ),
             ],
         )
-        def test_it_should_return_400_when_vuln_status_is_alerted(
+        def test_it_should_return_400_when_ticket_handling_status_is_alerted(
             self,
-            vuln_status,
+            ticket_handling_status,
             scheduled_at,
             expected_response_detail,
         ):
-            response = self.common_setup_for_set_ticket_status(vuln_status, True, scheduled_at)
+            response = self.common_setup_for_set_ticket_status(
+                ticket_handling_status, True, scheduled_at
+            )
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "vuln_status, scheduled_at, expected_response_detail",
+            "ticket_handling_status, scheduled_at, expected_response_detail",
             [
                 (
-                    models.VulnStatusType.acknowledged.value,
+                    models.TicketHandlingStatus.acknowledged.value,
                     "2000-01-01T00:00:00Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.VulnStatusType.acknowledged.value,
+                    models.TicketHandlingStatus.acknowledged.value,
                     "2345-06-07T08:09:10Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.VulnStatusType.completed.value,
+                    models.TicketHandlingStatus.completed.value,
                     "2000-01-01T00:00:00Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.VulnStatusType.completed.value,
+                    models.TicketHandlingStatus.completed.value,
                     "2345-06-07T08:09:10Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
             ],
         )
-        def test_it_should_return_400_when_vuln_statuss_is_not_scheduled_and_schduled_at_is_time(
+        def test_it_should_return_400_when_handling_status_is_not_scheduled_and_schduled_at_is_time(
             self,
-            vuln_status,
+            ticket_handling_status,
             scheduled_at,
             expected_response_detail,
         ):
-            response = self.common_setup_for_set_ticket_status(vuln_status, True, scheduled_at)
+            response = self.common_setup_for_set_ticket_status(
+                ticket_handling_status, True, scheduled_at
+            )
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "vuln_status, need_scheduled_at, scheduled_at, expected_response_detail",
+            "ticket_handling_status, need_scheduled_at, scheduled_at, expected_response_detail",
             [
                 (
-                    models.VulnStatusType.scheduled.value,
+                    models.TicketHandlingStatus.scheduled.value,
                     False,
                     None,
                     "If status is scheduled, specify schduled_at",
                 ),
                 (
-                    models.VulnStatusType.scheduled.value,
+                    models.TicketHandlingStatus.scheduled.value,
                     True,
                     None,
                     "If status is scheduled, unable to reset schduled_at",
                 ),
                 (
-                    models.VulnStatusType.scheduled.value,
+                    models.TicketHandlingStatus.scheduled.value,
                     True,
                     "2000-01-01T00:00:00Z",
                     "If status is scheduled, schduled_at must be a future time",
@@ -478,43 +484,49 @@ class TestTicketStatus:
         )
         def test_it_should_return_400_when_schduled_at_is_not_future_time(
             self,
-            vuln_status,
+            ticket_handling_status,
             need_scheduled_at,
             scheduled_at,
             expected_response_detail,
         ):
-            # when vuln_status is schduled and schduled at is not future time, return 200.
+            # when ticket_handling_status is schduled and schduled at is not future time,
+            # return 200.
 
             response = self.common_setup_for_set_ticket_status(
-                vuln_status, need_scheduled_at, scheduled_at
+                ticket_handling_status, need_scheduled_at, scheduled_at
             )
             assert response.status_code == 400
             assert response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "vuln_status, need_scheduled_at, scheduled_at, expected_response_status_code",
+            (
+                "ticket_handling_status",
+                "need_scheduled_at",
+                "scheduled_at",
+                "expected_response_status_code",
+            ),
             [
-                (models.VulnStatusType.acknowledged.value, False, None, 200),
+                (models.TicketHandlingStatus.acknowledged.value, False, None, 200),
                 (
-                    models.VulnStatusType.acknowledged.value,
+                    models.TicketHandlingStatus.acknowledged.value,
                     True,
                     None,
                     200,
                 ),
-                (models.VulnStatusType.scheduled.value, True, "2345-06-07T08:09:10Z", 200),
-                (models.VulnStatusType.completed.value, False, None, 200),
-                (models.VulnStatusType.completed.value, True, None, 200),
+                (models.TicketHandlingStatus.scheduled.value, True, "2345-06-07T08:09:10Z", 200),
+                (models.TicketHandlingStatus.completed.value, False, None, 200),
+                (models.TicketHandlingStatus.completed.value, True, None, 200),
             ],
         )
-        def test_it_should_return_200_when_vuln_statuss_and_schduled_at_have_the_correct_values(
+        def test_it_should_return_200_when_handling_status_and_schduled_at_have_the_correct_values(
             self,
-            vuln_status,
+            ticket_handling_status,
             need_scheduled_at,
             scheduled_at,
             expected_response_status_code,
         ):
             response = self.common_setup_for_set_ticket_status(
-                vuln_status, need_scheduled_at, scheduled_at
+                ticket_handling_status, need_scheduled_at, scheduled_at
             )
             assert response.status_code == expected_response_status_code
             set_response = response.json()
@@ -525,21 +537,21 @@ class TestTicketStatus:
             else:
                 assert set_response["scheduled_at"] == scheduled_at
             assert set_response["ticket_id"] == self.ticket_id1
-            assert set_response["vuln_status"] == vuln_status
+            assert set_response["ticket_handling_status"] == ticket_handling_status
             assert set_response["user_id"] == str(self.user1.user_id)
             assert set_response["assignees"] == [str(self.user2.user_id)]
 
         @pytest.mark.parametrize(
-            "current_vuln_status, current_scheduled_at, expected_response_detail",
+            "current_ticket_handling_status, current_scheduled_at, expected_response_detail",
             [
                 (
-                    models.VulnStatusType.completed.value,
+                    models.TicketHandlingStatus.completed.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
                 ),
                 (
-                    models.VulnStatusType.acknowledged.value,
+                    models.TicketHandlingStatus.acknowledged.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
@@ -548,29 +560,29 @@ class TestTicketStatus:
         )
         def test_it_should_return_400_when_previous_status_is_schduled_and_schduled_at_is_reset(
             self,
-            current_vuln_status,
+            current_ticket_handling_status,
             current_scheduled_at,
             expected_response_detail,
         ):
-            # When previou vuln_status is schduled and current vuln_status is not schduled,
-            # return 400 if current_scheduled_at does not contain
+            # When previou ticket_handling_status is schduled and current ticket_handling_status is
+            #  not schduled, return 400 if current_scheduled_at does not contain
             # a value to reset None.
 
-            previous_vuln_status = models.VulnStatusType.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_vuln_status, True, previous_scheduled_at
+                previous_ticket_handling_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_vuln_status, False, current_scheduled_at
+                current_ticket_handling_status, False, current_scheduled_at
             )
             assert current_response.status_code == 400
             assert current_response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "current_vuln_status, current_scheduled_at, expected_response_detail",
+            "current_ticket_handling_status, current_scheduled_at, expected_response_detail",
             [
                 (
                     None,
@@ -584,31 +596,31 @@ class TestTicketStatus:
                 ),
             ],
         )
-        def test_it_should_return_400_when_vuln_status_and_scheduled_at_is_not_appropriate(
+        def test_it_should_return_400_when_handling_status_and_scheduled_at_is_not_appropriate(
             self,
-            current_vuln_status,
+            current_ticket_handling_status,
             current_scheduled_at,
             expected_response_detail,
         ):
-            # When previou vuln_status is schduled and current vuln_status is None,
-            # return 400 if current_scheduled_at does not contain
+            # When previou ticket_handling_status is schduled and current ticket_handling_status
+            #  is None, return 400 if current_scheduled_at does not contain
             # future time or None.
 
-            previous_vuln_status = models.VulnStatusType.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_vuln_status, True, previous_scheduled_at
+                previous_ticket_handling_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_vuln_status, True, current_scheduled_at
+                current_ticket_handling_status, True, current_scheduled_at
             )
             assert current_response.status_code == 400
             assert current_response.json()["detail"] == expected_response_detail
 
         @pytest.mark.parametrize(
-            "current_vuln_status, need_scheduled_at, "
+            "current_ticket_handling_status, need_scheduled_at, "
             + "current_scheduled_at, expected_response_status_code",
             [
                 (
@@ -618,7 +630,7 @@ class TestTicketStatus:
                     200,
                 ),
                 (
-                    models.VulnStatusType.completed.value,
+                    models.TicketHandlingStatus.completed.value,
                     True,
                     None,
                     200,
@@ -627,27 +639,27 @@ class TestTicketStatus:
         )
         def test_it_should_return_200_when_previous_and_current_status_have_the_correct_values(
             self,
-            current_vuln_status,
+            current_ticket_handling_status,
             need_scheduled_at,
             current_scheduled_at,
             expected_response_status_code,
         ):
-            # When previou vuln_status is schduled and current vuln_status is None,
-            # return 200 if current_scheduled_at contain None.
+            # When previou ticket_handling_status is schduled and current ticket_handling_status
+            # is None, return 200 if current_scheduled_at contain None.
 
-            # When previou vuln_status is schduled and current vuln_status is completed,
-            # return 200 if current_scheduled_at contain
+            # When previou ticket_handling_status is schduled and current ticket_handling_status is
+            # completed, return 200 if current_scheduled_at contain
             # a value to reset None.
 
-            previous_vuln_status = models.VulnStatusType.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
-                previous_vuln_status, True, previous_scheduled_at
+                previous_ticket_handling_status, True, previous_scheduled_at
             )
             assert previous_response.status_code == 200
 
             current_response = self.common_setup_for_set_ticket_status(
-                current_vuln_status, need_scheduled_at, current_scheduled_at
+                current_ticket_handling_status, need_scheduled_at, current_scheduled_at
             )
             assert current_response.status_code == expected_response_status_code
 
@@ -656,10 +668,10 @@ class TestTicketStatus:
             assert set_response["user_id"] == str(self.user1.user_id)
             assert set_response["assignees"] == [str(self.user2.user_id)]
 
-            _current_vuln_status = current_vuln_status
-            if current_vuln_status is None:
-                _current_vuln_status = models.VulnStatusType.scheduled.value
-            assert set_response["vuln_status"] == _current_vuln_status
+            _current_ticket_handling_status = current_ticket_handling_status
+            if current_ticket_handling_status is None:
+                _current_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+            assert set_response["ticket_handling_status"] == _current_ticket_handling_status
 
             if need_scheduled_at:
                 _scheduled_at = current_scheduled_at
@@ -674,7 +686,7 @@ class TestTicketStatus:
 
         def test_it_should_set_requester_if_assignee_is_not_specify_and_saved_current_user(self):
             status_request = {
-                "vuln_status": models.VulnStatusType.completed.value,
+                "ticket_handling_status": models.TicketHandlingStatus.completed.value,
                 "note": "assign None",
             }
             url = f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket_id1}/ticketstatuses"
@@ -692,9 +704,11 @@ class TestTicketStatus:
             assert data["assignees"] == [str(self.user1.user_id)]
 
         def test_it_should_return_400_when_there_is_no_time_zone_in_scheduled_at_time(self):
-            vuln_status = models.VulnStatusType.scheduled.value
+            ticket_handling_status = models.TicketHandlingStatus.scheduled.value
             scheduled_at = "2345-06-07T08:09:10"  # without time zone
-            response = self.common_setup_for_set_ticket_status(vuln_status, True, scheduled_at)
+            response = self.common_setup_for_set_ticket_status(
+                ticket_handling_status, True, scheduled_at
+            )
             assert response.status_code == 400
             assert response.json()["detail"] == "Unwise expiration (grant timezone)"
 
@@ -806,7 +820,7 @@ class TestGetTickets:
                 "ticket_status": {
                     "status_id": db_status1.status_id,  # do not check
                     "ticket_id": str(db_ticket1.ticket_id),
-                    "vuln_status": models.VulnStatusType.alerted.value,
+                    "ticket_handling_status": models.TicketHandlingStatus.alerted.value,
                     "user_id": None,
                     "created_at": datetime.isoformat(db_status1.created_at).replace(
                         "+00:00", "Z"
@@ -1355,7 +1369,7 @@ class TestPutTicket:
         assert data["vuln_id"] == str(self.vuln1.vuln_id)
         assert data["dependency_id"] == str(self.dependency1.dependency_id)
         assert data["created_at"] == self.ticket1.created_at.isoformat().replace("+00:00", "Z")
-        assert data["ssvc_deployer_priority"] == models.VulnStatusType.scheduled.value
+        assert data["ssvc_deployer_priority"] == models.TicketHandlingStatus.scheduled.value
         assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
         assert (
             data["ticket_safety_impact_change_reason"]
@@ -1363,7 +1377,10 @@ class TestPutTicket:
         )
         assert data["ticket_status"]["status_id"] == self.ticket_status1.status_id
         assert data["ticket_status"]["ticket_id"] == str(self.ticket1.ticket_id)
-        assert data["ticket_status"]["vuln_status"] == models.VulnStatusType.alerted.value
+        assert (
+            data["ticket_status"]["ticket_handling_status"]
+            == models.TicketHandlingStatus.alerted.value
+        )
         assert data["ticket_status"]["user_id"] is None
         assert data["ticket_status"][
             "created_at"
@@ -1656,7 +1673,7 @@ class TestPutTicket:
             .one()
         )
         assert updated_ticket.ssvc_deployer_priority != initial_priority
-        assert updated_ticket.ssvc_deployer_priority == models.VulnStatusType.scheduled
+        assert updated_ticket.ssvc_deployer_priority == models.TicketHandlingStatus.scheduled
 
     def test_it_should_return_422_when_invalid_ticket_safety_impact(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -253,7 +253,7 @@ class TestTicketStatus:
             expected_status = {
                 "status_id": data["status_id"],  # do not check
                 "ticket_id": str(self.ticket_id1),
-                "ticket_handling_status": models.TicketHandlingStatus.alerted.value,
+                "ticket_handling_status": models.TicketHandlingStatusType.alerted.value,
                 "user_id": None,
                 "created_at": data["created_at"],  # check later
                 "assignees": [],
@@ -268,7 +268,7 @@ class TestTicketStatus:
 
         def test_returns_current_status_if_status_created(self):
             status_request = {
-                "ticket_handling_status": models.TicketHandlingStatus.scheduled.value,
+                "ticket_handling_status": models.TicketHandlingStatusType.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10Z",
@@ -329,7 +329,7 @@ class TestTicketStatus:
 
         def test_set_requested_status(self):
             status_request = {
-                "ticket_handling_status": models.TicketHandlingStatus.scheduled.value,
+                "ticket_handling_status": models.TicketHandlingStatusType.scheduled.value,
                 "assignees": [str(self.user2.user_id)],
                 "note": "assign user2 and schedule at 2345/6/7",
                 "scheduled_at": "2345-06-07T08:09:10Z",
@@ -392,19 +392,19 @@ class TestTicketStatus:
         @pytest.mark.parametrize(
             "ticket_handling_status, scheduled_at, expected_response_detail",
             [
-                (models.TicketHandlingStatus.alerted.value, None, "Wrong topic status"),
+                (models.TicketHandlingStatusType.alerted.value, None, "Wrong topic status"),
                 (
-                    models.TicketHandlingStatus.alerted.value,
+                    models.TicketHandlingStatusType.alerted.value,
                     None,
                     "Wrong topic status",
                 ),
                 (
-                    models.TicketHandlingStatus.alerted.value,
+                    models.TicketHandlingStatusType.alerted.value,
                     "2000-01-01T00:00:00",
                     "Wrong topic status",
                 ),
                 (
-                    models.TicketHandlingStatus.alerted.value,
+                    models.TicketHandlingStatusType.alerted.value,
                     "2345-06-07T08:09:10",
                     "Wrong topic status",
                 ),
@@ -426,22 +426,22 @@ class TestTicketStatus:
             "ticket_handling_status, scheduled_at, expected_response_detail",
             [
                 (
-                    models.TicketHandlingStatus.acknowledged.value,
+                    models.TicketHandlingStatusType.acknowledged.value,
                     "2000-01-01T00:00:00Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.acknowledged.value,
+                    models.TicketHandlingStatusType.acknowledged.value,
                     "2345-06-07T08:09:10Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.completed.value,
+                    models.TicketHandlingStatusType.completed.value,
                     "2000-01-01T00:00:00Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.completed.value,
+                    models.TicketHandlingStatusType.completed.value,
                     "2345-06-07T08:09:10Z",
                     "If status is not scheduled, do not specify schduled_at",
                 ),
@@ -463,19 +463,19 @@ class TestTicketStatus:
             "ticket_handling_status, need_scheduled_at, scheduled_at, expected_response_detail",
             [
                 (
-                    models.TicketHandlingStatus.scheduled.value,
+                    models.TicketHandlingStatusType.scheduled.value,
                     False,
                     None,
                     "If status is scheduled, specify schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.scheduled.value,
+                    models.TicketHandlingStatusType.scheduled.value,
                     True,
                     None,
                     "If status is scheduled, unable to reset schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.scheduled.value,
+                    models.TicketHandlingStatusType.scheduled.value,
                     True,
                     "2000-01-01T00:00:00Z",
                     "If status is scheduled, schduled_at must be a future time",
@@ -506,16 +506,21 @@ class TestTicketStatus:
                 "expected_response_status_code",
             ),
             [
-                (models.TicketHandlingStatus.acknowledged.value, False, None, 200),
+                (models.TicketHandlingStatusType.acknowledged.value, False, None, 200),
                 (
-                    models.TicketHandlingStatus.acknowledged.value,
+                    models.TicketHandlingStatusType.acknowledged.value,
                     True,
                     None,
                     200,
                 ),
-                (models.TicketHandlingStatus.scheduled.value, True, "2345-06-07T08:09:10Z", 200),
-                (models.TicketHandlingStatus.completed.value, False, None, 200),
-                (models.TicketHandlingStatus.completed.value, True, None, 200),
+                (
+                    models.TicketHandlingStatusType.scheduled.value,
+                    True,
+                    "2345-06-07T08:09:10Z",
+                    200,
+                ),
+                (models.TicketHandlingStatusType.completed.value, False, None, 200),
+                (models.TicketHandlingStatusType.completed.value, True, None, 200),
             ],
         )
         def test_it_should_return_200_when_handling_status_and_schduled_at_have_the_correct_values(
@@ -545,13 +550,13 @@ class TestTicketStatus:
             "current_ticket_handling_status, current_scheduled_at, expected_response_detail",
             [
                 (
-                    models.TicketHandlingStatus.completed.value,
+                    models.TicketHandlingStatusType.completed.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
                 ),
                 (
-                    models.TicketHandlingStatus.acknowledged.value,
+                    models.TicketHandlingStatusType.acknowledged.value,
                     None,
                     "If current status is not scheduled and previous status is schduled, "
                     "need to reset schduled_at",
@@ -568,7 +573,7 @@ class TestTicketStatus:
             #  not schduled, return 400 if current_scheduled_at does not contain
             # a value to reset None.
 
-            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
                 previous_ticket_handling_status, True, previous_scheduled_at
@@ -606,7 +611,7 @@ class TestTicketStatus:
             #  is None, return 400 if current_scheduled_at does not contain
             # future time or None.
 
-            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
                 previous_ticket_handling_status, True, previous_scheduled_at
@@ -630,7 +635,7 @@ class TestTicketStatus:
                     200,
                 ),
                 (
-                    models.TicketHandlingStatus.completed.value,
+                    models.TicketHandlingStatusType.completed.value,
                     True,
                     None,
                     200,
@@ -651,7 +656,7 @@ class TestTicketStatus:
             # completed, return 200 if current_scheduled_at contain
             # a value to reset None.
 
-            previous_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+            previous_ticket_handling_status = models.TicketHandlingStatusType.scheduled.value
             previous_scheduled_at = "2345-06-07T08:09:10Z"
             previous_response = self.common_setup_for_set_ticket_status(
                 previous_ticket_handling_status, True, previous_scheduled_at
@@ -670,7 +675,7 @@ class TestTicketStatus:
 
             _current_ticket_handling_status = current_ticket_handling_status
             if current_ticket_handling_status is None:
-                _current_ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+                _current_ticket_handling_status = models.TicketHandlingStatusType.scheduled.value
             assert set_response["ticket_handling_status"] == _current_ticket_handling_status
 
             if need_scheduled_at:
@@ -686,7 +691,7 @@ class TestTicketStatus:
 
         def test_it_should_set_requester_if_assignee_is_not_specify_and_saved_current_user(self):
             status_request = {
-                "ticket_handling_status": models.TicketHandlingStatus.completed.value,
+                "ticket_handling_status": models.TicketHandlingStatusType.completed.value,
                 "note": "assign None",
             }
             url = f"/pteams/{self.pteam1.pteam_id}/tickets/{self.ticket_id1}/ticketstatuses"
@@ -704,7 +709,7 @@ class TestTicketStatus:
             assert data["assignees"] == [str(self.user1.user_id)]
 
         def test_it_should_return_400_when_there_is_no_time_zone_in_scheduled_at_time(self):
-            ticket_handling_status = models.TicketHandlingStatus.scheduled.value
+            ticket_handling_status = models.TicketHandlingStatusType.scheduled.value
             scheduled_at = "2345-06-07T08:09:10"  # without time zone
             response = self.common_setup_for_set_ticket_status(
                 ticket_handling_status, True, scheduled_at
@@ -820,7 +825,7 @@ class TestGetTickets:
                 "ticket_status": {
                     "status_id": db_status1.status_id,  # do not check
                     "ticket_id": str(db_ticket1.ticket_id),
-                    "ticket_handling_status": models.TicketHandlingStatus.alerted.value,
+                    "ticket_handling_status": models.TicketHandlingStatusType.alerted.value,
                     "user_id": None,
                     "created_at": datetime.isoformat(db_status1.created_at).replace(
                         "+00:00", "Z"
@@ -1369,7 +1374,7 @@ class TestPutTicket:
         assert data["vuln_id"] == str(self.vuln1.vuln_id)
         assert data["dependency_id"] == str(self.dependency1.dependency_id)
         assert data["created_at"] == self.ticket1.created_at.isoformat().replace("+00:00", "Z")
-        assert data["ssvc_deployer_priority"] == models.TicketHandlingStatus.scheduled.value
+        assert data["ssvc_deployer_priority"] == models.TicketHandlingStatusType.scheduled.value
         assert data["ticket_safety_impact"] == request["ticket_safety_impact"]
         assert (
             data["ticket_safety_impact_change_reason"]
@@ -1379,7 +1384,7 @@ class TestPutTicket:
         assert data["ticket_status"]["ticket_id"] == str(self.ticket1.ticket_id)
         assert (
             data["ticket_status"]["ticket_handling_status"]
-            == models.TicketHandlingStatus.alerted.value
+            == models.TicketHandlingStatusType.alerted.value
         )
         assert data["ticket_status"]["user_id"] is None
         assert data["ticket_status"][
@@ -1673,7 +1678,7 @@ class TestPutTicket:
             .one()
         )
         assert updated_ticket.ssvc_deployer_priority != initial_priority
-        assert updated_ticket.ssvc_deployer_priority == models.TicketHandlingStatus.scheduled
+        assert updated_ticket.ssvc_deployer_priority == models.TicketHandlingStatusType.scheduled
 
     def test_it_should_return_422_when_invalid_ticket_safety_impact(self):
         user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/pteams/test_pteam_vuln_ids.py
+++ b/api/app/tests/requests/pteams/test_pteam_vuln_ids.py
@@ -33,7 +33,7 @@ class TestGetVulnIdsTiedToServicePackage:
         )
 
         json_data = {
-            "vuln_status": "acknowledged",
+            "ticket_handling_status": "acknowledged",
             "note": "string",
             "assignees": [],
             "scheduled_at": None,

--- a/api/app/tests/requests/pteams/test_pteams_summary.py
+++ b/api/app/tests/requests/pteams/test_pteams_summary.py
@@ -121,7 +121,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatusType)
                 },
             }
         ]
@@ -165,7 +165,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatusType)
                 },
             }
         ]
@@ -217,8 +217,11 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.TicketHandlingStatus)},
-                    models.TicketHandlingStatus.alerted.value: 1,  # default status is ALERTED
+                    **{
+                        status_type.value: 0
+                        for status_type in list(models.TicketHandlingStatusType)
+                    },
+                    models.TicketHandlingStatusType.alerted.value: 1,  # default status is ALERTED
                 },
             }
         ]
@@ -317,8 +320,11 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.TicketHandlingStatus)},
-                    models.TicketHandlingStatus.alerted.value: 2,  # default status is ALERTED
+                    **{
+                        status_type.value: 0
+                        for status_type in list(models.TicketHandlingStatusType)
+                    },
+                    models.TicketHandlingStatusType.alerted.value: 2,  # default status is ALERTED
                 },
             }
         ]
@@ -371,7 +377,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatusType)
                 },
             }
         ]

--- a/api/app/tests/requests/pteams/test_pteams_summary.py
+++ b/api/app/tests/requests/pteams/test_pteams_summary.py
@@ -121,7 +121,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.VulnStatusType)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
                 },
             }
         ]
@@ -165,7 +165,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.VulnStatusType)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
                 },
             }
         ]
@@ -217,8 +217,8 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.VulnStatusType)},
-                    models.VulnStatusType.alerted.value: 1,  # default status is ALERTED
+                    **{status_type.value: 0 for status_type in list(models.TicketHandlingStatus)},
+                    models.TicketHandlingStatus.alerted.value: 1,  # default status is ALERTED
                 },
             }
         ]
@@ -317,8 +317,8 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": expected_ssvc_priority.value,
                 "updated_at": datetime.isoformat(vuln1.updated_at),
                 "status_count": {
-                    **{status_type.value: 0 for status_type in list(models.VulnStatusType)},
-                    models.VulnStatusType.alerted.value: 2,  # default status is ALERTED
+                    **{status_type.value: 0 for status_type in list(models.TicketHandlingStatus)},
+                    models.TicketHandlingStatus.alerted.value: 2,  # default status is ALERTED
                 },
             }
         ]
@@ -371,7 +371,7 @@ class TestGetPTeamPackagesSummary:
                 "ssvc_priority": None,
                 "updated_at": None,
                 "status_count": {
-                    status_type.value: 0 for status_type in list(models.VulnStatusType)
+                    status_type.value: 0 for status_type in list(models.TicketHandlingStatus)
                 },
             }
         ]

--- a/api/app/tests/requests/test_tickets.py
+++ b/api/app/tests/requests/test_tickets.py
@@ -148,7 +148,7 @@ def ticket_setup(testdb):
         pteam1.pteam_id,
         ticket1["ticket_id"],
         {
-            "vuln_status": "acknowledged",
+            "ticket_handling_status": "acknowledged",
             "assignees": [str(user1.user_id)],
             "note": "",
             "scheduled_at": None,
@@ -158,13 +158,23 @@ def ticket_setup(testdb):
         USER2,
         pteam2.pteam_id,
         ticket2["ticket_id"],
-        {"vuln_status": "acknowledged", "assignees": [], "note": "", "scheduled_at": None},
+        {
+            "ticket_handling_status": "acknowledged",
+            "assignees": [],
+            "note": "",
+            "scheduled_at": None,
+        },
     )
     set_ticket_status(
         USER3,
         pteam3.pteam_id,
         ticket3["ticket_id"],
-        {"vuln_status": "acknowledged", "assignees": [], "note": "", "scheduled_at": None},
+        {
+            "ticket_handling_status": "acknowledged",
+            "assignees": [],
+            "note": "",
+            "scheduled_at": None,
+        },
     )
 
     return {

--- a/web/src/pages/Package/VulnTables/ReportCompletedActions.jsx
+++ b/web/src/pages/Package/VulnTables/ReportCompletedActions.jsx
@@ -99,7 +99,7 @@ export function ReportCompletedActions(props) {
             pteamId,
             ticketId,
             data: {
-              vuln_status: "completed",
+              ticket_handling_status: "completed",
               logging_ids: actionLogs.map((log) => log.logging_id),
               note: note.trim() || null,
               scheduled_at: null, // clear scheduled date

--- a/web/src/pages/Package/VulnTables/TicketHandlingStatusSelector.jsx
+++ b/web/src/pages/Package/VulnTables/TicketHandlingStatusSelector.jsx
@@ -25,12 +25,12 @@ import { useRef, useState } from "react";
 
 import dialogStyle from "../../../cssModule/dialog.module.css";
 import { useUpdateTicketStatusMutation } from "../../../services/tcApi";
-import { vulnStatusProps } from "../../../utils/const";
+import { ticketHandlingStatusProps } from "../../../utils/const";
 import { errorToString } from "../../../utils/func";
 
 import { ReportCompletedActions } from "./ReportCompletedActions";
 
-export function VulnStatusSelector(props) {
+export function TicketHandlingStatusSelector(props) {
   const {
     pteamId,
     serviceId,
@@ -57,18 +57,18 @@ export function VulnStatusSelector(props) {
     {
       display: "Acknowledge",
       rawStatus: "acknowledged",
-      disabled: currentStatus.vuln_status === "acknowledged",
+      disabled: currentStatus.ticket_handling_status === "acknowledged",
     },
     { display: "Schedule", rawStatus: "scheduled", disabled: false },
     {
       display: "Complete",
       rawStatus: "completed",
-      disabled: currentStatus.vuln_status === "completed",
+      disabled: currentStatus.ticket_handling_status === "completed",
     },
   ];
 
   const modifyTicketStatus = async (selectedStatus) => {
-    let requestParams = { vuln_status: selectedStatus };
+    let requestParams = { ticket_handling_status: selectedStatus };
     if (selectedStatus === "scheduled") {
       if (!schedule) return;
       requestParams["scheduled_at"] = schedule.toISOString();
@@ -133,7 +133,7 @@ export function VulnStatusSelector(props) {
       <Button
         endIcon={<ArrowDropDownIcon />}
         sx={{
-          ...vulnStatusProps[currentStatus.vuln_status].buttonStyle,
+          ...ticketHandlingStatusProps[currentStatus.ticket_handling_status].buttonStyle,
           fontSize: 14,
           padding: "1px 3px",
           minHeight: "25px",
@@ -151,7 +151,7 @@ export function VulnStatusSelector(props) {
         onClick={() => setOpen(!open)}
         ref={anchorRef}
       >
-        {vulnStatusProps[currentStatus.vuln_status].chipLabelCapitalized}
+        {ticketHandlingStatusProps[currentStatus.ticket_handling_status].chipLabelCapitalized}
       </Button>
       <Popper
         open={open}
@@ -174,7 +174,7 @@ export function VulnStatusSelector(props) {
                   {selectableItems.map((item) => (
                     <MenuItem
                       key={item.rawStatus}
-                      selected={currentStatus.vuln_status === item.rawStatus}
+                      selected={currentStatus.ticket_handling_status === item.rawStatus}
                       disabled={item.disabled}
                       onClick={(event) => handleUpdateStatus(event, item)}
                       dense={true}
@@ -231,7 +231,7 @@ export function VulnStatusSelector(props) {
   );
 }
 
-VulnStatusSelector.propTypes = {
+TicketHandlingStatusSelector.propTypes = {
   pteamId: PropTypes.string.isRequired,
   serviceId: PropTypes.string.isRequired,
   vulnId: PropTypes.string.isRequired,

--- a/web/src/pages/Package/VulnTables/TicketTableRow.jsx
+++ b/web/src/pages/Package/VulnTables/TicketTableRow.jsx
@@ -7,7 +7,7 @@ import { WarningTooltip } from "../WarningTooltip.jsx";
 
 import { AssigneesSelector } from "./AssigneesSelector.jsx";
 import { SafetyImpactSelector } from "./SafetyImpactSelector.jsx";
-import { VulnStatusSelector } from "./VulnStatusSelector.jsx";
+import { TicketHandlingStatusSelector } from "./TicketHandlingStatusSelector.jsx";
 
 export function TicketTableRow(props) {
   const {
@@ -57,7 +57,7 @@ export function TicketTableRow(props) {
       </TableCell>
       <TableCell>
         <Box sx={{ display: "flex", alignItems: "center" }}>
-          <VulnStatusSelector
+          <TicketHandlingStatusSelector
             pteamId={pteamId}
             serviceId={serviceId}
             vulnId={vulnId}
@@ -67,7 +67,7 @@ export function TicketTableRow(props) {
             actionByFixedVersions={actionByFixedVersions}
             vulnActions={vulnActions}
           />
-          {(ticket.ticket_status.vuln_status ?? "alerted") === "alerted" && (
+          {(ticket.ticket_status.ticket_handling_status ?? "alerted") === "alerted" && (
             <WarningTooltip message="No one has acknowledged this vuln" />
           )}
         </Box>

--- a/web/src/pages/Status/PTeamStatusCard.jsx
+++ b/web/src/pages/Status/PTeamStatusCard.jsx
@@ -14,12 +14,12 @@ import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
 
 import { SSVCPriorityStatusChip } from "../../components/SSVCPriorityStatusChip";
-import { vulnStatusProps, sortedVulnStatus } from "../../utils/const";
+import { ticketHandlingStatusProps, sortedTicketHandlingStatus } from "../../utils/const";
 import { calcTimestampDiff, compareSSVCPriority } from "../../utils/func";
 
 function LineWithTooltip(props) {
-  const { vulnStatus, ratio, num } = props;
-  const constProp = vulnStatusProps[vulnStatus];
+  const { ticketHandlingStatus, ratio, num } = props;
+  const constProp = ticketHandlingStatusProps[ticketHandlingStatus];
 
   const tipAreaHeight = 15;
   const lineHeight = 5;
@@ -59,7 +59,7 @@ function LineWithTooltip(props) {
 }
 
 LineWithTooltip.propTypes = {
-  vulnStatus: PropTypes.string,
+  ticketHandlingStatus: PropTypes.string,
   ratio: PropTypes.number,
   num: PropTypes.number,
 };
@@ -80,7 +80,7 @@ function StatusRatioGraph(props) {
       {keys.map((key) => (
         <LineWithTooltip
           key={key}
-          vulnStatus={key}
+          ticketHandlingStatus={key}
           ratio={ratios[key] ?? 0}
           num={counts[key] ?? 0}
         />
@@ -102,7 +102,9 @@ export function PTeamStatusCard(props) {
     displaySSVCPriority = "safe"; // solved all and at least 1 tickets
   } else if (
     !packageInfo.ssvc_priority &&
-    sortedVulnStatus.every((vulnStatus) => packageInfo.status_count[vulnStatus] === 0)
+    sortedTicketHandlingStatus.every(
+      (ticketHandlingStatus) => packageInfo.status_count[ticketHandlingStatus] === 0,
+    )
   ) {
     displaySSVCPriority = "empty";
   } else {

--- a/web/src/pages/ToDo/ToDoDrawer.jsx
+++ b/web/src/pages/ToDo/ToDoDrawer.jsx
@@ -21,7 +21,7 @@ import { preserveParams } from "../../utils/urlUtils";
 import { createActionByFixedVersions, findMatchedVulnPackage } from "../../utils/vulnUtils.js";
 import { AssigneesSelector } from "../Package/VulnTables/AssigneesSelector.jsx";
 import { SafetyImpactSelector } from "../Package/VulnTables/SafetyImpactSelector.jsx";
-import { VulnStatusSelector } from "../Package/VulnTables/VulnStatusSelector.jsx";
+import { TicketHandlingStatusSelector } from "../Package/VulnTables/TicketHandlingStatusSelector.jsx";
 import { VulnerabilityView } from "../Vulnerability/VulnerabilityView.jsx";
 
 export function ToDoDrawer(props) {
@@ -199,7 +199,7 @@ export function ToDoDrawer(props) {
                 Status
               </Typography>
               <FormControl sx={{ width: 130 }} size="small" variant="standard">
-                <VulnStatusSelector
+                <TicketHandlingStatusSelector
                   pteamId={row.pteam_id}
                   serviceId={row.service_id}
                   vulnId={row.vuln_id}

--- a/web/src/pages/Vulnerability/TicketCard.jsx
+++ b/web/src/pages/Vulnerability/TicketCard.jsx
@@ -17,7 +17,7 @@ import PropTypes from "prop-types";
 import { ssvcPriorityProps } from "../../utils/const.js";
 import { AssigneesSelector } from "../Package/VulnTables/AssigneesSelector.jsx";
 import { SafetyImpactSelector } from "../Package/VulnTables/SafetyImpactSelector.jsx";
-import { VulnStatusSelector } from "../Package/VulnTables/VulnStatusSelector.jsx";
+import { TicketHandlingStatusSelector } from "../Package/VulnTables/TicketHandlingStatusSelector.jsx";
 import { WarningTooltip } from "../Package/WarningTooltip.jsx";
 
 export function TicketCard(props) {
@@ -75,7 +75,7 @@ export function TicketCard(props) {
               <TableCell sx={{ fontWeight: "bold" }}>Status</TableCell>
               <TableCell>
                 <Box sx={{ display: "flex", alignItems: "center" }}>
-                  <VulnStatusSelector
+                  <TicketHandlingStatusSelector
                     pteamId={pteamId}
                     serviceId={serviceId}
                     vulnId={vulnId}
@@ -85,7 +85,7 @@ export function TicketCard(props) {
                     actionByFixedVersions={actionByFixedVersions}
                     vulnActions={vulnActions}
                   />
-                  {(ticket.ticket_status.vuln_status ?? "alerted") === "alerted" && (
+                  {(ticket.ticket_status.ticket_handling_status ?? "alerted") === "alerted" && (
                     <WarningTooltip message="No one has acknowledged this vuln" />
                   )}
                 </Box>

--- a/web/src/utils/const.js
+++ b/web/src/utils/const.js
@@ -231,8 +231,8 @@ export const safetyImpactProps = {
   Negligible: propSafetyImpactNegligible,
 };
 
-export const sortedVulnStatus = ["alerted", "acknowledged", "scheduled", "completed"];
-export const vulnStatusProps = {
+export const sortedTicketHandlingStatus = ["alerted", "acknowledged", "scheduled", "completed"];
+export const ticketHandlingStatusProps = {
   alerted: {
     chipLabel: "alerted",
     chipLabelCapitalized: "Alerted",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- チケットステータスの状態を示すVulnStatusは、名称をTicketHandlingStatusにした方が適切なため、変更する
  - 変更点
    - models.py　VulnStatusType → TicketHandlingStatusType
models.py　TicketStatus.vuln_status → ticket_handling_status
      - これに関するAPI、Webのコード、マイグレーションスクリプト
    - schemas.py　vuln_status → ticket_handling_status
      -  これに関するAPI、Webのコード


<!-- I want to review in Japanese. -->
