### PR TITLE
add OpenInNewIcon to Data Sources and change Icon in ticket tab

### DIFF
--- a/web/src/pages/ToDo/Insights/InsightReference.jsx
+++ b/web/src/pages/ToDo/Insights/InsightReference.jsx
@@ -1,10 +1,12 @@
 import ArticleIcon from "@mui/icons-material/Article";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import {
   Box,
   List,
   ListItem,
   ListItemIcon,
   ListItemText,
+  Link,
   Typography,
   Divider,
 } from "@mui/material";
@@ -39,31 +41,30 @@ export function InsightReference(props) {
         <List dense>
           {insightReferences.map((reference, index) => (
             <ListItem key={index}>
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <ArticleIcon fontSize="small" />
-              </ListItemIcon>
+              {(reference.link_text || reference.url) && (
+                <ListItemIcon sx={{ minWidth: 40 }}>
+                  <ArticleIcon fontSize="small" />
+                </ListItemIcon>
+              )}
               <ListItemText
                 primary={
                   reference.url ? (
-                    <a
+                    <Link
                       href={reference.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      style={{
-                        color: "#1976d2",
-                        textDecoration: "underline",
-                        cursor: "pointer",
-                        fontWeight: 500,
+                      underline="none"
+                      sx={{
+                        display: "inline-flex",
+                        gap: 0.5,
+                        color: "#000",
                       }}
-                      onMouseOver={(e) => (e.currentTarget.style.color = "#1565c0")}
-                      onFocus={(e) => (e.currentTarget.style.color = "#1565c0")}
-                      onMouseOut={(e) => (e.currentTarget.style.color = "#1976d2")}
-                      onBlur={(e) => (e.currentTarget.style.color = "#1976d2")}
                     >
-                      {reference.link_text}
-                    </a>
+                      <span style={{ color: "#000" }}>{reference.link_text}</span>
+                      {reference.url ? <OpenInNewIcon fontSize="small" color="primary" /> : null}
+                    </Link>
                   ) : (
-                    <>{reference.link_text}</>
+                    <span style={{ color: "#000" }}>{reference.link_text}</span>
                   )
                 }
               />

--- a/web/src/pages/ToDo/ToDoDrawer.jsx
+++ b/web/src/pages/ToDo/ToDoDrawer.jsx
@@ -1,5 +1,5 @@
 import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArrowRight";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import LinkIcon from "@mui/icons-material/Link";
 import {
   Chip,
   Drawer,
@@ -142,7 +142,7 @@ export function ToDoDrawer(props) {
                 <Typography>{vuln?.cve_id || "-"}</Typography>
               )}
               <IconButton size="small" onClick={handleCVEClick}>
-                <OpenInNewIcon color="primary" fontSize="small" />
+                <LinkIcon color="primary" fontSize="small" />
               </IconButton>
             </Box>
             <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -151,7 +151,7 @@ export function ToDoDrawer(props) {
               </Typography>
               <Typography>{pteamName || "-"}</Typography>
               <IconButton size="small" onClick={handleTeamClick}>
-                <OpenInNewIcon color="primary" fontSize="small" />
+                <LinkIcon color="primary" fontSize="small" />
               </IconButton>
             </Box>
             <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -160,7 +160,7 @@ export function ToDoDrawer(props) {
               </Typography>
               <Typography>{serviceName || "-"}</Typography>
               <IconButton size="small" onClick={handleServiceClick}>
-                <OpenInNewIcon color="primary" fontSize="small" />
+                <LinkIcon color="primary" fontSize="small" />
               </IconButton>
             </Box>
             <Box sx={{ display: "flex", alignItems: "center" }}>
@@ -173,7 +173,7 @@ export function ToDoDrawer(props) {
                   : "-"}
               </Typography>
               <IconButton size="small" onClick={handlePackageClick}>
-                <OpenInNewIcon color="primary" fontSize="small" />
+                <LinkIcon color="primary" fontSize="small" />
               </IconButton>
             </Box>
             <Box sx={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
## PR の目的
- ToDoページのInsightタブのData SourceのアイコンとしてOpenInNewIconを設定
   - urlにマウスホバー時の下線なし
   - 黒字（アイコンは青（primary））

- ToDoページのticket タブのアイコンとしてLinkIconを設定

## 経緯・意図・意思決定
- InsightタブのData Sourceのアイコンは外部ページへの遷移であるため、OpenInNewIconを採用
- ticketタブのアイコンはアプリケーション内部への遷移であるため、LinkIconを採用

