### PR TITLE
add target in collect_tickets_data response

### DIFF
--- a/scripts/collect_tickets_data.py
+++ b/scripts/collect_tickets_data.py
@@ -130,7 +130,7 @@ class ThreatconnectomeClient:
                 f"{self.api_url}/pteams/{pteam_id}/dependencies/{dependency_id}",
             )
         except APIError as error:
-            sys.exit("Is pteam_id correct\n" + str(error))
+            sys.exit("Is the pteam_id correct?\n" + str(error))
         return response.json()
 
     def get_vuln(self, vuln_id):


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- collect_tickets_data が返すデータにおいて、ticketsの要素dictにtargetを追加する

## 経緯・意図・意思決定
safetyImpactを推定する外部ツールの入力情報として、yarn.lock、requirements.txtなどのパスが必要であった。
threatconnectomeでこれに近い情報として、Dependencyテーブルのtargetがあるため、collect_tickets_data がtargetを出力し、targetを指定してsafetyImpactを推定することとする。

<!-- I want to review in Japanese. -->
