### PR TITLE
bugfix/fixed the vulnerability search screen

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -20,9 +20,7 @@ export function PackageView(props) {
       <Grid container>
         {/* affected versions */}
         <Grid
-          item
-          xs={12}
-          md={7}
+          size={{ xs: 12, md: 7 }}
           sx={{
             display: "flex",
             flexDirection: "column",
@@ -66,9 +64,7 @@ export function PackageView(props) {
         </Grid>
         {/* patched versions */}
         <Grid
-          item
-          xs={12}
-          md={5}
+          size={{ xs: 12, md: 5 }}
           sx={{
             display: "flex",
             flexDirection: "column",

--- a/web/src/pages/PTeam/PTeamInviteModal.jsx
+++ b/web/src/pages/PTeam/PTeamInviteModal.jsx
@@ -10,7 +10,6 @@ import {
   IconButton,
   Link,
   Slider,
-  TextField,
   Typography,
 } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
@@ -102,7 +101,7 @@ export function PTeamInviteModal(props) {
               </Box>
             ) : (
               <Grid container alignItems="center">
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <Box sx={{ p: 1 }}>
                     <DateTimePicker
                       format="yyyy/MM/dd HH:mm"
@@ -111,13 +110,17 @@ export function PTeamInviteModal(props) {
                       minDateTime={now}
                       value={expiration}
                       onChange={(newDate) => setExpiration(newDate)}
-                      renderInput={(params) => (
-                        <TextField fullWidth margin="dense" required {...params} />
-                      )}
+                      slotProps={{
+                        textField: {
+                          fullWidth: true,
+                          margin: "dense",
+                          required: true,
+                        },
+                      }}
                     />
                   </Box>
                 </Grid>
-                <Grid item xs={12} sm={6}>
+                <Grid size={{ xs: 12, md: 6 }}>
                   <Box display="flex" flexDirection="column" justifyContent="center" sx={{ p: 1 }}>
                     <Typography>Max uses: {maxUses || "unlimited"}</Typography>
                     <Box mx={1}>

--- a/web/src/pages/ToDo/Insights/RiskAnalysisView.jsx
+++ b/web/src/pages/ToDo/Insights/RiskAnalysisView.jsx
@@ -68,7 +68,7 @@ export function RiskAnalysisView(props) {
       <Paper elevation={3} sx={{ p: 4, borderRadius: 4 }}>
         <Grid container spacing={4}>
           {/* Risk Summary */}
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
               <Box>
                 <WarningAmberIcon sx={{ fontSize: 40, color: "error.main" }} />
@@ -96,7 +96,7 @@ export function RiskAnalysisView(props) {
           </Grid>
 
           {/* Detailed Analysis */}
-          <Grid item xs={12}>
+          <Grid size={12}>
             <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
               <Tabs
                 value={tabValue}

--- a/web/src/pages/ToDo/Insights/ThreatScenario.jsx
+++ b/web/src/pages/ToDo/Insights/ThreatScenario.jsx
@@ -20,7 +20,7 @@ export function ThreatScenario(props) {
         {threatScenarios.map((scenario, index) => {
           const ImpactCategoryIcon = impactCategoryIcons[scenario.impact_category].icon;
           return (
-            <Grid item xs={12} key={index}>
+            <Grid size={12} key={index}>
               <Card variant="outlined">
                 <CardHeader
                   avatar={

--- a/web/src/pages/VulnDetail/VulnSSVCElement.jsx
+++ b/web/src/pages/VulnDetail/VulnSSVCElement.jsx
@@ -18,7 +18,7 @@ export function VulnSSVCElement(props) {
   const valueDescription = filterValue.valueDescription;
 
   return (
-    <Grid key={title} item xs={12} md={6}>
+    <Grid key={title} size={{ xs: 12, md: 6 }}>
       <Card variant="outlined" sx={{ p: 3, height: "100%" }}>
         <Box
           sx={{

--- a/web/src/pages/VulnManagement/VulnSearchModal.jsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.jsx
@@ -244,16 +244,16 @@ export function VulnSearchModal(props) {
           </Grid>
         )}
         {dateFormList === "range" && (
-          <Grid item xs={11.4} display="flex">
+          <Grid size={{ xs: 11.4 }} display="flex">
             <DateTimePicker
               inputFormat="yyyy/MM/dd HH:mm"
               mask="____/__/__ __:__"
               maxDateTime={updatedBefore || now}
               value={updatedAfter}
               onChange={(newDate) => setUpdatedAfter(newDate)}
-              renderInput={(params) => (
-                <TextField size="small" fullWidth margin="dense" required {...params} />
-              )}
+              slotProps={{
+                textField: { size: "small", fullWidth: true, margin: "dense", required: true },
+              }}
             />
             <Typography sx={{ margin: "20px" }}>~</Typography>
             <DateTimePicker
@@ -263,9 +263,12 @@ export function VulnSearchModal(props) {
               maxDateTime={now}
               value={updatedBefore}
               onChange={(newDate) => setUpdatedBefore(newDate)}
-              renderInput={(params) => (
-                <TextField size="small" fullWidth margin="dense" required {...params} />
-              )}
+              slotProps={{
+                textField: { size: "small", fullWidth: true, margin: "dense", required: true },
+              }}
+              // renderInput={(params) => (
+              //   <TextField size="small" fullWidth margin="dense" required {...params} />
+              // )}
             />
           </Grid>
         )}

--- a/web/src/pages/VulnManagement/VulnSearchModal.jsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.jsx
@@ -266,9 +266,6 @@ export function VulnSearchModal(props) {
               slotProps={{
                 textField: { size: "small", fullWidth: true, margin: "dense", required: true },
               }}
-              // renderInput={(params) => (
-              //   <TextField size="small" fullWidth margin="dense" required {...params} />
-              // )}
             />
           </Grid>
         )}

--- a/web/src/pages/VulnManagement/VulnSearchModal.jsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.jsx
@@ -136,10 +136,10 @@ export function VulnSearchModal(props) {
 
   const titleForm = (
     <Grid container sx={{ margin: 1.5, width: "100%" }}>
-      <Grid item xs={2} md={2}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>Title</Typography>
       </Grid>
-      <Grid item xs={10} md={10} sx={{ display: "flex" }}>
+      <Grid size={{ xs: 10, md: 10 }} sx={{ display: "flex" }}>
         <TextField
           value={titleWords}
           onChange={(event) => setTitleWords(event.target.value)}
@@ -152,11 +152,11 @@ export function VulnSearchModal(props) {
   );
 
   const cveIdForm = (
-    <Grid container sx={{ margin: 1.5 }}>
-      <Grid item xs={2} md={2}>
+    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>CVE ID</Typography>
       </Grid>
-      <Grid item xs={10} md={10}>
+      <Grid size={{ xs: 10, md: 10 }}>
         <TextField
           value={cveIds}
           onChange={(event) => setCveIds(event.target.value)}
@@ -169,11 +169,11 @@ export function VulnSearchModal(props) {
   );
 
   const cvssForm = (
-    <Grid container sx={{ margin: 1.5 }} alignItems={"center"}>
-      <Grid item xs={2} md={2}>
+    <Grid container sx={{ margin: 1.5, width: "100%" }} alignItems={"center"}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>CVSS v3</Typography>
       </Grid>
-      <Grid item xs={10} md={10}>
+      <Grid size={{ xs: 10, md: 10 }}>
         <ToggleButtonGroup
           color="primary"
           exclusive
@@ -212,11 +212,11 @@ export function VulnSearchModal(props) {
   );
 
   const dateForm = (
-    <Grid container sx={{ margin: 1.5 }}>
-      <Grid item xs={2} md={2}>
+    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>Last Update</Typography>
       </Grid>
-      <Grid item xs={10} md={10} display="flex" flexDirection="column">
+      <Grid size={{ xs: 10, md: 10 }} display="flex" flexDirection="column">
         <FormControl variant="standard" sx={{ m: 1, maxWidth: 200 }}>
           <Select value={dateFormList} onChange={dateFormChange}>
             <MenuItem value="">None</MenuItem>
@@ -228,7 +228,7 @@ export function VulnSearchModal(props) {
           </Select>
         </FormControl>
         {(dateFormList === "since" || dateFormList === "until") && (
-          <Grid item xs={5}>
+          <Grid size={{ xs: 5 }}>
             <DateTimePicker
               format="yyyy/MM/dd HH:mm"
               mask="____/__/__ __:__"
@@ -237,9 +237,9 @@ export function VulnSearchModal(props) {
               onChange={(newDate) =>
                 (dateFormList === "since" ? setUpdatedAfter : setUpdatedBefore)(newDate)
               }
-              renderInput={(params) => (
-                <TextField size="small" fullWidth margin="dense" required {...params} />
-              )}
+              slotProps={{
+                textField: { size: "small", fullWidth: true, margin: "dense", required: true },
+              }}
             />
           </Grid>
         )}
@@ -274,11 +274,11 @@ export function VulnSearchModal(props) {
   );
 
   const creatorForm = (
-    <Grid container sx={{ margin: 1.5 }}>
-      <Grid item xs={2} md={2}>
+    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>Creator ID</Typography>
       </Grid>
-      <Grid item xs={10} md={10}>
+      <Grid size={{ xs: 10, md: 10 }}>
         <TextField
           value={creatorIds}
           onChange={(event) => setCreatorIds(event.target.value)}
@@ -291,11 +291,11 @@ export function VulnSearchModal(props) {
   );
 
   const uuidForm = (
-    <Grid container sx={{ margin: 1.5 }}>
-      <Grid item xs={2} md={2}>
+    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+      <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>Vuln ID</Typography>
       </Grid>
-      <Grid item xs={10} md={10}>
+      <Grid size={{ xs: 10, md: 10 }}>
         <TextField
           value={vulnIds}
           onChange={(event) => setVulnIds(event.target.value)}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- [こちらのPR](https://github.com/nttcom/threatconnectome/pull/898)でmaterial uiのパッケージをアップデートしたことに伴い、Vuln Searchの画面のデザインが崩れていたため修正しました

### 原因
- "@mui/material"をv5からv7にアップデートした際に`Gird`のサイズの扱い方が変わっていたためエラーが起きていました

### その他の修正
- DateTimePickerのrenderInputについてもアップデートしたことにより扱い方が変わっていたため修正しました

修正前:
<img width="1530" height="952" alt="スクリーンショット 2025-09-05 16 38 46（2）" src="https://github.com/user-attachments/assets/7aaedc87-97ba-47bc-8f8f-d8ee827d45a6" />

修正後:
<img width="1497" height="884" alt="スクリーンショット 2025-09-05 16 38 59（2）" src="https://github.com/user-attachments/assets/c657f723-31c5-4f66-b1ac-818059fb32f8" />


## 参考
- Gird
  - https://mui.com/material-ui/migration/upgrade-to-grid-v2/#codemod-not-covering-wrapped-grid-components
- DateTimePicker
  - https://mui.com/material-ui/migration/upgrade-to-grid-v2/#3-update-the-size-props

<!-- I want to review in Japanese. -->
