### PR TITLE
change max_reason_safety_impact_length_in_half

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -970,7 +970,7 @@ def update_ticket_safety_impact(
     """
     Update ticket_safety_impact.
     """
-    max_reason_safety_impact_length_in_half = 500
+    max_reason_safety_impact_length_in_half = 2000
 
     if not (pteam := persistence.get_pteam_by_id(db, pteam_id)):
         raise NO_SUCH_PTEAM


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- ticket_safety_impact_change_reason(ticket用safety_impactの変更理由)の最大文字長を半角500文字から2000文字に変更する。
  - ※全角は2文字として計算する

## 経緯・意図・意思決定
AIによるsafety_impact推定を行っているが、これが1000文字を超えるケースがあったため、最大長を変更する。



<!-- I want to review in Japanese. -->
