### PR TITLE
fix Grid component in PTeamStatusSSVCCards

### DIFF
--- a/web/src/pages/Status/PTeamStatusSSVCCards.jsx
+++ b/web/src/pages/Status/PTeamStatusSSVCCards.jsx
@@ -94,7 +94,7 @@ export function PTeamStatusSSVCCards(props) {
   return (
     // Create Highest SSVC Priority card
     <Grid container spacing={2}>
-      <Grid key={HighestSSVCPriorityList.title} item xs={4}>
+      <Grid key={HighestSSVCPriorityList.title} size={{ xs: 4 }}>
         <Paper
           sx={{
             textAlign: "center",
@@ -162,7 +162,7 @@ export function PTeamStatusSSVCCards(props) {
 
       {SSVCCardsList.map((card) => (
         // Create System Exposure card and Mission Impact
-        <Grid key={card.title} item xs={4}>
+        <Grid key={card.title} size={{ xs: 4 }}>
           <Paper
             sx={{
               textAlign: "center",


### PR DESCRIPTION
## PR の目的
- PTeamStatusSSVCCardsのGrid Componentを修正し、PTeamStatusSSVCCardsが真ん中に表示されるように変更

## 経緯・意図・意思決定
- MUIのアップデート時にPTeamStatusSSVCCardsのUI表示が左寄りになっていたため。
