### PR TITLE
Topic/update UI library

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,12 +1,12 @@
-import js from "@eslint/js"
+import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import prettier from "eslint-config-prettier";
 import importPlugin from "eslint-plugin-import";
 import jsxA11y from "eslint-plugin-jsx-a11y";
-import react from "eslint-plugin-react"
-import reactHooks from "eslint-plugin-react-hooks"
-import reactRefresh from "eslint-plugin-react-refresh"
-import globals from "globals"
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import globals from "globals";
 
 export default [
   { ignores: ["dist", "build"] },
@@ -34,6 +34,7 @@ export default [
         node: {
           extensions: [".js", ".jsx"],
         },
+        exports: { extensions: [".js", ".jsx"] },
       },
     },
     plugins: {
@@ -50,10 +51,7 @@ export default [
       ...reactHooks.configs.recommended.rules,
       ...vitest.configs.recommended.rules,
       "react/jsx-no-target-blank": "off",
-      "react-refresh/only-export-components": [
-        "warn",
-        { allowConstantExport: true },
-      ],
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
       "no-unused-vars": "off",
       quotes: ["error", "double"],
       "import/order": [
@@ -61,14 +59,16 @@ export default [
         {
           alphabetize: { order: "asc" },
           groups: ["builtin", "external", "parent", "sibling", "index", "object", "type"],
-          pathGroups: [{
-            group: "parent",
-            pattern: "@alias/**",
-            position: "before",
-          }],
+          pathGroups: [
+            {
+              group: "parent",
+              pattern: "@alias/**",
+              position: "before",
+            },
+          ],
           "newlines-between": "always",
         },
       ],
     },
   },
-]
+];

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,6 +47,7 @@
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-config-react-hooks": "^1.0.0",
+        "eslint-import-resolver-exports": "^1.0.0-beta.5",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
@@ -4689,6 +4690,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/eslint-import-resolver-exports": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-exports/-/eslint-import-resolver-exports-1.0.0-beta.5.tgz",
+      "integrity": "sha512-o6t0w7muUpXr7MkUVzD5igQoDfAQvTmcPp8HEAJdNF8eOuAO+yn6I/TTyMxz9ecCwzX7e02vzlkHURoScUuidg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve.exports": "^2.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -7400,6 +7415,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {

--- a/web/package.json
+++ b/web/package.json
@@ -43,6 +43,7 @@
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-react-hooks": "^1.0.0",
+    "eslint-import-resolver-exports": "^1.0.0-beta.5",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
UIに利用している各ライブラリのアップデート
- npm-check-updatesを用いて、ライブラリのアップデートをチェック&実行
- react、react-domに関しては最新バージョンは19.1.1だが、他のライブラリがreactの19.1.1に対応ようでnpm installが失敗するため、18.3.1のままにしている

段階的なアップデートを行うために各コミットで
npm update > ncu -u --target minor > ncu -u --target latestの順で実行している

web/eslint.config.jsの修正
- react-error-boundaryを6.0.0以上にするとESM形式のみの対応になり、web/node_modules/react-error-boundary/package.jsonに記載のentry fileの情報がexports項目に記載されるようになる
  - https://github.com/bvaughn/react-error-boundary/releases
- eslintの現状の設定だとexports項目をうまく解決できない
　　-  [参考](https://github.com/import-js/eslint-plugin-import/issues/1868)
- これを解決するためにeslint-import-resolver-exportsを追加し、その設定をweb/eslint.config.jsに追加
  - https://www.npmjs.com/package/eslint-import-resolver-exports

<!-- I want to review in Japanese. -->
