### PR TITLE
check title is None

### DIFF
--- a/scripts/vulnrichment2tc.py
+++ b/scripts/vulnrichment2tc.py
@@ -130,10 +130,13 @@ def _get_cve_data_from_json_data(vulnrichment_json: dict) -> tuple:
 
     adp_vulnrichment = next(
         filter(
-            lambda x: x["title"] == "CISA ADP Vulnrichment",
+            lambda x: x.get("title") == "CISA ADP Vulnrichment",
             vulnrichment_json["containers"]["adp"],
-        )
+        ),
+        None,
     )
+    if not adp_vulnrichment:
+        return ()
 
     if all("other" not in x for x in adp_vulnrichment["metrics"]):
         return ()


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- vulnrichment2tc実行時、下記ファイルが正常に処理されなかったため、修正する
vulnrichment/2017/12xxx/CVE-2017-12637.json
  - [原因]
    - containers.adp: listから"title" == "CISA ADP Vulnrichment"の要素を探す際、
"title"が存在しない要素があり、そこで処理が止まっていた。
  - [対策]
    - titleを持たない要素があっても処理が止まらないよう修正する

<!-- I want to review in Japanese. -->
