### PR TITLE
Topic/update python version

### DIFF
--- a/.github/workflows/lint_e2etest.yml
+++ b/.github/workflows/lint_e2etest.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.12"
   PYTHON_ROOT_DIRS: ./
   E2ETEST_DIRS: ./e2etests
 

--- a/.github/workflows/lint_scripts.yml
+++ b/.github/workflows/lint_scripts.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.12"
   PYTHON_ROOT_DIRS: ./
   SCRIPTS_DIRS: ./scripts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   CACHE_VERSION: 1
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.12"
   PYTHON_ROOT_DIRS: ./app
   API_DIRS: ./api
   FIREBASE_DIRS: ./firebase

--- a/.github/workflows/pip-dependencies.yml
+++ b/.github/workflows/pip-dependencies.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEFAULT_PYTHON: "3.10"
+  DEFAULT_PYTHON: "3.12"
   API_DIRS: ./api
 
 jobs:

--- a/api-test.dockerfile
+++ b/api-test.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 LABEL description="Metemcyber Threatconnectome"
 LABEL version="0.1.0"

--- a/api.dockerfile
+++ b/api.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 LABEL description="Metemcyber Threatconnectome"
 LABEL version="0.1.0"

--- a/api/Pipfile
+++ b/api/Pipfile
@@ -37,4 +37,4 @@ httpretty = "*"
 pytest-mock = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.12"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "507122b965e98dc7c99054aa37abe52d5d0c412318d50752ad9c732b3c0dabdb"
+            "sha256": "32a24697fe08a11cd3b6228041fd2e4478a52925d71c0fc6f0dd15d987f57591"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.12"
         },
         "sources": [
             {
@@ -429,11 +429,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:60f291b0881e5c72919b156d1ee276d1b69a2538fcdc35f4e87559ae11678f77",
-                "sha256:8cace9359b85f315f21868cf771143d6dbb47dcc5a3a9317c8207accc4d10fd3"
+                "sha256:16eeca305e4747a6871f8f7627eef3b862fdd365b872ca74d4a89e9841d0f8e8",
+                "sha256:4c77ec00c98ccc6428e4c39404926f41e2152f48809b02af29d5116645c3c317"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.3.1"
+            "version": "==3.4.0"
         },
         "google-crc32c": {
             "hashes": [
@@ -1203,12 +1203,12 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db",
-                "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b"
+                "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2",
+                "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.11.7"
+            "version": "==2.11.9"
         },
         "pydantic-core": {
             "hashes": [

--- a/e2e-test.dockerfile
+++ b/e2e-test.dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bullseye
+FROM python:3.12-slim
 COPY ./Pipfile.lock ./Pipfile /
 RUN python -m pip install --upgrade pip
 RUN python -m pip install pipenv

--- a/e2etests/Pipfile
+++ b/e2etests/Pipfile
@@ -14,4 +14,4 @@ ruff = "*"
 mypy = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.12"

--- a/e2etests/Pipfile.lock
+++ b/e2etests/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78324e5a34b6e28c567ebd26949549c0516015545a1f0980766ebc990dab2ff2"
+            "sha256": "6104dd43f7038f180b74bda53e6e069a56241edbdff946f74c114341faf966e2"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.12"
         },
         "sources": [
             {
@@ -114,7 +114,7 @@
                 "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10",
                 "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.3.0"
         },
         "greenlet": {
@@ -323,24 +323,24 @@
                 "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a",
                 "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.8'",
             "version": "==2.2.1"
         },
         "types-requests": {
             "hashes": [
-                "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3",
-                "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163"
+                "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1",
+                "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.32.4.20250809"
+            "version": "==2.32.4.20250913"
         },
         "typing-extensions": {
             "hashes": [
                 "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
                 "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
             ],
-            "markers": "python_version < '3.13'",
+            "markers": "python_version >= '3.9'",
             "version": "==4.15.0"
         },
         "urllib3": {

--- a/scripts/Pipfile
+++ b/scripts/Pipfile
@@ -14,4 +14,4 @@ ruff = "*"
 mypy = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.12"

--- a/scripts/Pipfile
+++ b/scripts/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 requests = "*"
 types-requests = "*"
 boltdb = "*"
+typing-extensions = "*"
 
 [dev-packages]
 black = "*"

--- a/scripts/Pipfile.lock
+++ b/scripts/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aed36734a1e93118e760e3c614ab5f57ef2c624e1f233d2294b1a42f6e57e2fa"
+            "sha256": "40ee5c7dc65cb5de9ad8c74bdabce73dd2ab4466d3179b0fcf6cbfb7e594fb26"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -143,6 +143,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==2.32.4.20250913"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
+                "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.15.0"
         },
         "urllib3": {
             "hashes": [
@@ -337,7 +346,7 @@
                 "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
                 "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.9'",
             "version": "==4.15.0"
         }
     }

--- a/scripts/Pipfile.lock
+++ b/scripts/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f19993523d269d13c23f15fdc6f876bdb531531204c531c343630149a0390dc7"
+            "sha256": "aed36734a1e93118e760e3c614ab5f57ef2c624e1f233d2294b1a42f6e57e2fa"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.12"
         },
         "sources": [
             {
@@ -137,12 +137,12 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3",
-                "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163"
+                "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1",
+                "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==2.32.4.20250809"
+            "version": "==2.32.4.20250913"
         },
         "urllib3": {
             "hashes": [


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- pythonのバージョンをアップデートしました
- typing_extensionsがpythonの3.12ではPython 標準ライブラリでは無くなったのでscript/Pipfile, Pipfile.lockに追加しました

修正箇所
- api.dockerfile
- api-test.dockerfile
- e2e-test.dockerfile
- api/Pipfile, Pipfile.lock
- scipts/Pipfile, Pipfile.lock
- e2etests/Pipfile, Pipfile.lock
- lint_e2etest.yml
- lint_scripts.yml
- main.yml
- pip-dependencies.yml

## 参考
- https://qiita.com/ijknabla/items/866ef9de98d313b34eb1

<!-- I want to review in Japanese. -->
