### PR TITLE
update firebase-tools in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install firebase local emulators
-        run: npm install -g firebase-tools@11.25.2
+        run: npm install -g firebase-tools@14.16.0
       - name: Run firebase and run pytest
         run: |
           firebase emulators:exec --import=./data-test \


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- CI上でAPIテストを行う際に使用するfirebase-toolsのバージョンをv14.16.0にアップデートする

## 経緯・意図・意思決定
https://github.com/nttcom/threatconnectome/pull/923
において、firebase/Dockerfileに記述したfirebase-toolsのバージョンをv14.16.0に変更したが、
.github/workflows/main.ymlで同様の修正が漏れていた。

## 参考文献
https://github.com/firebase/firebase-tools/releases?after=v8.4.0
によると、各バージョンが安定バージョンかどうかの記述はないが、多種の修正を実施しているv14.16.0が適切と判断した

<!-- I want to review in Japanese. -->
