### PR TITLE
bugfix/downgrade kong

### DIFF
--- a/docker-compose-supabase-local.yml
+++ b/docker-compose-supabase-local.yml
@@ -124,7 +124,7 @@ services:
 
   kong:
     container_name: supabase-kong
-    image: kong:3.9.1
+    image: kong:2.8.1
     restart: unless-stopped
     ports:
       - 8000:8000/tcp

--- a/docker-compose-supabase-test.yml
+++ b/docker-compose-supabase-test.yml
@@ -94,7 +94,7 @@ services:
 
   kong:
     container_name: supabase-kong
-    image: kong:3.9.1
+    image: kong:2.8.1
     restart: unless-stopped
     ports:
       - 8000:8000/tcp


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的
- [このPR](https://github.com/nttcom/threatconnectome/pull/923)で kongのバージョンを`3.9.1`としていましたが、コンテナが動作しないため、元のバージョンである2.8.1に戻します

<!-- I want to review in Japanese. -->
