### PR TITLE
fix eslint

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,12 +1,13 @@
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
+import globals from "globals";
+import eslintConfigPrettier from "eslint-config-prettier";
 import prettier from "eslint-config-prettier";
 import importPlugin from "eslint-plugin-import";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
-import globals from "globals";
 import unusedImports from "eslint-plugin-unused-imports";
 
 export default [
@@ -47,7 +48,6 @@ export default [
     },
     rules: {
       ...js.configs.recommended.rules,
-      ...prettier.rules,
       ...react.configs.recommended.rules,
       ...react.configs["jsx-runtime"].rules,
       ...reactHooks.configs.recommended.rules,
@@ -58,7 +58,6 @@ export default [
       "react/no-unused-prop-types": ["error"],
       "unused-imports/no-unused-imports": "error",
       "no-unused-vars": "off",
-      quotes: ["error", "double"],
       "import/order": [
         "error",
         {
@@ -76,4 +75,5 @@ export default [
       ],
     },
   },
+  eslintConfigPrettier,
 ];


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- eslint.config.jsにおいて、Prettierの設定を優先させる記述を修正する
  - 変更前
`...prettier.rules,`
  - 変更後
`eslintConfigPrettier`
- quotesは非推奨のため、削除する

## 経緯・意図・意思決定
`const message = "He said, \"It's a great design!\"";`
と記述すると、まずPrettierが下記に整形する
`const message = 'He said, "It\'s a great design!"';`
その後、npm run checkを実行するとエラーとなっていた。

web/eslint.config.jsにおいて、
`...prettier.rules,`
を定義することでPrettierの設定を優先させようとしていたが、その後に
`quotes: ["error", "double"],`
を記述していたため、Prettierと競合するquotesが有効となった。

## 参考文献
1. ESLint公式：非推奨となったルール一覧
https://eslint.org/docs/latest/rules/#deprecated
2. Prettier公式ガイド：リンター（ESLint）との統合
https://prettier.io/docs/en/integrating-with-linters
3. eslint-config-prettier (GitHubリポジトリ)
https://github.com/prettier/eslint-config-prettier

<!-- I want to review in Japanese. -->
