### PR TITLE
check duplicate email in create user

### DIFF
--- a/api/app/persistence.py
+++ b/api/app/persistence.py
@@ -13,6 +13,10 @@ def get_account_by_uid(db: Session, uid: str) -> models.Account | None:
     return db.scalars(select(models.Account).where(models.Account.uid == uid)).one_or_none()
 
 
+def get_accounts_by_email(db: Session, email: str) -> Sequence[models.Account]:
+    return db.scalars(select(models.Account).where(models.Account.email == email)).all()
+
+
 def get_account_by_id(db: Session, user_id: UUID | str) -> models.Account | None:
     return db.scalars(
         select(models.Account).where(models.Account.user_id == str(user_id))

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -50,6 +50,12 @@ def create_user(
     if persistence.get_account_by_uid(db, uid):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uid already used")
 
+    if len(persistence.get_accounts_by_email(db, email)) > 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This email is already registered in the system. Please use a different email.",
+        )
+
     account = models.Account(**data.model_dump(), uid=uid, email=email)
     persistence.create_account(db, account)
 

--- a/api/app/tests/medium/routers/test_users.py
+++ b/api/app/tests/medium/routers/test_users.py
@@ -23,15 +23,19 @@ def test_create_user():
     assert user1.user_id != ZERO_FILLED_UUID
 
 
-def test_duplicate_email_user_can_be_registered(testdb):
+def test_it_should_return_400_when_create_user_with_duplicate_email(testdb):
     email = USER1["email"]
-    account = models.Account(uid="test_uid1", email=email, years=2)
+    years = USER1["years"]
+    account = models.Account(uid="test_uid1", email=email, years=years)
     persistence.create_account(testdb, account)
 
-    user1 = create_user(USER1)
-    assert user1.email == USER1["email"]
-    assert user1.years == USER1["years"]
-    assert user1.user_id != ZERO_FILLED_UUID
+    request = {"years": years}
+    response = client.post("/users", headers=headers(USER1), json=request)
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "This email is already registered in the system. Please use a different email."
+    )
 
 
 def test_duplicate_user():

--- a/web/src/pages/Login/LoginPage.jsx
+++ b/web/src/pages/Login/LoginPage.jsx
@@ -78,14 +78,17 @@ export function Login() {
           break;
         }
         case "No such user":
-          await createUser({}); // should get uid & email via firebase credential in api.
-          // TODO: navigate to the first time login page, or say hello on snackbar.
-          navigate("/account", {
-            state: {
-              from: redirectedFrom.from ?? "/",
-              search: redirectedFrom.search ?? "",
-            },
-          });
+          await createUser({})
+            .unwrap()
+            .then(() =>
+              navigate("/account", {
+                state: {
+                  from: redirectedFrom.from ?? "/",
+                  search: redirectedFrom.search ?? "",
+                },
+              }),
+            )
+            .catch((error) => setMessage(error.data?.detail ?? "Something went wrong."));
           break;
         default:
           setMessage("Something went wrong.");


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- Post /users APIにおいて、Authサービスから取得したemailがTCのDBに登録済の場合、エラーとする
- UIでログイン時にAuthサービス認証後、TcのDBにアカウント登録されていないことを検知し、アカウント作成APIを呼び出した際、APIがエラーであればエラー表示するよう実装した

## 経緯・意図・意思決定


<!-- I want to review in Japanese. -->
