### PR TITLE
fix height vuln version Box

### DIFF
--- a/web/src/components/PackageView.jsx
+++ b/web/src/components/PackageView.jsx
@@ -36,7 +36,8 @@ export function PackageView(props) {
                   alignItems: "center",
                   mb: 1,
                   minWidth: 0,
-                  height: "48px",
+                  minHeight: "48px",
+                  flexWrap: "wrap",
                 }}
               >
                 <WarningIcon sx={{ fontSize: 32, color: yellow[900], mr: 1 }} />
@@ -80,7 +81,8 @@ export function PackageView(props) {
                   alignItems: "center",
                   mb: 1,
                   minWidth: 0,
-                  height: "48px",
+                  minHeight: "48px",
+                  flexWrap: "wrap",
                 }}
               >
                 <RecommendIcon sx={{ fontSize: 32, color: green[500], mr: 1 }} />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- 脆弱性情報のfixedVersionsを表示するページにおいて、１つのバージョン文字列が長く自動改行される際、高さが不正になり上のアイテムに重なる不具合を修正した
  - 影響範囲
    - Vuln詳細ページのPackage
    - PackageページDETAILボタンによるDrawerのPackage
    - PackageページDETAILボタンによるDrawerを全画面表示した際のPackage
    - TodoページDETAILSボタンVulnタブのPackage

<!-- I want to review in Japanese. -->
