### PR TITLE
feat(SafetyImpactSelector): Safety Impactの編集UIをダイアログに集約

### DIFF
--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -2,6 +2,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import {
   Box,
   Button,
+  Collapse,
   Dialog,
   DialogActions,
   DialogContent,
@@ -11,6 +12,7 @@ import {
   IconButton,
   MenuItem,
   Select,
+  Stack,
   TextField,
   Tooltip,
   Typography,
@@ -38,33 +40,33 @@ export function SafetyImpactSelectorView(props) {
 
   const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
   const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
-  const [openReasonDialog, setOpenReasonDialog] = useState(false);
+  const [openDialog, setOpenDialog] = useState(false);
 
   const defaultSafetyImpactItem = "Default";
 
   const { enqueueSnackbar } = useSnackbar();
 
+  const handleOpenDialog = () => {
+    setPendingSafetyImpact(fixedTicketSafetyImpact || defaultSafetyImpactItem);
+    setPendingReasonSafetyImpact(fixedTicketSafetyImpactChangeReason || "");
+    setOpenDialog(true);
+  };
+
   const handleSelectSafetyImpact = (e) => {
-    if (e.target.value === defaultSafetyImpactItem) {
-      setPendingSafetyImpact("");
-      setPendingReasonSafetyImpact("");
-      onRevertedToDefault();
-    } else {
-      setPendingSafetyImpact(e.target.value);
-      setPendingReasonSafetyImpact(
-        fixedTicketSafetyImpactChangeReason === null ? "" : fixedTicketSafetyImpactChangeReason,
-      );
-      setOpenReasonDialog(true);
-    }
+    setPendingSafetyImpact(e.target.value);
   };
 
   const handleClose = () => {
-    setOpenReasonDialog(false);
+    setOpenDialog(false);
   };
 
-  const handleSaveReason = async () => {
-    onSave(pendingSafetyImpact, pendingReasonSafetyImpact);
-    setOpenReasonDialog(false);
+  const handleSaveReason = () => {
+    if (pendingSafetyImpact === defaultSafetyImpactItem) {
+      onRevertedToDefault();
+    } else {
+      onSave(pendingSafetyImpact, pendingReasonSafetyImpact);
+    }
+    setOpenDialog(false);
   };
 
   const handleReasonSafetyImpactLengthCheck = (string) => {
@@ -79,6 +81,15 @@ export function SafetyImpactSelectorView(props) {
       setPendingReasonSafetyImpact(string);
     }
   };
+
+  const isUnchanged =
+    (fixedTicketSafetyImpact || defaultSafetyImpactItem) === pendingSafetyImpact &&
+    (fixedTicketSafetyImpactChangeReason || "") === pendingReasonSafetyImpact;
+
+  const isReasonRequiredAndEmpty =
+    pendingSafetyImpact !== defaultSafetyImpactItem && pendingReasonSafetyImpact === "";
+
+  const isSaveDisabled = isUnchanged || isReasonRequiredAndEmpty;
 
   const StyledTooltip = styled(({ className, ...props }) => (
     <Tooltip {...props} classes={{ popper: className }} />
@@ -100,10 +111,9 @@ export function SafetyImpactSelectorView(props) {
     <Box sx={{ display: "flex", alignItems: "center" }}>
       <FormControl sx={{ width: 130 }} size="small" variant="standard">
         <Select
+          open={false}
           value={fixedTicketSafetyImpact ? fixedTicketSafetyImpact : defaultSafetyImpactItem}
-          onChange={(e) => {
-            handleSelectSafetyImpact(e);
-          }}
+          onOpen={handleOpenDialog}
         >
           <MenuItem key={defaultSafetyImpactItem} value={defaultSafetyImpactItem}>
             {defaultSafetyImpactItem}
@@ -134,38 +144,43 @@ export function SafetyImpactSelectorView(props) {
           </IconButton>
         </StyledTooltip>
       )}
-      <Dialog open={openReasonDialog} onClose={handleClose} maxWidth="sm" fullWidth>
+      <Dialog open={openDialog} onClose={handleClose} maxWidth="sm" fullWidth>
         <DialogTitle>Safety Impact update</DialogTitle>
         <DialogContent>
-          <Box sx={{ pb: 2 }}>
-            <DialogContentText>
-              Current:{" "}
-              {fixedTicketSafetyImpact
-                ? safetyImpactProps[fixedTicketSafetyImpact].displayName
-                : defaultSafetyImpactItem}
-            </DialogContentText>
-            <DialogContentText>
-              Updated:{" "}
-              {pendingSafetyImpact === ""
-                ? defaultSafetyImpactItem
-                : safetyImpactProps[pendingSafetyImpact].displayName}
-            </DialogContentText>
-          </Box>
-          <DialogContentText>Enter the reason for changing Safety Impact</DialogContentText>
-          <TextField
-            hiddenLabel
-            variant="filled"
-            fullWidth
-            multiline
-            rows={4}
-            placeholder="Continue writing here"
-            value={pendingReasonSafetyImpact}
-            onChange={(e) => handleReasonSafetyImpactLengthCheck(e.target.value)}
-          />
+          <Stack spacing={2}>
+            <FormControl fullWidth>
+              <Select
+                value={pendingSafetyImpact}
+                onChange={handleSelectSafetyImpact}
+                inputProps={{ "aria-label": "Safety Impact" }}
+              >
+                <MenuItem value={defaultSafetyImpactItem}>{defaultSafetyImpactItem}</MenuItem>
+                {sortedSafetyImpacts.map((safetyImpact) => (
+                  <MenuItem key={safetyImpact} value={safetyImpact}>
+                    {safetyImpactProps[safetyImpact]?.displayName}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Collapse in={pendingSafetyImpact !== defaultSafetyImpactItem}>
+              <DialogContentText>Enter the reason for changing Safety Impact</DialogContentText>
+              <TextField
+                hiddenLabel
+                variant="filled"
+                fullWidth
+                multiline
+                rows={4}
+                placeholder="Continue writing here"
+                value={pendingReasonSafetyImpact}
+                onChange={(e) => handleReasonSafetyImpactLengthCheck(e.target.value)}
+              />
+            </Collapse>
+          </Stack>
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Button onClick={handleSaveReason} disabled={pendingReasonSafetyImpact === ""}>
+          <Button onClick={handleSaveReason} disabled={isSaveDisabled}>
             Save
           </Button>
         </DialogActions>

--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -164,14 +164,13 @@ export function SafetyImpactSelectorView(props) {
             </FormControl>
 
             <Collapse in={pendingSafetyImpact !== defaultSafetyImpactItem}>
-              <DialogContentText>Enter the reason for changing Safety Impact</DialogContentText>
+              <DialogContentText>Provide the reason for this Safety Impact</DialogContentText>
               <TextField
                 hiddenLabel
                 variant="filled"
                 fullWidth
                 multiline
                 rows={4}
-                placeholder="Continue writing here"
                 value={pendingReasonSafetyImpact}
                 onChange={(e) => handleReasonSafetyImpactLengthCheck(e.target.value)}
               />

--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -60,7 +60,7 @@ export function SafetyImpactSelectorView(props) {
     setOpenDialog(false);
   };
 
-  const handleSaveReason = () => {
+  const handleSave = () => {
     if (pendingSafetyImpact === defaultSafetyImpactItem) {
       onRevertedToDefault();
     } else {
@@ -180,7 +180,7 @@ export function SafetyImpactSelectorView(props) {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Button onClick={handleSaveReason} disabled={isSaveDisabled}>
+          <Button onClick={handleSave} disabled={isSaveDisabled}>
             Save
           </Button>
         </DialogActions>

--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -109,7 +109,7 @@ export function SafetyImpactSelectorView(props) {
 
   return (
     <Box sx={{ display: "flex", alignItems: "center" }}>
-      <FormControl sx={{ width: 130 }} size="small" variant="standard">
+      <FormControl size="small" variant="standard">
         <Select
           open={false}
           value={fixedTicketSafetyImpact ? fixedTicketSafetyImpact : defaultSafetyImpactItem}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

`SafetyImpactSelector`コンポーネントのUIをリファクタリングし、`Safety Impact`の選択と変更理由の入力を、単一のダイアログ内で完結させることで、ユーザー体験の一貫性と操作性を向上させます。

## 経緯・意図・意思決定

### 経緯
従来のUIでは、ユーザーの選択によってコンポーネントの応答が異なり、UX上の課題を抱えていました。

- **操作の一貫性の欠如**:
  従来のUIでは、`<Select>`のドロップダウンから行う選択によって、その後の挙動が異なっていました。
    - **`Default`を選択した場合**: 確認なしで、即座に変更が反映される。
    - **`Default`以外を選択した場合**: 変更理由を入力するための、追加のダイアログが開く。
  このように、同じ選択操作であるにもかかわらず、その後のフローが分岐することで、ユーザーを混乱させる可能性がありました。

- **理由の再編集が煩雑**:
  - **同じステータスのまま理由だけを更新したい**場合に、一度別のステータスに変更してから、再度元のステータスに戻して理由を編集し直す、という手間のかかる操作が必要でした。

### 意思決定
これらの課題を解決するため、UI操作のフローを以下のように統一しました。

1.  **UI操作の統一**:
    外側の`<Select>`は、常に編集用ダイアログを開くためのトリガーとして機能するように変更しました。これにより、ユーザーはいつでも現在の状態を確認し、必要であればステータスや理由を直感的に編集できます。

2.  **UXの向上**:
    ダイアログ内で`Default`ステータスが選択されている場合は、理由入力フォームを`<Collapse>`コンポーネントでスムーズに非表示にします。これにより、UIの高さが滑らかに変化するようにし、理由が不要であることを明確に伝えます。

3.  **ロジックの堅牢化**:
    `Save`ボタンは、「元の状態から変更がない場合」や「理由が必須なのに空の場合」には非活性化されるようにロジックを更新し、不要なAPIコールや無意味な保存を防ぎます。

4.  **コードのクリーンアップ**:
    `handleSaveReason`関数において、`await`が使用されておらず非同期処理が不要だったため、不要な`async`キーワードを削除しました。

### このプルリクエストの対象外とした内容
- **Tooltipの表示修正**:
    今回の変更は、ダイアログの機能追加にスコープを絞っています。情報アイコンに紐づく`Tooltip`の表示内容の修正は、後続の別PRで対応します。
<!-- I want to review in Japanese. -->