### PR TITLE
feat(ui): Safety Impact理由の長いTooltipを省略表示に対応

### DIFF
--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -30,6 +30,8 @@ import {
 } from "../../../utils/const";
 import { countFullWidthAndHalfWidthCharacters } from "../../../utils/func";
 
+const TOOLTIP_TEXT_LIMIT = 150;
+
 export function SafetyImpactSelectorView(props) {
   const {
     fixedTicketSafetyImpact,
@@ -41,6 +43,7 @@ export function SafetyImpactSelectorView(props) {
   const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
   const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
   const [openDialog, setOpenDialog] = useState(false);
+  const [readMoreDialogOpen, setReadMoreDialogOpen] = useState(false);
 
   const defaultSafetyImpactItem = "Default";
 
@@ -107,6 +110,37 @@ export function SafetyImpactSelectorView(props) {
     },
   }));
 
+  const handleOpenReadMoreDialog = () => {
+    setReadMoreDialogOpen(true);
+  };
+
+  const handleCloseReadMoreDialog = () => {
+    setReadMoreDialogOpen(false);
+  };
+
+  const reasonText = fixedTicketSafetyImpactChangeReason || "";
+  const isLongReason = reasonText.length > TOOLTIP_TEXT_LIMIT;
+
+  const tooltipContent = (
+    <>
+      <Typography variant="h6" sx={{ px: 1, pt: 1 }}>
+        Why was it changed from the default safety impact?
+      </Typography>
+      <Box sx={{ p: 1 }}>
+        <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+          {isLongReason ? `${reasonText.substring(0, TOOLTIP_TEXT_LIMIT)}...` : reasonText}
+        </Typography>
+      </Box>
+      {isLongReason && (
+        <Box sx={{ textAlign: "right", px: 1, pb: 1 }}>
+          <Button size="small" onClick={handleOpenReadMoreDialog}>
+            Read more...
+          </Button>
+        </Box>
+      )}
+    </>
+  );
+
   return (
     <Box sx={{ display: "flex", alignItems: "center" }}>
       <FormControl size="small" variant="standard">
@@ -126,19 +160,7 @@ export function SafetyImpactSelectorView(props) {
         </Select>
       </FormControl>
       {fixedTicketSafetyImpactChangeReason !== null && (
-        <StyledTooltip
-          arrow
-          title={
-            <>
-              <Typography variant="h6">
-                Why was it changed from the default safety impact?
-              </Typography>
-              <Box sx={{ p: 1 }}>
-                <Typography variant="body2">{fixedTicketSafetyImpactChangeReason}</Typography>
-              </Box>
-            </>
-          }
-        >
+        <StyledTooltip arrow title={tooltipContent}>
           <IconButton size="small">
             <InfoOutlinedIcon color="primary" fontSize="small" />
           </IconButton>
@@ -183,6 +205,23 @@ export function SafetyImpactSelectorView(props) {
           <Button onClick={handleSave} disabled={isSaveDisabled}>
             Save
           </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={readMoreDialogOpen} onClose={handleCloseReadMoreDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>Why was it changed from the default safety impact?</DialogTitle>
+        <DialogContent>
+          <DialogContentText
+            sx={{
+              whiteSpace: "pre-wrap",
+              overflowWrap: "break-word",
+            }}
+          >
+            {reasonText}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseReadMoreDialog}>Close</Button>
         </DialogActions>
       </Dialog>
     </Box>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## レビュワーの方へ

**このPRは `#938` のブランチから作成されております。**

お手数ですが、先に `#938` をマージしていただくと、このPRのターゲットブランチが自動的に `main` に切り替わり、差分が今回の変更のみに限定されるため、レビューがしやすくなるかと思います。ご検討のほどよろしくお願いいたします。

## PR の目的

Safety Impactの変更理由が長い場合、UI上のTooltipが画面幅をはみ出してレイアウトが崩れる問題を解決します。

この修正により、Tooltipに表示するテキストに文字数制限を設け、全文はダイアログで確認できるUIを実装します。

## 経緯・意図・意思決定

### 経緯

現状、Safety Impactの変更理由はAPI経由の場合、文字数制限なく登録が可能です。
そのため、非常に長い理由が登録された場合にTooltipの表示が崩れ、ユーザービリティを損なう可能性がありました。

### 実装の意図・詳細

* Tooltipに表示するテキストが一定文字数（150文字）を超えた場合、末尾を「...」で省略し、「Read more...」ボタンを表示します。
* 「Read more...」ボタンをクリックすると、全文が確認できるダイアログが表示されます。
* ダイアログ内では、URLなどの改行されない長い文字列も`overflowWrap: "break-word"`によって適切に折り返され、横スクロールが発生しないように配慮しました。

### 対象外とした内容

今回の対応では、スマホなどのタッチデバイスでTooltipがタップ時に表示されない問題は**対象外**とします。別のPRで対応する方針です。

<!-- I want to review in Japanese. -->
