### PR TITLE
fix ticket count and vuln_ids sort

### DIFF
--- a/api/app/tests/common/upload_test/test_trivy_cyclonedx_asynckit.json
+++ b/api/app/tests/common/upload_test/test_trivy_cyclonedx_asynckit.json
@@ -27,6 +27,21 @@
   },
   "components": [
     {
+      "bom-ref": "test-ref-key",
+      "type": "application",
+        "name": "sample target1",
+      "properties": [
+        {
+          "name": "aquasecurity:trivy:Class",
+          "value": "lang-pkgs"
+        },
+        {
+          "name": "aquasecurity:trivy:Type",
+          "value": "npm"
+        }
+      ]
+    },
+    {
       "bom-ref": "8c90136c-e90f-4db3-9c25-264e6f54452e",
       "type": "application",
       "name": "package-lock.json",
@@ -67,6 +82,14 @@
     }
   ],
   "dependencies": [
+    {
+      "ref": "test-ref-key",
+      "dependsOn": ["pkg:npm/asynckit@0.4.0"]
+    },
+    {
+      "ref": "8c90136c-e90f-4db3-9c25-264e6f54452e",
+      "dependsOn": ["pkg:npm/asynckit@0.4.0"]
+    },
     {
       "ref": "pkg:npm/asynckit@0.4.0",
       "dependsOn": []


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- Packageページにおいて、1件のVulnに対して2件Ticketがあり、1件のTicketのみCompletedにした場合において、[Get /pteams/{pteam_id}/ticket_counts] APIが仕様と異なる挙動であったため、修正する
  - [仕様]
    - 1件のVulnに紐づくどれか一つのTicketのticket_handling_statusがcompletedである場合、このVulnに紐づく全TicketをSOLVEDに表示する
    - 1件のVulnに紐づくどれか一つのTicketのticket_handling_statusがcompletedでない場合、このVulnに紐づく全TicketをUNSOLVEDに表示する
- [Get /pteams/{pteam_id}/vuln_ids] APIは、第一ソートキーが各Vulnに紐づくTicketのSSVCの中の最悪値の悪い順、第二ソートキーがvulnのupdated_atの新しい順、という仕様。
ここで、各Vulnに紐づくTicketのSSVCの中の最悪値の算出が誤っており、見つけた１件目のTicketのSSVCとなっていたため、最悪値となるよう修正する

## 経緯・意図・意思決定
[Get /pteams/{pteam_id}/ticket_counts] APIのSOLVED、UNSOLVEDの仕様が明確になっていなかった。
今回修正するにあたり、上記仕様と下記仕様が候補になった。
[別仕様案]
> 一部のTicketがCompletedであっても、Vuln全体がCompletedではない場合、CompletedのTicketも含めてUNSOLVEDにのみ表示して、SOLVEDには表示しない

性能評価を実施した結果、どちらの案も大差無かったため、運用面を考慮して今回修正した仕様を採用した。

性能評価を実施するに辺り、修正2件目のソート不具合も性能に影響するため、合わせて修正した。


<!-- I want to review in Japanese. -->
