### PR TITLE
set leaveDelay to SafetyImpact Tooltip

### DIFF
--- a/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
+++ b/web/src/pages/Package/VulnTables/SafetyImpactSelectorView.jsx
@@ -95,7 +95,7 @@ export function SafetyImpactSelectorView(props) {
   const isSaveDisabled = isUnchanged || isReasonRequiredAndEmpty;
 
   const StyledTooltip = styled(({ className, ...props }) => (
-    <Tooltip {...props} classes={{ popper: className }} />
+    <Tooltip {...props} classes={{ popper: className }} leaveDelay={500} />
   ))(() => ({
     [`& .${tooltipClasses.arrow}`]: {
       "&:before": {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- SafetyImpact に150文字を超える変更理由がセットされている場合、SafetyImpact の右の(i)アイコンで表示するTooltipに「READ MORE...」ボタンを表示するが、これを押そうとナナメにマウスを動かすと(i)アイコンとTooltipまでの間でマウスが外れたと判定され、Tooltipが閉じてしまう場合がる
  - 対策として、マウスが外れてからTooltipが閉じるまで、0.5秒遅延させる


## 経緯・意図・意思決定
別の不具合として、「READ MORE...」ボタンを押した際に、変更理由のダイアログが表示されず、Tooltipも閉じる場合があった。
同じ操作を行っても発生する場合としない場合があり、100回中10回程度発生した。

ボタンクリック時に、ダイアログが開く前にTooltipが閉じてしまうのが原因、と推測している。
この不具合は、本PRの修正の後、150回程度試行して再現しなかった。

<!-- I want to review in Japanese. -->
