### PR TITLE
fix vulns filter

### DIFF
--- a/api/app/tests/requests/test_vulns.py
+++ b/api/app/tests/requests/test_vulns.py
@@ -1253,7 +1253,7 @@ class TestGetVulns:
                 testdb,
             )
 
-    def test_it_should_return_all_vulns_when_creator_ids_is_empty(self, testdb: Session):
+    def test_it_should_return_no_vulns_when_creator_ids_is_empty(self, testdb: Session):
         # Given
         number_of_vulns = 3
         vuln_ids = []
@@ -1269,18 +1269,8 @@ class TestGetVulns:
         # Then
         assert response.status_code == 200
         response_data = response.json()
-        assert len(response_data["vulns"]) == number_of_vulns
-        assert response_data["num_vulns"] == number_of_vulns
-
-        # Check the details of each vuln
-        for i, vuln in enumerate(response_data["vulns"]):
-            reversed_index = len(response_data["vulns"]) - 1 - i
-            self.assert_vuln_response(
-                vuln,
-                vuln_ids[reversed_index],
-                self.create_vuln_request(reversed_index),
-                testdb,
-            )
+        assert len(response_data["vulns"]) == 0
+        assert response_data["num_vulns"] == 0
 
     def test_it_should_filter_by_package_name(self, testdb: Session):
         # Given


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## PR の目的

- Get /vulns APIのcreator_idsに存在しない値を1件だけ指定した場合、指定を無視する挙動であるが、全件HITしないよう修正する
  - creator_idsを複数件指定した場合、それぞれがor条件となる。存在するIDと存在しないIDを指定した場合、存在するIDにHITする行が返る
- 


## 経緯・意図・意思決定
vuln_ids、cve_idsが従来、修正後の挙動であったため、creator_idsも合わせて修正する

<!-- I want to review in Japanese. -->
