### PR TITLE
Replace margin with padding to prevent horizontal scroll

### DIFF
--- a/web/src/pages/VulnManagement/VulnSearchModal.jsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.jsx
@@ -146,7 +146,7 @@ export function VulnSearchModal(props) {
   const isValidUserInput = isValidCvssScore(minCvssScore) && isValidCvssScore(maxCvssScore);
 
   const titleForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+    <Grid container sx={{ p: 1.5, width: "100%" }}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("titleLabel")}</Typography>
       </Grid>
@@ -163,7 +163,7 @@ export function VulnSearchModal(props) {
   );
 
   const cveIdForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+    <Grid container sx={{ p: 1.5, width: "100%" }}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("cveIdLabel")}</Typography>
       </Grid>

--- a/web/src/pages/VulnManagement/VulnSearchModal.jsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.jsx
@@ -180,7 +180,7 @@ export function VulnSearchModal(props) {
   );
 
   const cvssForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }} alignItems={"center"}>
+    <Grid container sx={{ p: 1.5, width: "100%" }} alignItems={"center"}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("cvssV3Label")}</Typography>
       </Grid>
@@ -223,7 +223,7 @@ export function VulnSearchModal(props) {
   );
 
   const dateForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+    <Grid container sx={{ p: 1.5, width: "100%" }}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("lastUpdateLabel")}</Typography>
       </Grid>
@@ -285,7 +285,7 @@ export function VulnSearchModal(props) {
   );
 
   const creatorForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+    <Grid container sx={{ p: 1.5, width: "100%" }}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("creatorIdLabel")}</Typography>
       </Grid>
@@ -302,7 +302,7 @@ export function VulnSearchModal(props) {
   );
 
   const uuidForm = (
-    <Grid container sx={{ margin: 1.5, width: "100%" }}>
+    <Grid container sx={{ p: 1.5, width: "100%" }}>
       <Grid size={{ xs: 2, md: 2 }}>
         <Typography sx={{ marginTop: "10px" }}>{t("vulnIdLabel")}</Typography>
       </Grid>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- 脆弱性検索ダイアログで常に横スクロールバーが出る問題を修正
  - [原因] `sx={{ margin: 1.5, width: "100%" }}` としていたため、100%から更にmarginを取ってはみ出していた
  - [対策] marginをpadding に変更


## 実施したテスト項目
脆弱性検索ダイアログにおいて、ウィンドウ幅を変更して表示に問題ないことを確認

<!-- I want to review in Japanese. -->
