### PR TITLE
correct text wrapping issue in complete ticket typography

### DIFF
--- a/web/src/components/Ticket/CompleteTicketDialog.jsx
+++ b/web/src/components/Ticket/CompleteTicketDialog.jsx
@@ -208,7 +208,15 @@ export function CompleteTicketDialog(props) {
               >
                 <ActionTypeIcon />
                 <Box display="flex" flexDirection="column" sx={{ ml: 1 }}>
-                  <Typography noWrap variant="body2" sx={{ maxWidth: 400 }}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      maxWidth: 400,
+                      whiteSpace: "normal",
+                      wordBreak: "break-word",
+                      overflowWrap: "anywhere",
+                    }}
+                  >
                     {updateAction}
                   </Typography>
                 </Box>

--- a/web/src/components/Ticket/CompleteTicketDialog.jsx
+++ b/web/src/components/Ticket/CompleteTicketDialog.jsx
@@ -207,7 +207,7 @@ export function CompleteTicketDialog(props) {
                 }}
               >
                 <ActionTypeIcon />
-                <Box display="flex" flexDirection="column" sx={{ ml: 1 }}>
+                <Box display="flex" flexDirection="column" sx={{ ml: 1, minWidth: 0 }}>
                   <Typography
                     variant="body2"
                     sx={{


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

チケット完了時にアクション文字列が表示エリアからはみ出る事象の解消

## 経緯・意図・意思決定

チケット完了時に、ウィンドウ幅が狭く、アクション文字列が長い場合、アクション文字列が背景色がついたエリアからはみ出る事象が発生。
背景色がついたエリア内で折り返し表示されるように対応した。

## 実施したテスト項目

`npm run check`と`npm run test`を実行した。

<!-- I want to review in Japanese. -->
