### PR TITLE
temporarily remove SPDX identifiers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Threatconnectome supports vulnerability management in industries where products 
 
 - Alerts and Actions based on SSVC
 - PSIRT-friendly UI and Web API
-- SPDX 2.3 and CycloneDX 1.6 support
+- CycloneDX 1.6 support
 
 ## :eyes: Live demo
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

Readme内のSPDXの表記を一時的に削除。

## 経緯・意図・意思決定

現段階ではSPDXのフォーマットのSBOMが未対応なため、Readmeから文言を削除。

<!-- I want to review in Japanese. -->
