### PR TITLE
setup api agent

### DIFF
--- a/.github/instructions/directory-agent.instructions.md
+++ b/.github/instructions/directory-agent.instructions.md
@@ -1,0 +1,4 @@
+Before editing files, apply the nearest `agent.md` or `*.agent.md`
+(from the current directory up to the repository root).
+Nearest rules override others.
+``

--- a/.github/instructions/directory-agent.instructions.md
+++ b/.github/instructions/directory-agent.instructions.md
@@ -1,4 +1,3 @@
 Before editing files, apply the nearest `agent.md` or `*.agent.md`
 (from the current directory up to the repository root).
 Nearest rules override others.
-``

--- a/api/api.agent.md
+++ b/api/api.agent.md
@@ -1,0 +1,90 @@
+## Local API Rule
+
+This rule applies to all changes under `./api`.
+This file is located in `./api`.
+Always operate from the repository root.
+
+---
+
+## Command Safety Policy
+
+The agent may run the following commands without confirmation:
+
+- Read-only commands (e.g. grep, rg, cat, ls)
+- Commands that modify files within this repository only
+- Commands that start or stop local Docker containers defined in this repository
+- Test execution commands (e.g. pytest)
+
+Before running commands that affect anything outside the repository
+(e.g. global installs, system changes, external services, data deletion),
+the agent MUST ask for user confirmation.
+
+---
+
+## Mandatory Actions (Agent)
+
+Whenever code under `./api` is modified, you MUST do the following automatically.
+
+### 1. Update Tests
+
+If API schemas, models, or data structures change:
+
+- Find affected tests under `api/app/tests/`
+- Update them to match changed field names, types, and nullability
+
+### 2. Run Static Checks
+
+Always execute:
+
+```bash
+cd api
+pipenv run black --check --diff ./app
+pipenv run ruff check ./app
+pipenv run mypy ./app --show-error-codes --no-error-summary
+pipenv run codespell ./app
+```
+
+### 3. Run API Tests
+
+- Ensure `docker-compose-firebase-test.yml` is running  
+  (start it if not running; do NOT restart if already running)
+
+- Always execute tests:
+
+```bash
+docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv app/tests/
+```
+
+- Stop the test stack only if you started it
+
+## Frontend Type Definitions (`./web/types`) and OpenAPI
+
+The following files are auto-generated and must not be edited manually: ./web/types and ./openapi.json.
+
+### When to regenerate:
+
+If any of the following change:
+
+- API endpoint signatures
+- API request/response schemas in `./api/app/schemas.py`
+- Field names, types, or nullability in API request/response
+
+### How to regenerate:
+
+- Ensure `docker-compose-firebase-local.yml` is running  
+  (start it if not running; do NOT restart if already running)
+
+- Wait for API to be fully running:
+
+  ```bash
+  docker compose logs api | grep -q "Application startup complete"
+  ```
+
+- Under this common condition (API running), always run:
+
+```bash
+cd web
+npm run openapi:update
+```
+
+---

--- a/api/api.agent.md
+++ b/api/api.agent.md
@@ -77,7 +77,7 @@ If any of the following change:
 - Wait for API to be fully running:
 
   ```bash
-  docker compose logs api | grep -q "Application startup complete"
+  docker compose -f docker-compose-firebase-local.yml logs api | grep -q "Application startup complete"
   ```
 
 - Under this common condition (API running), always run:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- Copilot AgentがAPIを修正した際に、下記の後処理を自動実施するよう設定する
  - CI（main.yml）と同等の静的解析
  - 修正した範囲に影響するAPIの自動テスト実行
  - APIのURL、スキーマを変更した場合、"./web"ディレクトリで `npm run openapi:update`を実行してUI側のスキーマ定義を更新する

## 経緯・意図・意思決定
- apiディレクトリにapi.agent.mdを置いただけでは最初に読んでくれないケースがあったため、下記ファイルに*.agent.mdがあれば読むよう指示した
.github/instructions/directory-agent.instructions.md
- 下記テスト項目を満たす範囲で、できるだけ少ない指示で目的を達成することを目指した
  - openapiの自動生成コードが指示を守らず修正されるケースが多く、ここは指示の記載量をあまり削れなかった

## 実施したテスト項目
- 下記プロンプトを1回投げて目的を達成することを確認
  - get /pteams/{pteam_id}/ticket_counts APIのレスポンスの#sym:ssvc_priority_count をssvc_priority_count2にリネームして


<!-- I want to review in Japanese. -->
