### PR TITLE
docs: require stopping firebase local stack before running API tests

### DIFF
--- a/api/api.agent.md
+++ b/api/api.agent.md
@@ -46,6 +46,8 @@ pipenv run codespell ./app
 
 ### 3. Run API Tests
 
+- If `docker-compose-firebase-local.yml` is running, stop it before running the tests
+
 - Ensure `docker-compose-firebase-test.yml` is running  
   (start it if not running; do NOT restart if already running)
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- Copilot AgentがAPIを修正した時、`docker-compose-firebase-local.yml`が起動している場合は停止せず`docker-compose-firebase-test.yml`を起動する問題があったため、停止指示を追記

## 実施したテスト項目
- `docker-compose-firebase-local.yml`が起動している状態でCopilot AgentにAPI修正を依頼し、`docker-compose-firebase-local.yml`を停止してからテスト実行することを確認


<!-- I want to review in Japanese. -->
