### PR TITLE
docs: add requirement to read directory-agent instructions before edi…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,10 @@ Code review guidance has been separated into:
 
 - `.github/instructions/review.instructions.md`
 
+### Directory-level Agent Rules
+
+Before editing any file, read `.github/instructions/directory-agent.instructions.md`.
+
 ### Guidelines for Writing `*.instructions.md` and `agent.md` / `*.agent.md`
 
 - **Avoid ambiguous descriptions**: Vague wording causes inconsistent agent behavior. Write instructions that have only one reasonable interpretation.

--- a/.github/instructions/directory-agent.instructions.md
+++ b/.github/instructions/directory-agent.instructions.md
@@ -1,3 +1,3 @@
-Before editing files, apply the nearest `agent.md` or `*.agent.md`
-(from the current directory up to the repository root).
-Nearest rules override others.
+Before editing any file, you MUST read and follow the nearest `agent.md`
+or `*.agent.md` (from the file's directory up to the repository root).
+Nearest rules override others. This step is mandatory and must not be skipped.


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- `copilot-instructions.md`において、コード編集前に`directory-agent.instructions.md`を見るよう追記
- `directory-agent.instructions.md`において、`*.agent.md`を必ず見るよう追記

## 経緯・意図・意思決定
- 下記ケースにおいて、Agentが修正した際に`*.agent.md`を見ないケースがあった。そのAgentに聞いたら「`directory-agent.instructions.md`を見なかったのは失敗だ」と言うが、複数回発生したため、`copilot-instructions.md`に指示追記する
  - 見なかったケース
    - レビュー指摘の修正 (3/3回発生)
      - 小さい修正の場合は`npm run check`など実行されない
    - CLIからUI改善指示 (1/1回発生)
      - VSCode上でAgentに依頼した時は問題なかったが、CLIだと問題あった。１回しか試していないが
- `directory-agent.instructions.md`を見るよう追記した後、それでも`*.agent.md`をみないケースがあった。そのAgentに聞いたら「必須と書いてないので従わなかった」らしい


<!-- I want to review in Japanese. -->
