### PR TITLE
Allow service image upload without pre-made 720x480 by auto-cropping …

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -104,7 +104,7 @@
   },
   "PTeamServiceImageUploadDeleteButton": {
     "fileSizeExceeds": "Filesize exceeds max(512KiB)",
-    "dimensionsMustBe": "Dimensions must be {{width}}px × {{height}}px",
+    "imageProcessingFailed": "Failed to process image. Please try another image.",
     "uploadImage": "Upload image",
     "deleteImage": "Delete image"
   },

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -104,6 +104,7 @@
   },
   "PTeamServiceImageUploadDeleteButton": {
     "fileSizeExceeds": "Filesize exceeds max(512KiB)",
+    "normalizedFileSizeExceeds": "Filesize after PNG conversion exceeds max(512KiB)",
     "imageProcessingFailed": "Failed to process image. Please try another image.",
     "uploadImage": "Upload image",
     "deleteImage": "Delete image"

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -104,7 +104,7 @@
   },
   "PTeamServiceImageUploadDeleteButton": {
     "fileSizeExceeds": "ファイルサイズが最大値（512KiB）を超えています。",
-    "dimensionsMustBe": "画像サイズは{{width}}px × {{height}}pxである必要があります。",
+    "imageProcessingFailed": "画像の変換に失敗しました。別の画像で再度お試しください。",
     "uploadImage": "画像をアップロード",
     "deleteImage": "画像を削除"
   },

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -104,6 +104,7 @@
   },
   "PTeamServiceImageUploadDeleteButton": {
     "fileSizeExceeds": "ファイルサイズが最大値（512KiB）を超えています。",
+    "normalizedFileSizeExceeds": "画像のサイズ調整後のファイル容量が最大値（512KiB）を超えました。より小さい画像を使用してください。",
     "imageProcessingFailed": "画像の変換に失敗しました。別の画像で再度お試しください。",
     "uploadImage": "画像をアップロード",
     "deleteImage": "画像を削除"

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -50,6 +50,12 @@ export function PTeamServiceImageUploadDeleteButton(props) {
 
     try {
       const normalizedImage = await normalizeServiceImageToPng(selectedFile);
+
+      if (normalizedImage.file.size >= serviceImageMaxSize) {
+        enqueueSnackbar(t("normalizedFileSizeExceeds"), { variant: "error" });
+        return;
+      }
+
       setImageFileData(normalizedImage.file);
       setImageDeleteFlag(false);
       setImagePreview(normalizedImage.previewDataUrl);

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceImageUploadDeleteButton.jsx
@@ -11,11 +11,8 @@ import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  serviceImageHeightSize,
-  serviceImageWidthSize,
-  serviceImageMaxSize,
-} from "../../../utils/const";
+import { serviceImageMaxSize } from "../../../utils/const";
+import { normalizeServiceImageToPng } from "../../../utils/serviceImageUtils";
 
 export function PTeamServiceImageUploadDeleteButton(props) {
   const {
@@ -39,41 +36,27 @@ export function PTeamServiceImageUploadDeleteButton(props) {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const handleUploadImage = (event) => {
-    if (event.target.files[0].size >= serviceImageMaxSize) {
+  const handleUploadImage = async (event) => {
+    const selectedFile = event.target.files?.[0];
+
+    if (!selectedFile) {
+      return;
+    }
+
+    if (selectedFile.size >= serviceImageMaxSize) {
       enqueueSnackbar(t("fileSizeExceeds"), { variant: "error" });
       return;
     }
 
-    const reader = new FileReader();
-    const image = new Image();
-    reader.onload = (e) => {
-      image.src = e.target?.result;
-      image.onload = () => {
-        if (
-          image.naturalWidth === serviceImageWidthSize &&
-          image.naturalHeight === serviceImageHeightSize
-        ) {
-          setImageFileData(event.target.files[0]);
-          setImageDeleteFlag(false);
-          setImagePreview(e.target?.result);
-          if (originalImage === e.target?.result) {
-            setIsImageChanged(false);
-          } else {
-            setIsImageChanged(true);
-          }
-        } else {
-          enqueueSnackbar(
-            t("dimensionsMustBe", { width: serviceImageWidthSize, height: serviceImageHeightSize }),
-            {
-              variant: "error",
-            },
-          );
-          return;
-        }
-      };
-    };
-    reader.readAsDataURL(event.target.files[0]);
+    try {
+      const normalizedImage = await normalizeServiceImageToPng(selectedFile);
+      setImageFileData(normalizedImage.file);
+      setImageDeleteFlag(false);
+      setImagePreview(normalizedImage.previewDataUrl);
+      setIsImageChanged(originalImage !== normalizedImage.previewDataUrl);
+    } catch {
+      enqueueSnackbar(t("imageProcessingFailed"), { variant: "error" });
+    }
   };
 
   const handleDelete = () => {

--- a/web/src/utils/__tests__/serviceImageUtils.test.js
+++ b/web/src/utils/__tests__/serviceImageUtils.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateCenteredCropRect } from "../serviceImageUtils";
+
+describe("calculateCenteredCropRect", () => {
+  it("crops left and right sides when source image is wider than 4:3", () => {
+    const cropRect = calculateCenteredCropRect(2000, 1000, 720, 480);
+
+    expect(cropRect).toEqual({
+      sx: 250,
+      sy: 0,
+      sWidth: 1500,
+      sHeight: 1000,
+    });
+  });
+
+  it("crops top and bottom when source image is taller than 4:3", () => {
+    const cropRect = calculateCenteredCropRect(1000, 2000, 720, 480);
+
+    expect(cropRect).toEqual({
+      sx: 0,
+      sy: 666.6666666666667,
+      sWidth: 1000,
+      sHeight: 666.6666666666666,
+    });
+  });
+
+  it("keeps dimensions when source image already has 4:3 ratio", () => {
+    const cropRect = calculateCenteredCropRect(720, 480, 720, 480);
+
+    expect(cropRect).toEqual({
+      sx: 0,
+      sy: 0,
+      sWidth: 720,
+      sHeight: 480,
+    });
+  });
+});

--- a/web/src/utils/__tests__/serviceImageUtils.test.js
+++ b/web/src/utils/__tests__/serviceImageUtils.test.js
@@ -17,12 +17,10 @@ describe("calculateCenteredCropRect", () => {
   it("crops top and bottom when source image is taller than 4:3", () => {
     const cropRect = calculateCenteredCropRect(1000, 2000, 720, 480);
 
-    expect(cropRect).toEqual({
-      sx: 0,
-      sy: 666.6666666666667,
-      sWidth: 1000,
-      sHeight: 666.6666666666666,
-    });
+    expect(cropRect.sx).toBe(0);
+    expect(cropRect.sy).toBeCloseTo(666.667, 2);
+    expect(cropRect.sWidth).toBe(1000);
+    expect(cropRect.sHeight).toBeCloseTo(666.667, 2);
   });
 
   it("keeps dimensions when source image already has 4:3 ratio", () => {

--- a/web/src/utils/serviceImageUtils.js
+++ b/web/src/utils/serviceImageUtils.js
@@ -51,16 +51,13 @@ function loadImage(dataUrl) {
 
 function canvasToBlob(canvas) {
   return new Promise((resolve, reject) => {
-    canvas.toBlob(
-      (blob) => {
-        if (!blob) {
-          reject(new Error("Failed to convert image"));
-          return;
-        }
-        resolve(blob);
-      },
-      "image/png",
-    );
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Failed to convert image"));
+        return;
+      }
+      resolve(blob);
+    }, "image/png");
   });
 }
 

--- a/web/src/utils/serviceImageUtils.js
+++ b/web/src/utils/serviceImageUtils.js
@@ -60,7 +60,6 @@ function canvasToBlob(canvas) {
         resolve(blob);
       },
       "image/png",
-      0.92,
     );
   });
 }

--- a/web/src/utils/serviceImageUtils.js
+++ b/web/src/utils/serviceImageUtils.js
@@ -1,0 +1,111 @@
+import { serviceImageHeightSize, serviceImageWidthSize } from "./const";
+
+export function calculateCenteredCropRect(sourceWidth, sourceHeight, targetWidth, targetHeight) {
+  const sourceAspectRatio = sourceWidth / sourceHeight;
+  const targetAspectRatio = targetWidth / targetHeight;
+
+  if (sourceAspectRatio > targetAspectRatio) {
+    const cropWidth = sourceHeight * targetAspectRatio;
+    return {
+      sx: (sourceWidth - cropWidth) / 2,
+      sy: 0,
+      sWidth: cropWidth,
+      sHeight: sourceHeight,
+    };
+  }
+
+  const cropHeight = sourceWidth / targetAspectRatio;
+  return {
+    sx: 0,
+    sy: (sourceHeight - cropHeight) / 2,
+    sWidth: sourceWidth,
+    sHeight: cropHeight,
+  };
+}
+
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      if (!event.target?.result) {
+        reject(new Error("Failed to read selected file"));
+        return;
+      }
+      resolve(event.target.result);
+    };
+    reader.onerror = () => {
+      reject(new Error("Failed to read selected file"));
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(dataUrl) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Failed to decode selected image"));
+    image.src = dataUrl;
+  });
+}
+
+function canvasToBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Failed to convert image"));
+          return;
+        }
+        resolve(blob);
+      },
+      "image/png",
+      0.92,
+    );
+  });
+}
+
+function toPngFileName(fileName) {
+  const normalizedName = fileName.replace(/\.[^/.]+$/, "");
+  return `${normalizedName}.png`;
+}
+
+export async function normalizeServiceImageToPng(file) {
+  const sourceDataUrl = await readFileAsDataUrl(file);
+  const sourceImage = await loadImage(sourceDataUrl);
+  const cropRect = calculateCenteredCropRect(
+    sourceImage.naturalWidth,
+    sourceImage.naturalHeight,
+    serviceImageWidthSize,
+    serviceImageHeightSize,
+  );
+
+  const canvas = document.createElement("canvas");
+  canvas.width = serviceImageWidthSize;
+  canvas.height = serviceImageHeightSize;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Canvas context is not available");
+  }
+
+  context.drawImage(
+    sourceImage,
+    cropRect.sx,
+    cropRect.sy,
+    cropRect.sWidth,
+    cropRect.sHeight,
+    0,
+    0,
+    serviceImageWidthSize,
+    serviceImageHeightSize,
+  );
+
+  const outputBlob = await canvasToBlob(canvas);
+  const outputFile = new File([outputBlob], toPngFileName(file.name), { type: "image/png" });
+
+  return {
+    file: outputFile,
+    previewDataUrl: canvas.toDataURL("image/png"),
+  };
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- サービス画像アップロード時に、720x480以外のサイズを指定した場合、中央クロップして4:3化し、720x480のPNGに変換してからセットするよう変更

## 実施したテスト項目
- 以下のデータでサービス画像をアップロード
  - 720x480
  - その他の縦横サイズ

<!-- I want to review in Japanese. -->
