### PR TITLE
fix: reject whitespace-only input for team name, service name, and keyword

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -366,6 +366,11 @@ def update_pteam_service(
         service.keywords = sorted(fixed_words)
     if data.service_name is not None:
         update_service_name = data.service_name.strip()
+        if not update_service_name:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Service name cannot be empty",
+            )
         if (
             unicode_tool.count_full_width_and_half_width_characters(update_service_name)
             > max_service_name_length_in_half
@@ -1187,6 +1192,7 @@ def create_pteam(
         data.pteam_name,
         MAX_PTEAM_NAME_LENGTH_IN_HALF,
         PTEAM_NAME_TOO_LONG_MESSAGE,
+        required=True,
     )
 
     # Validate contact_info
@@ -1727,6 +1733,7 @@ def update_pteam(
             data.pteam_name,
             MAX_PTEAM_NAME_LENGTH_IN_HALF,
             PTEAM_NAME_TOO_LONG_MESSAGE,
+            required=True,
         )
         pteam.pteam_name = update_pteam_name
     if data.contact_info is not None:

--- a/api/app/routers/validators/field_validator.py
+++ b/api/app/routers/validators/field_validator.py
@@ -7,6 +7,7 @@ def strip_and_validate_field_length(
     field_value: str,
     max_length: int,
     error_message: str,
+    required: bool = False,
 ) -> str:
     """
     Validate field length and return stripped value.
@@ -15,14 +16,20 @@ def strip_and_validate_field_length(
         field_value: The field value to validate
         max_length: Maximum allowed length in half-width characters
         error_message: Error message to use if validation fails
+        required: If True, raise an error when the stripped value is empty
 
     Returns:
         Stripped field value
 
     Raises:
-        HTTPException: If field length exceeds maximum
+        HTTPException: If field is required and empty, or if field length exceeds maximum
     """
     stripped_value = field_value.strip()
+    if required and not stripped_value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Field cannot be empty",
+        )
     if unicode_tool.count_full_width_and_half_width_characters(stripped_value) > max_length:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/api/app/tests/requests/pteams/test_pteam_services.py
+++ b/api/app/tests/requests/pteams/test_pteam_services.py
@@ -993,8 +993,6 @@ class TestUpdatePTeamService:
         @pytest.mark.parametrize(
             "service_name, expected",
             [
-                ("", ""),
-                ("   ", ""),
                 (chars_255_in_half, chars_255_in_half),
                 (chars_255_in_half + "  ", chars_255_in_half),
                 (chars_127_in_full, chars_127_in_full),
@@ -1073,6 +1071,36 @@ class TestUpdatePTeamService:
 
             assert response.status_code == 400
             assert response.json()["detail"] == expected
+
+        @pytest.mark.parametrize(
+            "service_name",
+            [
+                "",
+                "   ",
+                "\t",
+                "\n",
+            ],
+        )
+        def test_it_should_return_400_when_service_name_is_empty_or_whitespace_only(
+            self, service_name
+        ):
+            """Test that empty or whitespace-only service_name is rejected on update"""
+            user1_access_token = self._get_access_token(USER1)
+            _headers = {
+                "Authorization": f"Bearer {user1_access_token}",
+                "Content-Type": "application/json",
+                "accept": "application/json",
+            }
+            request = {"service_name": service_name}
+
+            response = client.put(
+                f"/pteams/{self.pteam1.pteam_id}/services/{self.service_id1}",
+                headers=_headers,
+                json=request,
+            )
+
+            assert response.status_code == 400
+            assert response.json()["detail"] == "Service name cannot be empty"
 
         def test_it_should_return_200_when_service_name_is_not_specify(self):
             user1_access_token = self._get_access_token(USER1)

--- a/api/app/tests/requests/pteams/test_pteams.py
+++ b/api/app/tests/requests/pteams/test_pteams.py
@@ -295,6 +295,29 @@ class TestCreatePteam:
         del pteam1.pteam_id, pteam2.pteam_id
         assert pteam1 == pteam2
 
+    @pytest.mark.parametrize(
+        "pteam_name",
+        [
+            "",
+            "   ",
+            "\t",
+            "\n",
+        ],
+    )
+    def test_return_400_when_pteam_name_is_empty_or_whitespace_only(self, pteam_name):
+        """Test that empty or whitespace-only pteam_name is rejected on creation"""
+        # Given
+        create_user(USER1)
+
+        # When
+        response = client.post(
+            "/pteams", headers=headers(USER1), json={**PTEAM1, "pteam_name": pteam_name}
+        )
+
+        # Then
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Field cannot be empty"
+
 
 def test_it_should_return_400_when_try_delete_last_admin():
     user1 = create_user(USER1)
@@ -928,7 +951,6 @@ class TestUpdatePteam:
         pteam1 = create_pteam(USER1, PTEAM1)
 
         empty_data = {
-            "pteam_name": "",
             "contact_info": "",
             "alert_slack": {"enable": False, "webhook_url": ""},
         }
@@ -939,7 +961,7 @@ class TestUpdatePteam:
         # Then
         assert response.status_code == 200
         data = response.json()
-        assert data["pteam_name"] == ""
+        assert data["pteam_name"] == PTEAM1["pteam_name"]
         assert data["contact_info"] == ""
         assert data["alert_slack"]["webhook_url"] == ""
         assert data["alert_ssvc_priority"] == PTEAM1["alert_ssvc_priority"]
@@ -967,3 +989,29 @@ class TestUpdatePteam:
         # Then
         assert response.status_code == 400
         assert response.json()["detail"] == expected_response_detail
+
+    @pytest.mark.parametrize(
+        "pteam_name",
+        [
+            "",
+            "   ",
+            "\t",
+            "\n",
+        ],
+    )
+    def test_return_400_when_pteam_name_is_empty_or_whitespace_only(self, pteam_name):
+        """Test that empty or whitespace-only pteam_name is rejected on update"""
+        # Given
+        create_user(USER1)
+        pteam1 = create_pteam(USER1, PTEAM1)
+
+        # When
+        response = client.put(
+            f"/pteams/{pteam1.pteam_id}",
+            headers=headers(USER1),
+            json={"pteam_name": pteam_name},
+        )
+
+        # Then
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Field cannot be empty"

--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -184,7 +184,7 @@ export function PTeamGeneralSetting(props) {
         <Button
           onClick={() => handleUpdatePTeam()}
           sx={{ ...modalCommonButtonStyle, ml: 1 }}
-          disabled={!user.is_admin}
+          disabled={!user.is_admin || !pteamName?.trim()}
         >
           {t("save")}
         </Button>

--- a/web/src/pages/App/PTeamCreateModal.jsx
+++ b/web/src/pages/App/PTeamCreateModal.jsx
@@ -149,7 +149,7 @@ export function PTeamCreateModal(props) {
                 maxFull: Math.floor(maxPTeamNameLengthInHalf / 2),
               })}
               required
-              error={!pteamName}
+              error={!pteamName?.trim()}
               margin="dense"
             ></TextField>
             <TextField
@@ -173,7 +173,11 @@ export function PTeamCreateModal(props) {
           </Box>
         </DialogContent>
         <DialogActions className={dialogStyle.action_area}>
-          <Button onClick={handleCreate} disabled={!pteamName} className={dialogStyle.submit_btn}>
+          <Button
+            onClick={handleCreate}
+            disabled={!pteamName?.trim()}
+            className={dialogStyle.submit_btn}
+          >
             {t("create")}
           </Button>
         </DialogActions>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -248,8 +248,8 @@ export function PTeamServiceDetailsSettingsView(props) {
                   maxFull: Math.floor(maxServiceNameLengthInHalf / 2),
                 })}
                 onChange={(e) => handleServiceNameSetting(e.target.value)}
-                helperText={serviceName ? "" : t("nameRequired")}
-                error={!serviceName}
+                helperText={serviceName?.trim() ? "" : t("nameRequired")}
+                error={!serviceName?.trim()}
               />
             </Box>
             <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -305,7 +305,7 @@ export function PTeamServiceDetailsSettingsView(props) {
                         setKeywordText("");
                         setKeywordAddingMode(false);
                       }}
-                      disabled={!keywordText || currentKeywordsList.includes(keywordText)}
+                      disabled={!keywordText.trim() || currentKeywordsList.includes(keywordText)}
                     >
                       {t("add")}
                     </Button>
@@ -399,7 +399,7 @@ export function PTeamServiceDetailsSettingsView(props) {
             }}
             variant="contained"
             sx={{ borderRadius: 5, mr: 2, mb: 1 }}
-            disabled={!isChanged}
+            disabled={!isChanged || !serviceName?.trim()}
           >
             {t("save")}
           </Button>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -292,20 +292,20 @@ export function PTeamServiceDetailsSettingsView(props) {
                       value={keywordText}
                       onChange={(e) => handleKeywordSetting(e.target.value)}
                       sx={{ mr: 1 }}
-                      error={currentKeywordsList.includes(keywordText)}
+                      error={currentKeywordsList.includes(keywordText.trim())}
                       helperText={
-                        currentKeywordsList.includes(keywordText) ? t("sameKeywordExists") : ""
+                        currentKeywordsList.includes(keywordText.trim()) ? t("sameKeywordExists") : ""
                       }
                     />
                     <Button
                       variant="contained"
                       onClick={() => {
-                        const updatedKeywordsList = [...currentKeywordsList, keywordText];
+                        const updatedKeywordsList = [...currentKeywordsList, keywordText.trim()];
                         setCurrentKeywordsList(updatedKeywordsList);
                         setKeywordText("");
                         setKeywordAddingMode(false);
                       }}
-                      disabled={!keywordText.trim() || currentKeywordsList.includes(keywordText)}
+                      disabled={!keywordText.trim() || currentKeywordsList.includes(keywordText.trim())}
                     >
                       {t("add")}
                     </Button>

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -48,6 +48,7 @@ export function PTeamServiceDetailsSettingsView(props) {
   const [imagePreview, setImagePreview] = useState(null);
   const [currentKeywordsList, setCurrentKeywordsList] = useState(service.keywords);
   const [keywordText, setKeywordText] = useState("");
+  const trimmedKeywordText = keywordText.trim();
   const [open, setOpen] = useState(false);
   const [keywordAddingMode, setKeywordAddingMode] = useState(false);
   const [currentDescription, setCurrentDescription] = useState(service.description);
@@ -292,9 +293,9 @@ export function PTeamServiceDetailsSettingsView(props) {
                       value={keywordText}
                       onChange={(e) => handleKeywordSetting(e.target.value)}
                       sx={{ mr: 1 }}
-                      error={currentKeywordsList.includes(keywordText.trim())}
+                      error={currentKeywordsList.includes(trimmedKeywordText)}
                       helperText={
-                        currentKeywordsList.includes(keywordText.trim())
+                        currentKeywordsList.includes(trimmedKeywordText)
                           ? t("sameKeywordExists")
                           : ""
                       }
@@ -302,13 +303,13 @@ export function PTeamServiceDetailsSettingsView(props) {
                     <Button
                       variant="contained"
                       onClick={() => {
-                        const updatedKeywordsList = [...currentKeywordsList, keywordText.trim()];
+                        const updatedKeywordsList = [...currentKeywordsList, trimmedKeywordText];
                         setCurrentKeywordsList(updatedKeywordsList);
                         setKeywordText("");
                         setKeywordAddingMode(false);
                       }}
                       disabled={
-                        !keywordText.trim() || currentKeywordsList.includes(keywordText.trim())
+                        !trimmedKeywordText || currentKeywordsList.includes(trimmedKeywordText)
                       }
                     >
                       {t("add")}

--- a/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
+++ b/web/src/pages/Status/ServiceDetailsSettings/PTeamServiceDetailsSettingsView.jsx
@@ -294,7 +294,9 @@ export function PTeamServiceDetailsSettingsView(props) {
                       sx={{ mr: 1 }}
                       error={currentKeywordsList.includes(keywordText.trim())}
                       helperText={
-                        currentKeywordsList.includes(keywordText.trim()) ? t("sameKeywordExists") : ""
+                        currentKeywordsList.includes(keywordText.trim())
+                          ? t("sameKeywordExists")
+                          : ""
                       }
                     />
                     <Button
@@ -305,7 +307,9 @@ export function PTeamServiceDetailsSettingsView(props) {
                         setKeywordText("");
                         setKeywordAddingMode(false);
                       }}
-                      disabled={!keywordText.trim() || currentKeywordsList.includes(keywordText.trim())}
+                      disabled={
+                        !keywordText.trim() || currentKeywordsList.includes(keywordText.trim())
+                      }
                     >
                       {t("add")}
                     </Button>


### PR DESCRIPTION
## PR の目的

チーム名・サービス名・キーワードの入力欄でスペースのみが入力された場合に空文字列として保存される問題を修正します。

## 経緯・意図・意思決定

スペースのみの文字列（例: `"   "`）は空文字列として保存されてしまう問題がありました。フロントエンドとバックエンドの両方で対応することで、UI 経由・API 直接アクセスのいずれの経路からも防ぎます。

**フロントエンド**
- `PTeamCreateModal.jsx`: チーム名が空白のみの場合、作成ボタンを無効化・エラー表示
- `PTeamGeneralSetting.jsx`: チーム名が空白のみの場合、保存ボタンを無効化
- `PTeamServiceDetailsSettingsView.jsx`: サービス名が空白のみの場合はエラー表示・保存不可、キーワードが空白のみの場合は追加ボタンを無効化

**バックエンド**
- `field_validator.py`: `strip_and_validate_field_length()` に `required` パラメータを追加
- `pteams.py`: チーム名（作成・更新）に `required=True` を適用、サービス名更新時に空文字チェックを追加

## 実施したテスト項目

- チーム名・サービス名の空白・空文字入力に対して 400 を返すテストケースを追加
- 既存テストのうち空文字を許容していたケースを仕様変更に合わせて修正
- `npm run test`: Passed
- `testapi.sh`: Passed