### PR TITLE
add eol product apache-http-server

### DIFF
--- a/api/app/business/eol/product/ApacheHttpServerProduct.py
+++ b/api/app/business/eol/product/ApacheHttpServerProduct.py
@@ -1,0 +1,21 @@
+from app.detector.package_family import PackageFamily
+
+from .EoLBaseProduct import EoLBaseProduct
+
+
+class ApacheHttpServerProduct(EoLBaseProduct):
+    def __init__(self, ecosystem: str):
+        self.ecosystem = ecosystem
+
+    def match_package(self, package_name: str, package_version: str) -> bool:
+        package_family = PackageFamily.from_registry(self.ecosystem)
+
+        match package_family:
+            case PackageFamily.DEBIAN:
+                return package_name == "apache2"
+            case PackageFamily.RPM:
+                return package_name == "httpd"
+            case PackageFamily.ALPINE:
+                return package_name == "apache2"
+            case _:
+                return False

--- a/api/app/business/eol/product/eol_product_factory.py
+++ b/api/app/business/eol/product/eol_product_factory.py
@@ -1,6 +1,7 @@
 from app import models
 
 from .AmazonCorrettoProduct import AmazonCorrettoProduct
+from .ApacheHttpServerProduct import ApacheHttpServerProduct
 from .DjangoProduct import DjangoProduct
 from .EoLBaseProduct import EoLBaseProduct
 from .NumpyProduct import NumpyProduct
@@ -17,6 +18,8 @@ def gen_product_instance_for_eol(
     ecosystem: str,
 ) -> EoLBaseProduct:
     match eol_product.name:
+        case "apache-http-server":
+            return ApacheHttpServerProduct(ecosystem)
         case "sqlite":
             return SqliteProduct(ecosystem)
         case "postgresql":

--- a/api/app/business/eol/version/eol_version_factory.py
+++ b/api/app/business/eol/version/eol_version_factory.py
@@ -27,6 +27,8 @@ def gen_version_instance_for_eol(
                 return MajorOnlyVersion(version_string, ecosystem)
             case "amazon-corretto":
                 return MajorOnlyVersion(version_string, ecosystem)
+            case "apache-http-server":
+                return MajorAndMinorVersion(version_string, ecosystem)
             case "redis":
                 return MajorAndMinorVersion(version_string, ecosystem)
             case "django":

--- a/scripts/endoflife2tc.py
+++ b/scripts/endoflife2tc.py
@@ -217,6 +217,18 @@ eol_product_list: list[EOLProductItem] = [
             "is_ecosystem": False,
         },
     },
+    {
+        "product": "apache-http-server",
+        "threatconnectome": {
+            "product_category": ProductCategoryEnum.MIDDLEWARE,
+            "description": (
+                "The Apache HTTP Server Project is a collaborative software development effort "
+                "aimed at creating a robust, commercial-grade, feature-rich and freely available "
+                "source code implementation of an HTTP (Web) server."
+            ),
+            "is_ecosystem": False,
+        },
+    },
 ]
 
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- サポートするEOL productに「apache-http-server」を追加

## 経緯・意図・意思決定
- 初めてclaudeコマンドで追加

## 実施したテスト項目
- endoflife2tc.pyを実行
- claudeコマンドで追加した、ubuntu、rocky、aplineの「apache-http-server」を持つSBOMをTCにアップロードしてマッチングを確認
  - 生成したSBOMはEOL日付を持たないバージョンのためマッチングしなかった。
    - テスト用にSBOMのバージョンを手動で2.4から2.2に修正し、マッチングすることを確認した

<!-- I want to review in Japanese. -->
