### PR TITLE
fix: preserve multiple spaces in team name display

### DIFF
--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -232,10 +232,10 @@ export function PTeamGeneralSetting(props) {
           <Typography variant="h6">{t("deleteDialogTitle")}</Typography>
         </DialogTitle>
         <DialogContent>
-          <Typography mb={2}>
+          <Typography mb={2} sx={{ whiteSpace: "pre" }}>
             {t("deleteDialogDescription", { teamName: pteam.pteam_name })}
           </Typography>
-          <Typography variant="body2" mb={1}>
+          <Typography variant="body2" mb={1} sx={{ whiteSpace: "pre" }}>
             {t("deleteDialogConfirmLabel", { teamName: pteam.pteam_name })}
           </Typography>
           <TextField

--- a/web/src/components/PTeamLabel.jsx
+++ b/web/src/components/PTeamLabel.jsx
@@ -39,7 +39,7 @@ export function PTeamLabel(props) {
     <>
       <Box display="flex" flexDirection="column" flexGrow={1} my={2}>
         <Box display="flex" alignItems="center">
-          <Typography variant="h5" fontWeight={900}>
+          <Typography variant="h5" fontWeight={900} sx={{ whiteSpace: "pre" }}>
             {pteamName}
           </Typography>
           <IconButton onClick={() => setPTeamSettingsModalOpen(true)}>

--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
@@ -56,7 +56,7 @@ export function AcceptPTeamInvitation() {
   return (
     <>
       <Typography variant="h6">{t("title")}</Typography>
-      <Typography>
+      <Typography sx={{ whiteSpace: "pre" }}>
         {t("teamName")}: {detail.pteam_name}
       </Typography>
       <Typography>

--- a/web/src/pages/App/TeamSelector.jsx
+++ b/web/src/pages/App/TeamSelector.jsx
@@ -113,8 +113,9 @@ export function TeamSelector() {
                   key={pteam_role.pteam.pteam_id}
                   value={pteam_role.pteam.pteam_id}
                   onClick={() => switchToPTeam(pteam_role.pteam.pteam_id)}
+                  sx={{ whiteSpace: "pre" }}
                 >
-                  <span style={{ whiteSpace: "pre" }}>{textTrim(pteam_role.pteam.pteam_name)}</span>
+                  {textTrim(pteam_role.pteam.pteam_name)}
                 </MenuItem>
               ))}
           <MenuItem onClick={() => setOpenPTeamCreationModal(true)}>

--- a/web/src/pages/App/TeamSelector.jsx
+++ b/web/src/pages/App/TeamSelector.jsx
@@ -114,7 +114,7 @@ export function TeamSelector() {
                   value={pteam_role.pteam.pteam_id}
                   onClick={() => switchToPTeam(pteam_role.pteam.pteam_id)}
                 >
-                  {textTrim(pteam_role.pteam.pteam_name)}
+                  <span style={{ whiteSpace: "pre" }}>{textTrim(pteam_role.pteam.pteam_name)}</span>
                 </MenuItem>
               ))}
           <MenuItem onClick={() => setOpenPTeamCreationModal(true)}>

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
@@ -146,7 +146,11 @@ export function AccountSettingsDialog(props) {
                   <em>{t("none")}</em>
                 </MenuItem>
                 {userMe.pteam_roles.map((pteam_role) => (
-                  <MenuItem key={pteam_role.pteam.pteam_id} value={pteam_role.pteam.pteam_id} sx={{ whiteSpace: "pre" }}>
+                  <MenuItem
+                    key={pteam_role.pteam.pteam_id}
+                    value={pteam_role.pteam.pteam_id}
+                    sx={{ whiteSpace: "pre" }}
+                  >
                     {pteam_role.pteam.pteam_name}
                   </MenuItem>
                 ))}

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
@@ -114,7 +114,7 @@ export function AccountSettingsDialog(props) {
               </Typography>
               <Stack spacing={1}>
                 {userMe.pteam_roles.map((pteam_role) => (
-                  <DialogContentText key={pteam_role.pteam.pteam_id}>
+                  <DialogContentText key={pteam_role.pteam.pteam_id} sx={{ whiteSpace: "pre" }}>
                     {pteam_role.pteam.pteam_name}
                   </DialogContentText>
                 ))}
@@ -146,7 +146,7 @@ export function AccountSettingsDialog(props) {
                   <em>{t("none")}</em>
                 </MenuItem>
                 {userMe.pteam_roles.map((pteam_role) => (
-                  <MenuItem key={pteam_role.pteam.pteam_id} value={pteam_role.pteam.pteam_id}>
+                  <MenuItem key={pteam_role.pteam.pteam_id} value={pteam_role.pteam.pteam_id} sx={{ whiteSpace: "pre" }}>
                     {pteam_role.pteam.pteam_name}
                   </MenuItem>
                 ))}

--- a/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
+++ b/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
@@ -53,7 +53,9 @@ export function PTeamMemberRemoveModal(props) {
       </DialogTitle>
       <DialogContent>
         <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
-          <Typography sx={{ whiteSpace: "pre" }}>{t("confirmRemove", { userName, pteamName })}</Typography>
+          <Typography sx={{ whiteSpace: "pre" }}>
+            {t("confirmRemove", { userName, pteamName })}
+          </Typography>
         </Box>
       </DialogContent>
       <DialogActions className={dialogStyle.action_area}>

--- a/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
+++ b/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
@@ -53,7 +53,7 @@ export function PTeamMemberRemoveModal(props) {
       </DialogTitle>
       <DialogContent>
         <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
-          <Typography>{t("confirmRemove", { userName, pteamName })}</Typography>
+          <Typography sx={{ whiteSpace: "pre" }}>{t("confirmRemove", { userName, pteamName })}</Typography>
         </Box>
       </DialogContent>
       <DialogActions className={dialogStyle.action_area}>

--- a/web/src/pages/ToDo/TicketDetailView.jsx
+++ b/web/src/pages/ToDo/TicketDetailView.jsx
@@ -192,7 +192,7 @@ export function TicketDetailView({ ticket }) {
             </IconButton>
           </DetailRow>
           <DetailRow label={t("team")}>
-            <Typography>{pteam?.pteam_name || "-"}</Typography>
+            <Typography sx={{ whiteSpace: "pre" }}>{pteam?.pteam_name || "-"}</Typography>
             <IconButton size="small" onClick={handleTeamClick}>
               <LinkIcon color="primary" fontSize="small" />
             </IconButton>

--- a/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.jsx
+++ b/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.jsx
@@ -150,6 +150,7 @@ export function VulnerabilityCard({ ticket }) {
                     sx={{
                       overflowWrap: "break-word",
                       minWidth: 0,
+                      whiteSpace: "pre",
                     }}
                   >
                     {item.value}

--- a/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.jsx
+++ b/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.jsx
@@ -51,7 +51,7 @@ export function ToDoTableRow(props) {
     <>
       <TableRow hover sx={{ cursor: "pointer" }} onClick={handleRowClick}>
         <TableCell>{vulnIsLoading ? "..." : cveId}</TableCell>
-        <TableCell>{pteamIsLoading ? "..." : pteamName}</TableCell>
+        <TableCell sx={{ whiteSpace: "pre" }}>{pteamIsLoading ? "..." : pteamName}</TableCell>
         <TableCell>{serviceIsLoading ? "..." : serviceName}</TableCell>
         <TableCell>{serviceDependencyIsLoading ? "..." : packageName}</TableCell>
         <TableCell>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

チーム名の文字列間に複数のスペースが存在する場合、HTML のデフォルト動作によって1つのスペースに折りたたまれて表示される問題を修正する。

各コンポーネントに `white-space: pre` を適用し、チーム名のスペースをそのまま表示するようにした。

## 経緯・意図・意思決定

- HTML はデフォルトで連続する空白文字を1つのスペースに折りたたむ仕様がある
- チーム名に複数スペースを含むユーザーが存在した場合、表示上は1スペースに見えてしまい、意図した名前と異なる表示になる
- 修正方針として `white-space: pre` を採用
- 修正箇所
  - チームの削除確認ダイアログ（説明文・確認入力ラベル）
  - チーム名の見出し（各ページ上部の h5 テキスト）
  - メンバー削除確認ダイアログの本文
  - チーム切り替えドロップダウンのメニュー項目
  - アカウント設定ダイアログの所属チーム一覧テキスト
  - アカウント設定ダイアログのデフォルトチーム選択プルダウン
  - チケット詳細ビューのチーム名フィールド
  - ToDoテーブルのチーム名列
  - ToDoカードのチーム名フィールド
  - チーム招待承認ページのチーム名表示

## 実施したテスト項目

- `npm run check`
- `npm run test`

## 参考文献

<!-- I want to review in Japanese. -->
