### PR TITLE
fix: rename "CVE" label to "CVE ID" in ToDo view

### DIFF
--- a/web/public/locales/en/toDo.json
+++ b/web/public/locales/en/toDo.json
@@ -69,7 +69,7 @@
       "sortBy": "Sort By",
       "ascending": "Ascending",
       "descending": "Descending",
-      "cve_id": "CVE",
+      "cve_id": "CVE ID",
       "pteam_name": "Team",
       "service_name": "Service",
       "package_name": "Package",
@@ -83,7 +83,7 @@
     },
     "ToDoTable": {
       "loadingTickets": "Now loading Tickets...",
-      "cve": "CVE",
+      "cve": "CVE ID",
       "team": "Team",
       "service": "Service",
       "package": "Package",

--- a/web/public/locales/ja/toDo.json
+++ b/web/public/locales/ja/toDo.json
@@ -69,7 +69,7 @@
       "sortBy": "並べ替え",
       "ascending": "昇順",
       "descending": "降順",
-      "cve_id": "CVE",
+      "cve_id": "CVE ID",
       "pteam_name": "チーム",
       "service_name": "サービス",
       "package_name": "パッケージ",
@@ -83,7 +83,7 @@
     },
     "ToDoTable": {
       "loadingTickets": "チケットを読み込んでいます...",
-      "cve": "CVE",
+      "cve": "CVE ID",
       "team": "チーム",
       "service": "サービス",
       "package": "パッケージ",

--- a/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.jsx
+++ b/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.jsx
@@ -26,11 +26,11 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const sortableKeys = [
-  { key: "cve_id", label: "CVE ID", icon: <FingerprintIcon /> },
-  { key: "pteam_name", label: "Team", icon: <GroupOutlinedIcon /> },
-  { key: "service_name", label: "Service", icon: <DnsOutlinedIcon /> },
-  { key: "package_name", label: "Package", icon: <Inventory2OutlinedIcon /> },
-  { key: "ssvc_deployer_priority", label: "SSVC", icon: <FlagOutlinedIcon /> },
+  { key: "cve_id", icon: <FingerprintIcon /> },
+  { key: "pteam_name", icon: <GroupOutlinedIcon /> },
+  { key: "service_name", icon: <DnsOutlinedIcon /> },
+  { key: "package_name", icon: <Inventory2OutlinedIcon /> },
+  { key: "ssvc_deployer_priority", icon: <FlagOutlinedIcon /> },
 ];
 
 export function DisplayOptionsController({

--- a/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.jsx
+++ b/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.jsx
@@ -26,7 +26,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const sortableKeys = [
-  { key: "cve_id", label: "CVE", icon: <FingerprintIcon /> },
+  { key: "cve_id", label: "CVE ID", icon: <FingerprintIcon /> },
   { key: "pteam_name", label: "Team", icon: <GroupOutlinedIcon /> },
   { key: "service_name", label: "Service", icon: <DnsOutlinedIcon /> },
   { key: "package_name", label: "Package", icon: <Inventory2OutlinedIcon /> },


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

ToDo画面のUIラベル「CVE」を「CVE ID」に修正する。

## 経緯・意図・意思決定

表示ラベルが「CVE」となっていたが、正式な識別子名は「CVE ID」であるため、より正確な表記に統一する。
修正対象は以下の3箇所：
- 並べ替えオプションのラベル（`DisplayOptionsController.jsx`）
- ToDo テーブルのカラムヘッダー（`toDo.json` ja/en）

## 実施したテスト項目

- [x] ToDo カードビューの並べ替えオプションに「CVE ID」と表示されることを確認
- [x] ToDo テーブルビューのカラムヘッダーに「CVE ID」と表示されることを確認
- [x] 日本語・英語ロケール両方で表示を確認

## 参考文献

特になし

<!-- I want to review in Japanese. -->