### PR TITLE
fix: shorten evidence section title to "証拠" / "Evidence"

### DIFF
--- a/web/public/locales/en/package.json
+++ b/web/public/locales/en/package.json
@@ -116,7 +116,7 @@
           "saveReason": "Save Reason"
         },
         "CompletionEvidenceSection": {
-          "title": "Evidence of completion",
+          "title": "Evidence",
           "notProvided": "Not entered",
           "save": "Save",
           "updateSuccess": "Updated successfully",

--- a/web/public/locales/ja/package.json
+++ b/web/public/locales/ja/package.json
@@ -116,7 +116,7 @@
           "saveReason": "変更理由を保存する"
         },
         "CompletionEvidenceSection": {
-          "title": "完了の証拠",
+          "title": "証拠",
           "notProvided": "（未入力）",
           "save": "保存",
           "updateSuccess": "更新しました",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

パッケージ詳細画面の証拠セクションタイトルを短縮する。
- 日本語：「完了の証拠」→「証拠」
- 英語：「Evidence of completion」→「Evidence」

## 経緯・意図・意思決定

「完了の証拠」という表記を「証拠」へ統一する。
英語も同様に「Evidence」に短縮する。

## 実施したテスト項目

- [x] パッケージ詳細の証拠セクションのタイトルが「証拠」と表示されることを確認
- [x] 日本語・英語ロケール両方で表示を確認

## 参考文献

特になし

<!-- I want to review in Japanese. -->