### PR TITLE
fix: rename SBOM dialog title from "SBOMを更新" to "SBOMをアップロード"

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -23,7 +23,7 @@
     "dropOrClickToSelect": "Drop or click to select"
   },
   "SBOMUpdateDialog": {
-    "updateSBOM": "Upload SBOM",
+    "uploadSBOM": "Upload SBOM",
     "serviceName": "Service name",
     "upload": "Upload",
     "uploadingSBOMFile": "Uploading SBOM file",

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -23,7 +23,7 @@
     "dropOrClickToSelect": "Drop or click to select"
   },
   "SBOMUpdateDialog": {
-    "updateSBOM": "Update SBOM",
+    "updateSBOM": "Upload SBOM",
     "serviceName": "Service name",
     "upload": "Upload",
     "uploadingSBOMFile": "Uploading SBOM file",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -23,7 +23,7 @@
     "dropOrClickToSelect": "ドロップまたはクリックして選択"
   },
   "SBOMUpdateDialog": {
-    "updateSBOM": "SBOMをアップロード",
+    "uploadSBOM": "SBOMをアップロード",
     "serviceName": "サービス名",
     "uploadingSBOMFile": "SBOMファイルのアップロード中",
     "upload": "アップロード",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -23,7 +23,7 @@
     "dropOrClickToSelect": "ドロップまたはクリックして選択"
   },
   "SBOMUpdateDialog": {
-    "updateSBOM": "SBOMを更新",
+    "updateSBOM": "SBOMをアップロード",
     "serviceName": "サービス名",
     "uploadingSBOMFile": "SBOMファイルのアップロード中",
     "upload": "アップロード",

--- a/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
+++ b/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
@@ -113,7 +113,7 @@ export function SBOMUpdateDialog({
         <DialogTitle>
           <Box sx={{ alignItems: "center", display: "flex", flexDirection: "row" }}>
             <Typography variant="h6" flexGrow={1}>
-              {t("updateSBOM")}
+              {t("uploadSBOM")}
             </Typography>
             <IconButton onClick={handleDialogClose}>
               <CloseIcon />


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

SBOMダイアログのタイトルを「SBOMを更新」から「SBOMをアップロード」に統一する。

## 経緯・意図・意思決定

新規アップロードUIと更新UIの両方で `SBOMUpdateDialog` を使用しているが、タイトルが「SBOMを更新」と表示されており、新規アップロード時のユーザー体験と乖離していた。  

## 実施したテスト項目

- [x] SBOMダイアログのタイトルが「SBOMをアップロード」と表示されることを確認
- [x] 日本語・英語ロケール両方で表示を確認

## 参考文献

特になし

<!-- I want to review in Japanese. -->