### PR TITLE
fix: trim service name on SBOM upload

### DIFF
--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -1357,6 +1357,8 @@ async def upload_pteam_sbom_file(
         "file_size": file.size,
     }
 
+    service = service.strip()
+
     if len(service) > 255:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/api/app/tests/requests/pteams/test_pteam_services.py
+++ b/api/app/tests/requests/pteams/test_pteam_services.py
@@ -487,6 +487,40 @@ class TestPostUploadPTeamSbomFile:
         data = response.json()
         assert data["detail"] == "Length of Service name exceeds 255 characters"
 
+    def test_it_should_return_400_when_upload_sbom_with_spaces_only_servicename(self):
+        params = {"service": "   "}
+        sbom_file = (
+            Path(__file__).resolve().parent.parent / "upload_test" / "test_trivy_cyclonedx.json"
+        )
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"] == "Missing service_name"
+
+    def test_it_should_trim_spaces_when_upload_sbom_with_padded_servicename(self):
+        params = {"service": "  myservice  "}
+        sbom_file = (
+            Path(__file__).resolve().parent.parent / "upload_test" / "test_trivy_cyclonedx.json"
+        )
+        with open(sbom_file, "rb") as tags:
+            response = client.post(
+                f"/pteams/{self.pteam1.pteam_id}/upload_sbom_file",
+                headers=file_upload_headers(USER1),
+                params=params,
+                files={"file": tags},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["service_name"] == "myservice"
+
     @pytest.mark.skip(reason="TODO: need api to get background task status")
     def test_upload_pteam_sbom_file_wrong_content_format(self):
         params = {"service": "threatconnectome"}

--- a/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
+++ b/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
@@ -52,11 +52,12 @@ export function SBOMUpdateDialog({
   const [serviceNameInput, setServiceNameInput] = useState("");
 
   const effectiveServiceName = serviceName ?? serviceNameInput;
+  const trimmedServiceName = effectiveServiceName.trim();
 
   const isDuplicateServiceName =
     !!existingServiceNames &&
-    !!effectiveServiceName &&
-    existingServiceNames.includes(effectiveServiceName);
+    !!trimmedServiceName &&
+    existingServiceNames.includes(trimmedServiceName);
 
   useEffect(() => {
     if (open) {
@@ -70,7 +71,7 @@ export function SBOMUpdateDialog({
   const estimateTime = calculateEstimateTimeFromSize(sbomFile?.size ?? 0);
 
   const handleUpload = () => {
-    if (!sbomFile || !effectiveServiceName) {
+    if (!sbomFile || !trimmedServiceName) {
       alert(t("alertMissingFile"));
       return;
     }
@@ -79,7 +80,7 @@ export function SBOMUpdateDialog({
     enqueueSnackbar(t("uploadingFile", { fileName: sbomFile.name }), { variant: "info" });
     uploadSBOMFile({
       path: { pteam_id: pteamId },
-      query: { service: effectiveServiceName },
+      query: { service: trimmedServiceName },
       body: { file: sbomFile },
     })
       .unwrap()
@@ -170,7 +171,7 @@ export function SBOMUpdateDialog({
           <Button
             variant="contained"
             onClick={handleUpload}
-            disabled={!sbomFile || !effectiveServiceName || isDuplicateServiceName}
+            disabled={!sbomFile || !trimmedServiceName || isDuplicateServiceName}
           >
             {t("upload")}
           </Button>


### PR DESCRIPTION
## PR の目的

SBOMファイルアップロード時に、サービス名の前後にスペースが含まれていた場合、スペースを含んだままサービス名が登録されてしまう問題を修正する。

## 経緯・意図・意思決定

SBOMアップロード API（`upload_pteam_sbom_file`）では、クエリパラメータ `service` をそのまま使用しており、ユーザーが誤って前後にスペースを含めた場合でもそのまま保存されていた。
バックエンドとフロントエンドの両方で trim を行うことで、どのような経路（UI・API直接呼び出し）からアクセスされても一貫した動作を保証する。

## 実施したテスト項目

- `npm run test`
- `./testapi.sh`