### PR TITLE
feat: [UI] Statusページ改善 — サービス詳細を左ペインに移動 & Packageテーブル列変更（モック繋ぎこみ）

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -5,7 +5,9 @@
     "search_enter": "Search (press ENTER to apply)",
     "loading_team": "Now loading Team...",
     "loading_packages_summary": "Now loading PTeamPackagesSummary...",
-    "rows": "Rows"
+    "rows": "Rows",
+    "packageName": "Package Name",
+    "license": "License"
   },
   "PTeamServicesListModal": {
     "loadingTeam": "Now loading Team...",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -5,7 +5,9 @@
     "search_enter": "検索 (ENTERで適用)",
     "loading_team": "チーム情報を読み込んでいます...",
     "loading_packages_summary": "パッケージサマリーを読み込んでいます...",
-    "rows": "行"
+    "rows": "行",
+    "packageName": "パッケージ名",
+    "license": "ライセンス"
   },
   "PTeamServicesListModal": {
     "loadingTeam": "チーム情報を読み込んでいます...",

--- a/web/src/pages/Status/PTeamStatusCard.jsx
+++ b/web/src/pages/Status/PTeamStatusCard.jsx
@@ -1,112 +1,22 @@
 import {
-  Box,
   Chip,
-  Stack,
   TableCell,
   TableRow,
-  Tooltip,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
 import { grey, yellow, amber } from "@mui/material/colors";
-import { styled } from "@mui/material/styles";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
 
 import { SSVCPriorityStatusChip } from "../../components/SSVCPriorityStatusChip";
-import { ticketHandlingStatusProps, sortedTicketHandlingStatus } from "../../utils/const";
-import { calcTimestampDiff } from "../../utils/func";
 import { compareSSVCPriority } from "../../utils/ssvcUtils";
-
-function LineWithTooltip(props) {
-  const { ticketHandlingStatus, ratio, num } = props;
-  const constProp = ticketHandlingStatusProps[ticketHandlingStatus];
-
-  const tipAreaHeight = 15;
-  const lineHeight = 5;
-  const mt = (tipAreaHeight - lineHeight) / 2;
-
-  const StyledTooltip = styled((styledProps) => (
-    <Tooltip
-      arrow
-      title={num + " " + constProp.chipLabel}
-      classes={{ popper: styledProps.className }}
-      {...styledProps}
-    />
-  ))`
-    & .MuiTooltip-tooltip {
-      background-color: ${constProp.style.bgcolor};
-      color: ${constProp.style.color};
-    }
-    & .MuiTooltip-arrow {
-      color: ${constProp.style.bgcolor};
-    }
-  `;
-
-  return (
-    <StyledTooltip>
-      <Box sx={{ width: ratio + "%", height: tipAreaHeight + "px" }}>
-        <Box
-          sx={{
-            width: "100%",
-            height: lineHeight + "px",
-            mt: mt + "px",
-            backgroundColor: constProp.style.bgcolor,
-          }}
-        />
-      </Box>
-    </StyledTooltip>
-  );
-}
-
-LineWithTooltip.propTypes = {
-  ticketHandlingStatus: PropTypes.string,
-  ratio: PropTypes.number,
-  num: PropTypes.number,
-};
-
-function StatusRatioGraph(props) {
-  const { counts, displaySSVCPriority } = props;
-
-  if (displaySSVCPriority === "no_known_vulnerability") return "";
-  const keys = ["completed", "scheduled", "acknowledged", "alerted"];
-  const total = keys.reduce((ret, key) => ret + (counts[key] ?? 0), 0);
-  const ratios = keys.reduce((ret, key) => {
-    ret[key] = (100 * (counts[key] ?? 0)) / total;
-    return ret;
-  }, {});
-
-  return (
-    <Stack direction="row" spacing={0}>
-      {keys.map((key) => (
-        <LineWithTooltip
-          key={key}
-          ticketHandlingStatus={key}
-          ratio={ratios[key] ?? 0}
-          num={counts[key] ?? 0}
-        />
-      ))}
-    </Stack>
-  );
-}
-
-StatusRatioGraph.propTypes = {
-  counts: PropTypes.object,
-  displaySSVCPriority: PropTypes.string,
-};
 
 export function PTeamStatusCard(props) {
   const { onHandleClick, pteam, packageInfo, serviceIds } = props;
-  const { t } = useTranslation("status", { keyPrefix: "PTeamStatusCard" });
 
   // Change the background color and border based on the Alert Threshold value set by the team.
   const highlightCard =
     pteam.alert_ssvc_priority !== "defer" && // disable highlight if threshold is "defer"
     compareSSVCPriority(packageInfo.ssvc_priority, pteam.alert_ssvc_priority) <= 0;
-
-  const theme = useTheme();
-  const isMdDown = useMediaQuery(theme.breakpoints.down("md"));
 
   return (
     <TableRow
@@ -138,8 +48,6 @@ export function PTeamStatusCard(props) {
           }}
         >
           {packageInfo.package_name}
-          {":"}
-          {packageInfo.ecosystem}
         </Typography>
         {serviceIds &&
           pteam.services
@@ -147,28 +55,13 @@ export function PTeamStatusCard(props) {
             .sort((a, b) => a.service_name.localeCompare(b.service_name))
             .map((service) => <Chip key={service.service_id} label={service.service_name} />)}
       </TableCell>
-      <TableCell
-        align="right"
-        style={{ width: "30%" }}
-        sx={{ display: isMdDown ? "none" : undefined }}
-      >
-        <Box display="flex" flexDirection="column">
-          <Box display="flex" flexDirection="row" justifyContent="space-between">
-            <Typography
-              variant="body2"
-              sx={{
-                visibility:
-                  packageInfo.ssvc_priority === "no_known_vulnerability" ? "hidden" : "visible",
-              }}
-            >
-              {t("updated", { timeDiff: calcTimestampDiff(packageInfo.updated_at) })}
-            </Typography>
-          </Box>
-          <StatusRatioGraph
-            counts={packageInfo.status_count}
-            displaySSVCPriority={packageInfo.ssvc_priority}
-          />
-        </Box>
+      <TableCell style={{ width: "15%" }}>
+        <Typography variant="body2">{packageInfo.ecosystem}</Typography>
+      </TableCell>
+      <TableCell style={{ width: "15%" }}>
+        <Typography variant="body2" color="text.secondary">
+          {"-"}
+        </Typography>
       </TableCell>
     </TableRow>
   );
@@ -180,11 +73,7 @@ PTeamStatusCard.propTypes = {
   packageInfo: PropTypes.shape({
     package_name: PropTypes.string,
     package_id: PropTypes.string,
-    references: PropTypes.arrayOf(PropTypes.object),
-    text: PropTypes.string,
     ssvc_priority: PropTypes.string,
-    updated_at: PropTypes.string,
-    status_count: PropTypes.object,
     ecosystem: PropTypes.string,
   }).isRequired,
   serviceIds: PropTypes.array,

--- a/web/src/pages/Status/StatusPage.jsx
+++ b/web/src/pages/Status/StatusPage.jsx
@@ -2,11 +2,19 @@ import {
   AddCircleOutlineRounded as AddCircleOutlineRoundedIcon,
   Check as CheckIcon,
   Clear as ClearIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+  InfoOutlined as InfoOutlinedIcon,
   RemoveCircleOutline as RemoveCircleOutlineIcon,
+  StorageRounded as StorageRoundedIcon,
 } from "@mui/icons-material";
 import {
   Box,
+  Card,
+  CardContent,
+  CardMedia,
   Chip,
+  Collapse,
   FormControlLabel,
   IconButton,
   InputAdornment,
@@ -18,9 +26,13 @@ import {
   Pagination,
   Paper,
   Select,
+  Stack,
   Table,
   TableBody,
+  TableCell,
   TableContainer,
+  TableHead,
+  TableRow,
   TextField,
   Typography,
   useMediaQuery,
@@ -36,7 +48,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Android12Switch } from "../../components/Android12Switch";
 import { PTeamLabel } from "../../components/PTeamLabel";
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
-import { useGetPTeamQuery, useGetPTeamPackagesSummaryQuery } from "../../services/tcApi";
+import { useGetPTeamQuery, useGetPTeamPackagesSummaryQuery, useGetPTeamServiceThumbnailQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { getNoPTeamMessage } from "../../utils/const";
 import { errorToString } from "../../utils/func";
@@ -44,17 +56,184 @@ import { sortedSSVCPackagePriorities, getSsvcPriorityProps } from "../../utils/s
 import { preserveMyTasksParam, preserveParams } from "../../utils/urlUtils";
 
 import { DeleteServiceIcon } from "./DeleteServiceIcon";
-import { PTeamServiceDetailsResponsive } from "./PTeamServiceDetails/PTeamServiceDetailsResponsive";
 import { PTeamServiceSelectDialog } from "./PTeamServiceSelectDialog";
 import { PTeamServiceTabs } from "./PTeamServiceTabs";
 import { PTeamServicesListModal } from "./PTeamServicesListModal";
 import { PTeamStatusCard } from "./PTeamStatusCard";
 import { PTeamStatusCardFallback } from "./PTeamStatusCardFallback";
+import { PTeamStatusSSVCCards } from "./PTeamStatusSSVCCards";
 import { FileDropZone } from "./SbomDrop/FileDropZone";
+import { SBOMUpdateButton } from "./SbomDrop/SBOMUpdateButton";
 import { SBOMUpdateDialog } from "./SbomDrop/SBOMUpdateDialog";
 import { SBOMUploadProgressButton } from "./SbomProgress/SBOMUploadProgressButton";
+import { PTeamServiceDetailsSettings } from "./ServiceDetailsSettings/PTeamServiceDetailsSettings";
 
 const ssvcPriorityCountMax = 99999;
+
+const noImageUrl = "images/no-image-available-720x480.png";
+
+function ServiceLeftPane({ pteamId, service, highestSsvcPriority }) {
+  const { data: thumbnail, isError: thumbnailIsError, isLoading: thumbnailIsLoading } =
+    useGetPTeamServiceThumbnailQuery({
+      path: { pteam_id: pteamId, service_id: service.service_id },
+    });
+  const image =
+    thumbnailIsError || thumbnailIsLoading || !thumbnail ? noImageUrl : thumbnail;
+
+  const [detailsOpen, setDetailsOpen] = useState(true);
+  const [deployOpen, setDeployOpen] = useState(false);
+
+  const ipAddresses = service.asset?.ip_addresses || [];
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      {/* Service Image */}
+      <Card
+        sx={{
+          border: 1,
+          borderColor: "divider",
+          borderRadius: 3,
+          overflow: "hidden",
+          position: "relative",
+        }}
+      >
+        <CardMedia
+          component="img"
+          image={image}
+          alt={service.service_name}
+          sx={{ aspectRatio: "4/3", width: "100%", objectFit: "cover" }}
+        />
+        <Box sx={{ position: "absolute", top: 0, right: 48 }}>
+          <SBOMUpdateButton pteamId={pteamId} serviceName={service.service_name} />
+        </Box>
+        <PTeamServiceDetailsSettings
+          pteamId={pteamId}
+          service={service}
+          expandService={true}
+        />
+      </Card>
+
+      {/* Details Accordion */}
+      <Card sx={{ border: 1, borderColor: "divider", borderRadius: 3 }}>
+        <Box
+          onClick={() => setDetailsOpen(!detailsOpen)}
+          sx={{ display: "flex", alignItems: "center", px: 2, py: 1.5, cursor: "pointer" }}
+        >
+          <InfoOutlinedIcon sx={{ mr: 1, fontSize: 20, color: "text.secondary" }} />
+          <Typography variant="subtitle2">詳細情報</Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          {detailsOpen ? (
+            <ExpandLessIcon sx={{ color: "text.secondary" }} />
+          ) : (
+            <ExpandMoreIcon sx={{ color: "text.secondary" }} />
+          )}
+        </Box>
+        <Collapse in={detailsOpen}>
+          <CardContent sx={{ pt: 0 }}>
+            <Stack spacing={1.5}>
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 700, textTransform: "uppercase" }}
+                >
+                  サービス名
+                </Typography>
+                <Typography variant="body2" sx={{ fontWeight: 600, mt: 0.5 }}>
+                  {service.service_name}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 700, textTransform: "uppercase" }}
+                >
+                  説明文
+                </Typography>
+                <Typography variant="body2" sx={{ mt: 0.5, wordBreak: "break-all" }}>
+                  {service.description || (
+                    <Box component="span" sx={{ color: "text.secondary" }}>
+                      未設定
+                    </Box>
+                  )}
+                </Typography>
+              </Box>
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 700, textTransform: "uppercase" }}
+                >
+                  タグ
+                </Typography>
+                {service.keywords?.length > 0 ? (
+                  <Stack direction="row" flexWrap="wrap" sx={{ gap: 0.5, mt: 0.5 }}>
+                    {service.keywords.map((kw) => (
+                      <Chip key={kw} label={kw} size="small" />
+                    ))}
+                  </Stack>
+                ) : (
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                    未設定
+                  </Typography>
+                )}
+              </Box>
+            </Stack>
+          </CardContent>
+        </Collapse>
+      </Card>
+
+      {/* Deployments Accordion */}
+      <Card sx={{ border: 1, borderColor: "divider", borderRadius: 3 }}>
+        <Box
+          onClick={() => setDeployOpen(!deployOpen)}
+          sx={{ display: "flex", alignItems: "center", px: 2, py: 1.5, cursor: "pointer" }}
+        >
+          <StorageRoundedIcon sx={{ mr: 1, fontSize: 20, color: "text.secondary" }} />
+          <Typography variant="subtitle2">デプロイ先</Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          <Chip label={`${ipAddresses.length}件`} size="small" sx={{ mr: 1 }} />
+          {deployOpen ? (
+            <ExpandLessIcon sx={{ color: "text.secondary" }} />
+          ) : (
+            <ExpandMoreIcon sx={{ color: "text.secondary" }} />
+          )}
+        </Box>
+        <Collapse in={deployOpen}>
+          <CardContent sx={{ pt: 0 }}>
+            {ipAddresses.length > 0 ? (
+              <Stack spacing={0.5}>
+                {ipAddresses.map((ip, i) => (
+                  <Typography key={i} variant="body2">
+                    {ip}
+                  </Typography>
+                ))}
+              </Stack>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                未設定
+              </Typography>
+            )}
+          </CardContent>
+        </Collapse>
+      </Card>
+
+      {/* SSVC Cards */}
+      <PTeamStatusSSVCCards
+        pteamId={pteamId}
+        service={service}
+        highestSsvcPriority={highestSsvcPriority}
+      />
+    </Box>
+  );
+}
+
+ServiceLeftPane.propTypes = {
+  pteamId: PropTypes.string.isRequired,
+  service: PropTypes.object.isRequired,
+  highestSsvcPriority: PropTypes.string.isRequired,
+};
 
 function SearchField(props) {
   const { word, onApply } = props;
@@ -132,7 +311,6 @@ export function Status() {
   const pteamId = params.get("pteamId");
   const serviceId = params.get("serviceId");
 
-  const [expandService, setExpandService] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
   const searchMenuOpen = Boolean(anchorEl);
 
@@ -427,8 +605,6 @@ export function Status() {
     }
   };
 
-  const handleSwitchExpandService = () => setExpandService(!expandService);
-
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -545,89 +721,109 @@ export function Status() {
           />
         ))}
       <CustomTabPanel value={isActiveUploadMode} index={0}>
-        {service && (
-          <PTeamServiceDetailsResponsive
-            pteamId={pteamId}
-            service={service}
-            expandService={expandService}
-            onSwitchExpandService={handleSwitchExpandService}
-            highestSsvcPriority={pteamServicePackagesSummary.packages[0]?.ssvc_priority ?? "defer"}
-          />
-        )}
         <Box
           sx={{
-            display: "flex",
-            flexDirection: { md: "row", xs: "column" },
-            justifyContent: "space-between",
-            mt: 2,
+            display: "grid",
+            gridTemplateColumns: service
+              ? { xs: "1fr", md: "minmax(280px, 0.7fr) minmax(0, 1.9fr)" }
+              : "1fr",
+            gap: 3,
           }}
         >
-          {filterRow}
-          <Box mb={0.5} sx={{ display: "flex", flexDirection: "row", gap: 1 }}>
-            <SearchField word={searchWord} onApply={handleSearchWord} />
-            <IconButton
-              id="basic-button"
-              aria-controls={searchMenuOpen ? "basic-menu" : undefined}
-              aria-haspopup="true"
-              aria-expanded={searchMenuOpen ? "true" : undefined}
-              onClick={handleClick}
-              size="small"
-              sx={{ mt: 1.5 }}
+          {service && (
+            <ServiceLeftPane
+              pteamId={pteamId}
+              service={service}
+              highestSsvcPriority={
+                pteamServicePackagesSummary.packages[0]?.ssvc_priority ?? "defer"
+              }
+            />
+          )}
+          <Box>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { md: "row", xs: "column" },
+                justifyContent: "space-between",
+                mt: 2,
+              }}
             >
-              {searchMenuOpen ? <RemoveCircleOutlineIcon /> : <AddCircleOutlineRoundedIcon />}
-            </IconButton>
-            {SSVCPriorityMenu}
+              {filterRow}
+              <Box mb={0.5} sx={{ display: "flex", flexDirection: "row", gap: 1 }}>
+                <SearchField word={searchWord} onApply={handleSearchWord} />
+                <IconButton
+                  id="basic-button"
+                  aria-controls={searchMenuOpen ? "basic-menu" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={searchMenuOpen ? "true" : undefined}
+                  onClick={handleClick}
+                  size="small"
+                  sx={{ mt: 1.5 }}
+                >
+                  {searchMenuOpen ? <RemoveCircleOutlineIcon /> : <AddCircleOutlineRoundedIcon />}
+                </IconButton>
+                {SSVCPriorityMenu}
+              </Box>
+            </Box>
+            <TableContainer component={Paper} sx={{ mt: 0.5 }}>
+              <Table sx={{ minWidth: 320 }} aria-label="simple table">
+                <TableHead>
+                  <TableRow>
+                    <TableCell style={{ width: "5%" }}>SSVC</TableCell>
+                    <TableCell>{t("packageName")}</TableCell>
+                    <TableCell style={{ width: "15%" }}>ecosystem</TableCell>
+                    <TableCell style={{ width: "15%" }}>{t("license")}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {isActiveAllServicesMode ? (
+                    <>
+                      {targetPackages.map((packageInfo) => (
+                        <ErrorBoundary
+                          key={packageInfo.package_id}
+                          FallbackComponent={PTeamStatusCardFallback}
+                        >
+                          <PTeamStatusCard
+                            key={packageInfo.package_id}
+                            onHandleClick={() =>
+                              handleNavigateServiceList(
+                                packageInfo.package_id,
+                                packageInfo.package_name,
+                                packageInfo.service_ids,
+                              )
+                            }
+                            pteam={pteam}
+                            packageInfo={packageInfo}
+                            serviceIds={packageInfo.service_ids}
+                          />
+                        </ErrorBoundary>
+                      ))}
+                    </>
+                  ) : (
+                    <>
+                      {targetPackages.map((packageInfo) => (
+                        <ErrorBoundary
+                          key={packageInfo.package_id}
+                          FallbackComponent={PTeamStatusCardFallback}
+                        >
+                          <PTeamStatusCard
+                            key={packageInfo.package_id}
+                            onHandleClick={() =>
+                              handleNavigatePackage(serviceId, packageInfo.package_id)
+                            }
+                            pteam={pteam}
+                            packageInfo={packageInfo}
+                          />
+                        </ErrorBoundary>
+                      ))}
+                    </>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            {targetPackages.length > 3 && filterRow}
           </Box>
         </Box>
-        <TableContainer component={Paper} sx={{ mt: 0.5 }}>
-          <Table sx={{ minWidth: 320 }} aria-label="simple table">
-            <TableBody>
-              {isActiveAllServicesMode ? (
-                <>
-                  {targetPackages.map((packageInfo) => (
-                    <ErrorBoundary
-                      key={packageInfo.package_id}
-                      FallbackComponent={PTeamStatusCardFallback}
-                    >
-                      <PTeamStatusCard
-                        key={packageInfo.package_id}
-                        onHandleClick={() =>
-                          handleNavigateServiceList(
-                            packageInfo.package_id,
-                            packageInfo.package_name,
-                            packageInfo.service_ids,
-                          )
-                        }
-                        pteam={pteam}
-                        packageInfo={packageInfo}
-                        serviceIds={packageInfo.service_ids}
-                      />
-                    </ErrorBoundary>
-                  ))}
-                </>
-              ) : (
-                <>
-                  {targetPackages.map((packageInfo) => (
-                    <ErrorBoundary
-                      key={packageInfo.package_id}
-                      FallbackComponent={PTeamStatusCardFallback}
-                    >
-                      <PTeamStatusCard
-                        key={packageInfo.package_id}
-                        onHandleClick={() =>
-                          handleNavigatePackage(serviceId, packageInfo.package_id)
-                        }
-                        pteam={pteam}
-                        packageInfo={packageInfo}
-                      />
-                    </ErrorBoundary>
-                  ))}
-                </>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
-        {targetPackages.length > 3 && filterRow}
       </CustomTabPanel>
       <CustomTabPanel value={isActiveUploadMode} index={1}>
         <FileDropZone


### PR DESCRIPTION
## 概要

Statusページの新UIをモック繋ぎこみで実装します。

## 変更内容

### レイアウト変更 (StatusPage.jsx)

- サービス選択時に2カラムグリッドレイアウトを適用（左ペイン / 右ペイン）
- モバイル・全サービスモード時は1カラムを維持

### 左ペイン — ServiceLeftPane (StatusPage.jsx)

プロトタイプ (#1289) の新デザインを StatusPage.jsx 内にインライン実装:
- サービス画像（SBOMUpdateButton + 設定ボタン付き）
- 詳細情報アコーディオン（サービス名、説明文、タグ）
- デプロイ先アコーディオン（IPアドレス一覧）
- SSVCカード (PTeamStatusSSVCCards)

### Packageテーブル列変更 (PTeamStatusCard.jsx)

- 追加: ecosystem を独立列に分離、ライセンス列（プレースホルダ）
- 削除: 更新日時、プログレスバー
- ヘッダ行 (TableHead) を追加

## 関連

- ドラフトPR #1289 (プロトタイプ)
- 次スプリント: コンポーネント分割リファクタ予定