### PR TITLE
docs: mention SPDX 2.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Threatconnectome supports vulnerability management in industries where products 
 
 - Alerts and Actions based on SSVC
 - PSIRT-friendly UI and Web API
-- CycloneDX 1.6 support
+- SPDX 2.3 and CycloneDX 1.6 support
 
 ## :eyes: Live demo
 


### PR DESCRIPTION
## PR の目的

- README の対応フォーマット表記に SPDX 2.3 を追加する

## 経緯・意図・意思決定

- SPDX 2.3 をサポートしたため、README の機能概要を「SPDX 2.3 and CycloneDX 1.6 support」に更新しました。
- この記載は以前からあったものであり、SPDX 2.3が未サポートであったため下記PRで一旦記載削除していたが、今回機能サポートしたため追記した
https://github.com/nttcom/threatconnectome/pull/1252

