### PR TITLE
/pr-create スラッシュコマンドを追加

### DIFF
--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,22 @@
+---
+description: .github/pull_request_template.md に沿った本文でプルリクを作成する (デフォルト Draft、通常 PR にするには --ready)
+argument-hint: [--ready] [補足メモ]
+arguments:
+  - --ready (任意): 指定すると Draft ではなく review-ready の通常 PR として作成する。未指定時は Draft。
+  - 補足メモ (任意): PR 本文に反映したい追加情報 (issue 番号、背景、テストメモ等)。
+---
+
+現在のブランチから main への PR を作成する。`$ARGUMENTS` に `--ready` が含まれていれば通常 PR、含まれなければ Draft で作成し、`--ready` を除いた残りを補足メモとして扱う。
+
+## 手順
+
+1. **変更把握**: `git status` / `git diff main...HEAD` / `git log main..HEAD --oneline` / `git status -sb` を並列実行。
+2. **テンプレート読込**: Read ツールで `.github/pull_request_template.md` を毎回読み込む。見出し・コメントタグはそのまま、プレースホルダ例は実内容で書き換える。フォーマットはこのコマンドに埋め込まない。
+3. **本文ドラフト**: 差分・コミット・補足メモから各セクションを埋める。テストは実施済みのものだけ書く (未実施なら明記)。タイトルは 70 文字以内。署名は付けない。
+4. **push**: 未追跡なら `git push -u origin <branch>`、追跡済みなら `git push`。`--force` / `--no-verify` 禁止。
+5. **PR 作成**: `gh pr create --base main --title "..." --body "$(cat <<'EOF' ... EOF)"` で作成し、URL を出力。デフォルトは `--draft` を付ける。`--ready` 指定時のみ `--draft` を外す。
+
+## 注意
+
+- 機微ファイル (`.env` 等) が差分に混ざっていたら停止して警告。
+- 同名ブランチの PR が既存 (`gh pr view` で確認) なら新規作成せずユーザーに確認。

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -2,11 +2,16 @@
 description: .github/pull_request_template.md に沿った本文でプルリクを作成する (デフォルト Draft、通常 PR にするには --ready)
 argument-hint: [--ready] [補足メモ]
 arguments:
-  - --ready (任意): 指定すると Draft ではなく review-ready の通常 PR として作成する。未指定時は Draft。
-  - 補足メモ (任意): PR 本文に反映したい追加情報 (issue 番号、背景、テストメモ等)。
+  - --ready
+  - 補足メモ
 ---
 
+# プルリク作成
+
 現在のブランチから main への PR を作成する。`$ARGUMENTS` に `--ready` が含まれていれば通常 PR、含まれなければ Draft で作成し、`--ready` を除いた残りを補足メモとして扱う。
+
+- `--ready` (任意): 指定すると Draft ではなく review-ready の通常 PR として作成する。未指定時は Draft。
+- 補足メモ (任意): PR 本文に反映したい追加情報 (issue 番号、背景、テストメモ等)。
 
 ## 手順
 
@@ -14,7 +19,9 @@ arguments:
 2. **テンプレート読込**: Read ツールで `.github/pull_request_template.md` を毎回読み込む。見出し・コメントタグはそのまま、プレースホルダ例は実内容で書き換える。フォーマットはこのコマンドに埋め込まない。
 3. **本文ドラフト**: 差分・コミット・補足メモから各セクションを埋める。テストは実施済みのものだけ書く (未実施なら明記)。タイトルは 70 文字以内。署名は付けない。
 4. **push**: 未追跡なら `git push -u origin <branch>`、追跡済みなら `git push`。`--force` / `--no-verify` 禁止。
-5. **PR 作成**: `gh pr create --base main --title "..." --body "$(cat <<'EOF' ... EOF)"` で作成し、URL を出力。デフォルトは `--draft` を付ける。`--ready` 指定時のみ `--draft` を外す。
+5. **PR 作成**: 以下で作成し URL を出力。`--ready` 指定時のみ `--draft` を外す。
+   - デフォルト: `gh pr create --base main --draft --title "..." --body "$(cat <<'EOF' ... EOF)"`
+   - `--ready` 指定時: `gh pr create --base main --title "..." --body "$(cat <<'EOF' ... EOF)"`
 
 ## 注意
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- 機能追加
  - `.github/pull_request_template.md` のフォーマットに従って GitHub PR を作成する `/pr-create` カスタムコマンドを `.claude/commands/` に追加する

## 経緯・意図・意思決定

- PR 作成時にテンプレートの記入漏れや署名追加などのブレを減らすため、Claude Code 用のスラッシュコマンドを用意した。
- フォーマットはコマンドに埋め込まず、実行時に `.github/pull_request_template.md` を毎回読み込む方針とした。テンプレートが更新されれば次回以降の `/pr-create` 実行に自動的に反映される。
- デフォルトは Draft PR、`--ready` オプション指定時のみ review-ready の通常 PR として作成する。レビュー前のセルフチェック (CI 通過確認等) を挟みやすくするため。
- 引数仕様は他コマンド (`eol-sbom` 等) と合わせ、frontmatter の `argument-hint` と `arguments:` で `--ready` と補足メモを明示した。
- 機微ファイル混入チェックと、同名ブランチに既存 PR がある場合の確認手順も注意事項として含めた。

## 実施したテスト項目

- 本 PR の作成自体が `/pr-create` の動作確認を兼ねている (Draft 作成・テンプレート読込・push の流れがエラーなく通ることを確認)。
- `--ready` 経路は未実施。


<!-- I want to review in Japanese. -->