### PR TITLE
Remove pre-wrap from non-delete team name displays

### DIFF
--- a/web/src/components/PTeamLabel.jsx
+++ b/web/src/components/PTeamLabel.jsx
@@ -39,7 +39,7 @@ export function PTeamLabel(props) {
     <>
       <Box display="flex" flexDirection="column" flexGrow={1} my={2}>
         <Box display="flex" alignItems="center">
-          <Typography variant="h5" fontWeight={900} sx={{ whiteSpace: "pre" }}>
+          <Typography variant="h5" fontWeight={900}>
             {pteamName}
           </Typography>
           <IconButton onClick={() => setPTeamSettingsModalOpen(true)}>

--- a/web/src/components/__tests__/PTeamLabel.test.jsx
+++ b/web/src/components/__tests__/PTeamLabel.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+
+import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
+import { useGetUserMeQuery } from "../../services/tcApi";
+import { PTeamLabel } from "../PTeamLabel";
+
+vi.mock("../../hooks/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useSkipUntilAuthUserIsReady: vi.fn(),
+  };
+});
+
+vi.mock("../../services/tcApi", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useGetUserMeQuery: vi.fn(),
+  };
+});
+
+vi.mock("../PTeamSettingsModal", () => ({
+  PTeamSettingsModal: () => null,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+describe("PTeamLabel", () => {
+  it("renders team name without preserving repeated half-width spaces", () => {
+    vi.mocked(useSkipUntilAuthUserIsReady).mockReturnValue(false);
+    vi.mocked(useGetUserMeQuery).mockReturnValue({
+      data: {
+        pteam_roles: [
+          {
+            pteam: {
+              pteam_id: "team-1",
+              pteam_name: "Alpha  Beta",
+            },
+          },
+        ],
+      },
+      error: undefined,
+      isLoading: false,
+    });
+
+    render(<PTeamLabel pteamId="team-1" />);
+
+    const label = screen.getByRole("heading", { level: 5 });
+    expect(window.getComputedStyle(label).whiteSpace).not.toBe("pre");
+  });
+});

--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.jsx
@@ -56,7 +56,7 @@ export function AcceptPTeamInvitation() {
   return (
     <>
       <Typography variant="h6">{t("title")}</Typography>
-      <Typography sx={{ whiteSpace: "pre" }}>
+      <Typography>
         {t("teamName")}: {detail.pteam_name}
       </Typography>
       <Typography>

--- a/web/src/pages/App/TeamSelector.jsx
+++ b/web/src/pages/App/TeamSelector.jsx
@@ -113,7 +113,6 @@ export function TeamSelector() {
                   key={pteam_role.pteam.pteam_id}
                   value={pteam_role.pteam.pteam_id}
                   onClick={() => switchToPTeam(pteam_role.pteam.pteam_id)}
-                  sx={{ whiteSpace: "pre" }}
                 >
                   {textTrim(pteam_role.pteam.pteam_name)}
                 </MenuItem>

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
@@ -114,7 +114,7 @@ export function AccountSettingsDialog(props) {
               </Typography>
               <Stack spacing={1}>
                 {userMe.pteam_roles.map((pteam_role) => (
-                  <DialogContentText key={pteam_role.pteam.pteam_id} sx={{ whiteSpace: "pre" }}>
+                  <DialogContentText key={pteam_role.pteam.pteam_id}>
                     {pteam_role.pteam.pteam_name}
                   </DialogContentText>
                 ))}
@@ -146,11 +146,7 @@ export function AccountSettingsDialog(props) {
                   <em>{t("none")}</em>
                 </MenuItem>
                 {userMe.pteam_roles.map((pteam_role) => (
-                  <MenuItem
-                    key={pteam_role.pteam.pteam_id}
-                    value={pteam_role.pteam.pteam_id}
-                    sx={{ whiteSpace: "pre" }}
-                  >
+                  <MenuItem key={pteam_role.pteam.pteam_id} value={pteam_role.pteam.pteam_id}>
                     {pteam_role.pteam.pteam_name}
                   </MenuItem>
                 ))}

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/__tests__/AccountSettingsDialog.test.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/__tests__/AccountSettingsDialog.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+
+import { useAuth } from "../../../../../hooks/auth";
+import { AccountSettingsDialog } from "../AccountSettingsDialog";
+
+vi.mock("../../../../../hooks/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+  };
+});
+
+vi.mock("../../DeleteAccountDialog", () => ({
+  DeleteAccountDialog: () => null,
+}));
+
+vi.mock("../TwoFactorAuthSection/TwoFactorAuthSection", () => ({
+  TwoFactorAuthSection: () => null,
+}));
+
+describe("AccountSettingsDialog", () => {
+  it("renders team names without preserving repeated half-width spaces", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      isAuthenticatedWithSaml: vi.fn().mockReturnValue(false),
+    });
+
+    render(
+      <AccountSettingsDialog
+        accountSettingOpen
+        setAccountSettingOpen={vi.fn()}
+        onUpdateUser={vi.fn()}
+        userMe={{
+          email: "test@example.com",
+          user_id: "user-1",
+          years: 0,
+          default_pteam_id: null,
+          pteam_roles: [
+            {
+              pteam: {
+                pteam_id: "team-1",
+                pteam_name: "Gamma  Delta",
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    const teamName = screen
+      .getAllByText((_, element) => element?.textContent === "Gamma  Delta")
+      .find((element) => element.tagName === "P");
+    expect(window.getComputedStyle(teamName).whiteSpace).not.toBe("pre");
+  });
+});

--- a/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
+++ b/web/src/pages/PTeam/PTeamMemberRemoveModal.jsx
@@ -53,9 +53,7 @@ export function PTeamMemberRemoveModal(props) {
       </DialogTitle>
       <DialogContent>
         <Box display="flex" flexWrap="wrap" alignItems="baseline" sx={{ my: 2 }}>
-          <Typography sx={{ whiteSpace: "pre" }}>
-            {t("confirmRemove", { userName, pteamName })}
-          </Typography>
+          <Typography>{t("confirmRemove", { userName, pteamName })}</Typography>
         </Box>
       </DialogContent>
       <DialogActions className={dialogStyle.action_area}>

--- a/web/src/pages/ToDo/TicketDetailView.jsx
+++ b/web/src/pages/ToDo/TicketDetailView.jsx
@@ -192,7 +192,7 @@ export function TicketDetailView({ ticket }) {
             </IconButton>
           </DetailRow>
           <DetailRow label={t("team")}>
-            <Typography sx={{ whiteSpace: "pre" }}>{pteam?.pteam_name || "-"}</Typography>
+            <Typography>{pteam?.pteam_name || "-"}</Typography>
             <IconButton size="small" onClick={handleTeamClick}>
               <LinkIcon color="primary" fontSize="small" />
             </IconButton>

--- a/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.jsx
+++ b/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.jsx
@@ -150,7 +150,6 @@ export function VulnerabilityCard({ ticket }) {
                     sx={{
                       overflowWrap: "break-word",
                       minWidth: 0,
-                      whiteSpace: "pre",
                     }}
                   >
                     {item.value}

--- a/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.jsx
+++ b/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.jsx
@@ -51,7 +51,7 @@ export function ToDoTableRow(props) {
     <>
       <TableRow hover sx={{ cursor: "pointer" }} onClick={handleRowClick}>
         <TableCell>{vulnIsLoading ? "..." : cveId}</TableCell>
-        <TableCell sx={{ whiteSpace: "pre" }}>{pteamIsLoading ? "..." : pteamName}</TableCell>
+        <TableCell>{pteamIsLoading ? "..." : pteamName}</TableCell>
         <TableCell>{serviceIsLoading ? "..." : serviceName}</TableCell>
         <TableCell>{serviceDependencyIsLoading ? "..." : packageName}</TableCell>
         <TableCell>


### PR DESCRIPTION
  ## PR の目的

  - 以前修正を実施した`whiteSpace: "pre"` を使っている箇所を見直して通常表示に統一する

  ## 経緯・意図・意思決定

  - 表示崩れの原因となる whiteSpace: "pre"（または同等の指定）を、削除/通常表示に変更して統一した
  - 影響範囲はUI表示のみで、API仕様やデータ構造の変更は行っていない
  - 対象外:
      - チーム削除ダイアログの修正は実施せず

  ## 実施したテスト項目

  - cd web && npm run check
  - cd web && npm run test
  - テストケースの追加
  - 手動確認
      - チームセレクタ
      - PTeam招待受諾画面
      - アカウント設定ダイアログ
      - ToDo（カード/テーブル/詳細）

  ## 参考文献

  - なし