### PR TITLE
wrap descriptions in delete dialog text

### DIFF
--- a/web/src/components/PTeamGeneralSetting.jsx
+++ b/web/src/components/PTeamGeneralSetting.jsx
@@ -232,10 +232,14 @@ export function PTeamGeneralSetting(props) {
           <Typography variant="h6">{t("deleteDialogTitle")}</Typography>
         </DialogTitle>
         <DialogContent>
-          <Typography mb={2} sx={{ whiteSpace: "pre" }}>
+          <Typography mb={2} sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
             {t("deleteDialogDescription", { teamName: pteam.pteam_name })}
           </Typography>
-          <Typography variant="body2" mb={1} sx={{ whiteSpace: "pre" }}>
+          <Typography
+            variant="body2"
+            mb={1}
+            sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}
+          >
             {t("deleteDialogConfirmLabel", { teamName: pteam.pteam_name })}
           </Typography>
           <TextField


### PR DESCRIPTION
## PR の目的

 - チーム削除ダイアログで説明文がメッセージボックスからはみ出す問題を修正

## 経緯・意図・意思決定

 - 説明文が削除ダイアログ内でテキストが折り返されず、UIが崩れる問題が発生していた。
 - whiteSpace: "pre" を whiteSpace: "pre-wrap", overflowWrap: "anywhere" に変更し、長文でも自然に折り返されるように修正。

## 実施したテスト項目

 - npm run check, npm run test で静的チェック・ユニットテストが全てパスすることを確認
 - 実際の画面で説明文が折り返されることを目視確認