### PR TITLE
Statusページの完了後表示と状態管理を改善

### DIFF
--- a/web/src/pages/Status/SBOMManagement/RiskSettingsCard.jsx
+++ b/web/src/pages/Status/SBOMManagement/RiskSettingsCard.jsx
@@ -270,6 +270,8 @@ export function RiskSettingsCard({ onSave, sbom }) {
     try {
       const saved = await onSave?.({ missionImpact, systemExposure });
       if (saved !== false) {
+        setSystemExposure(currentSystemExposure);
+        setMissionImpact(currentMissionImpact);
         setEditing(false);
       }
     } finally {

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
@@ -23,10 +23,8 @@ export function useSBOMManagementController({
       setActiveId: state.setActiveId,
       setDeploymentsEditing: state.setDeploymentsEditing,
       setDetailsEditing: state.setDetailsEditing,
-      setPendingThumbnail: state.setPendingThumbnail,
+      setThumbnailState: state.setThumbnailState,
       setPendingUpload: state.setPendingUpload,
-      setAwaitingThumbnailRefresh: state.setAwaitingThumbnailRefresh,
-      setThumbnailDisplayOverride: state.setThumbnailDisplayOverride,
       updateActiveService: state.updateActiveService,
     },
     callbacks: {
@@ -36,10 +34,9 @@ export function useSBOMManagementController({
       activeId: state.activeId,
       activeService: state.activeService,
       isCreatingSbom: state.isCreatingSbom,
-      pendingThumbnail: state.pendingThumbnail,
       pteamId,
       serviceTabs: state.serviceTabs,
-      thumbnailDisplayOverride: state.thumbnailDisplayOverride,
+      thumbnailState: state.thumbnailState,
     },
   });
 
@@ -80,10 +77,9 @@ export function useSBOMManagementController({
         state.setDetailsOpen(true);
         state.setDetailsEditing(true);
       },
-      imageUrl: state.pendingThumbnail
-        ? state.pendingThumbnail.previewDataUrl || ""
-        : state.thumbnailDisplayOverride !== null
-          ? state.thumbnailDisplayOverride
+      imageUrl:
+        state.thumbnailState.previewDataUrl !== null
+          ? state.thumbnailState.previewDataUrl
           : state.activeService?.imageUrl || "",
       onCommit: mutations.commitDetailsEdit,
       onImageUpload: mutations.handleImageUpload,

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
@@ -18,8 +18,8 @@ export function useSBOMManagementController({
 
   const mutations = useSBOMManagementMutations({
     actions: {
-      markClean: state.markClean,
       resetUiState: state.resetUiState,
+      resetDraftToCurrentService: state.resetDraftToCurrentService,
       setActiveId: state.setActiveId,
       setDeploymentsEditing: state.setDeploymentsEditing,
       setDetailsEditing: state.setDetailsEditing,
@@ -42,12 +42,6 @@ export function useSBOMManagementController({
       thumbnailDisplayOverride: state.thumbnailDisplayOverride,
     },
   });
-
-  const displayedServiceTabs = state.serviceTabs.map((service) =>
-    service.id === state.activeId && state.activeService
-      ? { ...service, title: state.activeService.title }
-      : service,
-  );
 
   return {
     activeId: state.activeId,
@@ -122,7 +116,7 @@ export function useSBOMManagementController({
       onSave: mutations.commitServiceImpactEdit,
     },
     tabs: {
-      items: displayedServiceTabs,
+      items: state.serviceTabs,
       onAdd: state.addSbom,
       onSelect: (serviceId) => {
         state.selectService(serviceId);

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
@@ -17,17 +17,15 @@ import { errorToString } from "../../../utils/func";
 import { normalizeServiceImageToPng } from "../../../utils/serviceImageUtils";
 
 export function useSBOMManagementMutations({ actions, callbacks, state }) {
-  const { activeId, activeService, isCreatingSbom, pendingThumbnail, pteamId, serviceTabs } = state;
+  const { activeId, activeService, isCreatingSbom, pteamId, serviceTabs, thumbnailState } = state;
   const {
     resetDraftToCurrentService,
     resetUiState,
     setActiveId,
     setDeploymentsEditing,
     setDetailsEditing,
-    setPendingThumbnail,
+    setThumbnailState,
     setPendingUpload,
-    setAwaitingThumbnailRefresh,
-    setThumbnailDisplayOverride,
     updateActiveService,
   } = actions;
   const { onActiveIdChange } = callbacks;
@@ -129,10 +127,10 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
         enqueueSnackbar(t("imageTooLargeAfterConvert"), { variant: "error" });
         return;
       }
-      setPendingThumbnail({
+      setThumbnailState({
         file: normalized.file,
+        mode: "pendingUpload",
         previewDataUrl: normalized.previewDataUrl,
-        deleted: false,
       });
     } catch {
       enqueueSnackbar(t("imageProcessFailed"), { variant: "error" });
@@ -140,7 +138,11 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
   };
 
   const handleRemoveImage = () => {
-    setPendingThumbnail({ file: null, previewDataUrl: null, deleted: true });
+    setThumbnailState({
+      file: null,
+      mode: "pendingDelete",
+      previewDataUrl: "",
+    });
   };
 
   const commitDetailsEdit = async () => {
@@ -162,15 +164,15 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
       }).unwrap(),
     );
 
-    if (pendingThumbnail?.file) {
-      const file = pendingThumbnail.file;
+    if (thumbnailState.mode === "pendingUpload" && thumbnailState.file) {
+      const file = thumbnailState.file;
       calls.push(() =>
         updatePTeamServiceThumbnail({
           path: { pteam_id: pteamId, service_id: activeService.id },
           body: { uploaded: file },
         }).unwrap(),
       );
-    } else if (pendingThumbnail?.deleted) {
+    } else if (thumbnailState.mode === "pendingDelete") {
       calls.push(() =>
         deletePTeamServiceThumbnail({
           path: { pteam_id: pteamId, service_id: activeService.id },
@@ -180,17 +182,13 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
 
     try {
       await Promise.all(calls.map((fn) => fn()));
-      const nextThumbnailDisplayOverride = pendingThumbnail?.file
-        ? pendingThumbnail.previewDataUrl || ""
-        : pendingThumbnail?.deleted
-          ? ""
-          : null;
-      if (nextThumbnailDisplayOverride !== null) {
-        setThumbnailDisplayOverride(nextThumbnailDisplayOverride);
-        setAwaitingThumbnailRefresh(true);
+      if (thumbnailState.mode === "pendingUpload" || thumbnailState.mode === "pendingDelete") {
+        setThumbnailState({
+          ...thumbnailState,
+          mode: "awaitingRefetch",
+        });
       }
       enqueueSnackbar(t("updateDetailsSuccess"), { variant: "success" });
-      setPendingThumbnail(null);
       setDetailsEditing(false);
       resetDraftToCurrentService();
     } catch (error) {

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
@@ -19,7 +19,7 @@ import { normalizeServiceImageToPng } from "../../../utils/serviceImageUtils";
 export function useSBOMManagementMutations({ actions, callbacks, state }) {
   const { activeId, activeService, isCreatingSbom, pendingThumbnail, pteamId, serviceTabs } = state;
   const {
-    markClean,
+    resetDraftToCurrentService,
     resetUiState,
     setActiveId,
     setDeploymentsEditing,
@@ -192,7 +192,7 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
       enqueueSnackbar(t("updateDetailsSuccess"), { variant: "success" });
       setPendingThumbnail(null);
       setDetailsEditing(false);
-      markClean();
+      resetDraftToCurrentService();
     } catch (error) {
       enqueueSnackbar(t("updateFailed", { error: errorToString(error) }), { variant: "error" });
     }
@@ -215,7 +215,7 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
       }).unwrap();
       enqueueSnackbar(t("updateDeploymentsSuccess"), { variant: "success" });
       setDeploymentsEditing(false);
-      markClean();
+      resetDraftToCurrentService();
     } catch (error) {
       enqueueSnackbar(t("updateFailed", { error: errorToString(error) }), { variant: "error" });
     }
@@ -242,7 +242,7 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
         },
       }).unwrap();
       enqueueSnackbar(t("updateRiskSettingsSuccess"), { variant: "success" });
-      markClean();
+      resetDraftToCurrentService();
       return true;
     } catch (error) {
       enqueueSnackbar(t("updateFailed", { error: errorToString(error) }), { variant: "error" });

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
@@ -183,10 +183,11 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
     try {
       await Promise.all(calls.map((fn) => fn()));
       if (thumbnailState.mode === "pendingUpload" || thumbnailState.mode === "pendingDelete") {
-        setThumbnailState({
-          ...thumbnailState,
-          mode: "awaitingRefetch",
-        });
+        setThumbnailState((current) =>
+          current.mode === "pendingUpload" || current.mode === "pendingDelete"
+            ? { ...current, mode: "awaitingRefetch" }
+            : current,
+        );
       }
       enqueueSnackbar(t("updateDetailsSuccess"), { variant: "success" });
       setDetailsEditing(false);

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementState.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementState.js
@@ -2,6 +2,14 @@ import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import { NEW_SBOM_ID } from "../../../utils/SBOMManagement/sbomManagementUtils";
 
+function createThumbnailState() {
+  return {
+    file: null,
+    mode: "idle",
+    previewDataUrl: null,
+  };
+}
+
 function createEditorState(currentService) {
   return {
     activeServiceDraft: currentService,
@@ -76,10 +84,7 @@ export function useSBOMManagementState({
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [deploymentsOpen, setDeploymentsOpen] = useState(false);
   const [dangerOpen, setDangerOpen] = useState(false);
-  const [pendingThumbnail, setPendingThumbnail] = useState(null);
-  const [thumbnailDisplayOverride, setThumbnailDisplayOverride] = useState(null);
-  const [awaitingThumbnailRefresh, setAwaitingThumbnailRefresh] = useState(false);
-  const [hasSeenThumbnailRefetch, setHasSeenThumbnailRefetch] = useState(false);
+  const [thumbnailState, setThumbnailState] = useState(createThumbnailState);
   const [pendingUpload, setPendingUpload] = useState(null);
   const fileInputRef = useRef(null);
   const createFileInputRef = useRef(null);
@@ -100,10 +105,7 @@ export function useSBOMManagementState({
     dispatchEditorState({ type: "resetUi" });
     setCurrentPage(1);
     setDangerOpen(false);
-    setPendingThumbnail(null);
-    setThumbnailDisplayOverride(null);
-    setAwaitingThumbnailRefresh(false);
-    setHasSeenThumbnailRefetch(false);
+    setThumbnailState(createThumbnailState());
     setQuery("");
   };
 
@@ -115,31 +117,31 @@ export function useSBOMManagementState({
     dispatchEditorState({ type: "replaceCurrentService", currentService });
     setCurrentPage(1);
     setDangerOpen(false);
-    setPendingThumbnail(null);
-    setThumbnailDisplayOverride(null);
-    setAwaitingThumbnailRefresh(false);
-    setHasSeenThumbnailRefetch(false);
+    setThumbnailState(createThumbnailState());
     setQuery("");
   }, [currentService, selectedServiceId]);
 
   useEffect(() => {
-    if (!awaitingThumbnailRefresh) {
+    if (
+      thumbnailState.mode !== "awaitingRefetch" &&
+      thumbnailState.mode !== "awaitingRefetchSeen"
+    ) {
       return;
     }
 
     if (isThumbnailFetching) {
-      setHasSeenThumbnailRefetch(true);
+      setThumbnailState((current) =>
+        current.mode === "awaitingRefetch" ? { ...current, mode: "awaitingRefetchSeen" } : current,
+      );
       return;
     }
 
-    if (!hasSeenThumbnailRefetch) {
+    if (thumbnailState.mode !== "awaitingRefetchSeen") {
       return;
     }
 
-    setThumbnailDisplayOverride(null);
-    setAwaitingThumbnailRefresh(false);
-    setHasSeenThumbnailRefetch(false);
-  }, [awaitingThumbnailRefresh, hasSeenThumbnailRefetch, isThumbnailFetching]);
+    setThumbnailState(createThumbnailState());
+  }, [isThumbnailFetching, thumbnailState.mode]);
 
   const isEmpty = serviceTabs.length === 0;
   const isCreatingSbom = activeId === NEW_SBOM_ID || isEmpty;
@@ -230,7 +232,6 @@ export function useSBOMManagementState({
     pageSize,
     pageStartIndex,
     paginatedDependencies,
-    pendingThumbnail,
     pendingUpload,
     query,
     resetUiState,
@@ -246,13 +247,11 @@ export function useSBOMManagementState({
     setDetailsEditing,
     setDetailsOpen,
     setPageSize,
-    setPendingThumbnail,
-    setThumbnailDisplayOverride,
-    setAwaitingThumbnailRefresh,
+    setThumbnailState,
     setPendingUpload,
     setQuery,
+    thumbnailState,
     totalPages,
     updateActiveService,
-    thumbnailDisplayOverride,
   };
 }

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementState.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementState.js
@@ -1,6 +1,61 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import { NEW_SBOM_ID } from "../../../utils/SBOMManagement/sbomManagementUtils";
+
+function createEditorState(currentService) {
+  return {
+    activeServiceDraft: currentService,
+    deploymentsEditing: false,
+    detailsEditing: false,
+    isDirty: false,
+  };
+}
+
+function editorStateReducer(state, action) {
+  switch (action.type) {
+    case "syncCurrentService":
+      return {
+        ...state,
+        activeServiceDraft: action.currentService,
+      };
+    case "replaceCurrentService":
+      return createEditorState(action.currentService);
+    case "resetUi":
+      return {
+        ...state,
+        deploymentsEditing: false,
+        detailsEditing: false,
+        isDirty: false,
+      };
+    case "updateActiveService":
+      return {
+        ...state,
+        activeServiceDraft:
+          state.activeServiceDraft?.id === action.activeId
+            ? { ...state.activeServiceDraft, ...action.patch }
+            : state.activeServiceDraft,
+        isDirty: true,
+      };
+    case "resetDraftToCurrentService":
+      return {
+        ...state,
+        activeServiceDraft: action.currentService,
+        isDirty: false,
+      };
+    case "setDetailsEditing":
+      return {
+        ...state,
+        detailsEditing: action.value,
+      };
+    case "setDeploymentsEditing":
+      return {
+        ...state,
+        deploymentsEditing: action.value,
+      };
+    default:
+      return state;
+  }
+}
 
 export function useSBOMManagementState({
   currentDependencies = [],
@@ -10,15 +65,16 @@ export function useSBOMManagementState({
 }) {
   const selectedServiceId = currentService?.id ?? null;
   const [activeId, setActiveId] = useState(selectedServiceId ?? NEW_SBOM_ID);
-  const [activeServiceDraft, setActiveServiceDraft] = useState(currentService);
-  const [isDirty, setIsDirty] = useState(false);
+  const [editorState, dispatchEditorState] = useReducer(
+    editorStateReducer,
+    currentService,
+    createEditorState,
+  );
   const [query, setQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [detailsOpen, setDetailsOpen] = useState(false);
-  const [detailsEditing, setDetailsEditing] = useState(false);
   const [deploymentsOpen, setDeploymentsOpen] = useState(false);
-  const [deploymentsEditing, setDeploymentsEditing] = useState(false);
   const [dangerOpen, setDangerOpen] = useState(false);
   const [pendingThumbnail, setPendingThumbnail] = useState(null);
   const [thumbnailDisplayOverride, setThumbnailDisplayOverride] = useState(null);
@@ -35,17 +91,15 @@ export function useSBOMManagementState({
   }, [serviceTabs.length]);
 
   useEffect(() => {
-    if (!isDirty) {
-      setActiveServiceDraft(currentService);
+    if (!editorState.isDirty) {
+      dispatchEditorState({ type: "syncCurrentService", currentService });
     }
-  }, [currentService, isDirty]);
+  }, [currentService, editorState.isDirty]);
 
   const resetUiState = () => {
-    setIsDirty(false);
+    dispatchEditorState({ type: "resetUi" });
     setCurrentPage(1);
     setDangerOpen(false);
-    setDeploymentsEditing(false);
-    setDetailsEditing(false);
     setPendingThumbnail(null);
     setThumbnailDisplayOverride(null);
     setAwaitingThumbnailRefresh(false);
@@ -58,12 +112,9 @@ export function useSBOMManagementState({
     if (selectedServiceId === lastSelectedServiceIdRef.current) return;
     lastSelectedServiceIdRef.current = selectedServiceId;
     setActiveId(selectedServiceId ?? NEW_SBOM_ID);
-    setActiveServiceDraft(currentService);
-    setIsDirty(false);
+    dispatchEditorState({ type: "replaceCurrentService", currentService });
     setCurrentPage(1);
     setDangerOpen(false);
-    setDeploymentsEditing(false);
-    setDetailsEditing(false);
     setPendingThumbnail(null);
     setThumbnailDisplayOverride(null);
     setAwaitingThumbnailRefresh(false);
@@ -97,12 +148,12 @@ export function useSBOMManagementState({
       return null;
     }
 
-    if (activeServiceDraft?.id !== activeId) {
+    if (editorState.activeServiceDraft?.id !== activeId) {
       return null;
     }
 
-    return activeServiceDraft;
-  }, [activeId, activeServiceDraft, isCreatingSbom]);
+    return editorState.activeServiceDraft;
+  }, [activeId, editorState.activeServiceDraft, isCreatingSbom]);
 
   const filteredDependencies = useMemo(() => {
     const target = query.trim().toLowerCase();
@@ -127,14 +178,19 @@ export function useSBOMManagementState({
   const paginatedDependencies = filteredDependencies.slice(pageStartIndex, pageEndIndex);
 
   const updateActiveService = (patch) => {
-    setIsDirty(true);
-    setActiveServiceDraft((current) =>
-      current?.id === activeId ? { ...current, ...patch } : current,
-    );
+    dispatchEditorState({ type: "updateActiveService", activeId, patch });
   };
 
-  const markClean = () => {
-    setIsDirty(false);
+  const resetDraftToCurrentService = () => {
+    dispatchEditorState({ type: "resetDraftToCurrentService", currentService });
+  };
+
+  const setDetailsEditing = (value) => {
+    dispatchEditorState({ type: "setDetailsEditing", value });
+  };
+
+  const setDeploymentsEditing = (value) => {
+    dispatchEditorState({ type: "setDeploymentsEditing", value });
   };
 
   const addSbom = () => {
@@ -162,9 +218,9 @@ export function useSBOMManagementState({
     createFileInputRef,
     currentPage,
     dangerOpen,
-    deploymentsEditing,
+    deploymentsEditing: editorState.deploymentsEditing,
     deploymentsOpen,
-    detailsEditing,
+    detailsEditing: editorState.detailsEditing,
     detailsOpen,
     fileInputRef,
     filteredDependencies,
@@ -178,6 +234,7 @@ export function useSBOMManagementState({
     pendingUpload,
     query,
     resetUiState,
+    resetDraftToCurrentService,
     safeCurrentPage,
     selectService,
     serviceTabs,
@@ -195,7 +252,6 @@ export function useSBOMManagementState({
     setPendingUpload,
     setQuery,
     totalPages,
-    markClean,
     updateActiveService,
     thumbnailDisplayOverride,
   };

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -455,7 +455,7 @@ describe("StatusPage", () => {
       expect(navigate).toHaveBeenCalledWith(
         "/?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=d36d5c85-8b37-4da2-854c-bfa58a43d83e",
       );
-      expect(screen.queryByText("unsaved service title")).toBeNull();
+      expect(screen.queryByRole("button", { name: "unsaved service title" })).toBeNull();
       expect(screen.getByRole("button", { name: "test_service1" })).toBeInTheDocument();
     });
 

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -420,6 +420,45 @@ describe("StatusPage", () => {
       );
     });
 
+    it("discards unsaved details draft when a different SBOM tab is selected", async () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      const ue = userEvent.setup();
+      renderStatusPage();
+
+      await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+      fireEvent.change(screen.getByPlaceholderText("e.g. Payment Service SBOM"), {
+        target: { value: "unsaved service title" },
+      });
+
+      await ue.click(screen.getByRole("button", { name: "test_service2" }));
+
+      expect(navigate).toHaveBeenCalledWith(
+        "/?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=d36d5c85-8b37-4da2-854c-bfa58a43d83e",
+      );
+      expect(screen.queryByText("unsaved service title")).toBeNull();
+      expect(screen.getByRole("button", { name: "test_service1" })).toBeInTheDocument();
+    });
+
     it("updates system exposure and mission impact through the service API", async () => {
       const testLocation = {
         pathname: "/",
@@ -476,6 +515,9 @@ describe("StatusPage", () => {
           },
         });
       });
+      expect(screen.getByText("Small")).toBeInTheDocument();
+      expect(screen.getByText("MEF Support Crippled")).toBeInTheDocument();
+      expect(screen.queryByText("Degraded")).toBeNull();
       renderResult.rerender(
         <Provider store={store}>
           <Status />
@@ -531,6 +573,53 @@ describe("StatusPage", () => {
         variant: "error",
       });
       expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    });
+
+    it("keeps the tab title on the last fetched service name when details save fails", async () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      useUpdatePTeamServiceMutation.mockReturnValue([
+        createRejectedMutation({
+          status: 400,
+          data: { detail: "boom" },
+        }),
+      ]);
+
+      const ue = userEvent.setup();
+      renderStatusPage();
+
+      await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+      fireEvent.change(screen.getByPlaceholderText("e.g. Payment Service SBOM"), {
+        target: { value: "   " },
+      });
+      await ue.click(screen.getByRole("button", { name: "Done" }));
+
+      await waitFor(() => {
+        expect(enqueueSnackbar).toHaveBeenCalledWith("Update failed: 400: boom", {
+          variant: "error",
+        });
+      });
+
+      expect(screen.getByRole("button", { name: "test_service1" })).toBeInTheDocument();
     });
 
     it("shows refreshed service details after saving them", async () => {
@@ -590,6 +679,11 @@ describe("StatusPage", () => {
       fireEvent.change(tagsInput, { target: { value: "backend, prod, critical" } });
 
       await ue.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(screen.getByRole("button", { name: "test_service1" })).toBeInTheDocument();
+      expect(screen.queryByText("response description")).toBeNull();
+      expect(screen.queryByText("response")).toBeNull();
+      expect(screen.queryByText("Updated service description")).toBeNull();
 
       renderResult.rerender(
         <Provider store={store}>
@@ -1016,6 +1110,10 @@ describe("StatusPage", () => {
       expect(screen.getByDisplayValue("10.0.0.1")).toBeInTheDocument();
 
       await ue.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(screen.getByText("10.0.0.1")).toBeInTheDocument();
+      expect(screen.queryByText("response-ip")).toBeNull();
+      expect(screen.queryByText("10.0.0.1/32")).toBeNull();
 
       renderResult.rerender(
         <Provider store={store}>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- バグ改修
  - Statusページでサービス名編集時、APIでエラーになった場合に、エラーになったサービス名でタブ名を変更していた。
    - Statusページでサービス編集完了後に、入力値や更新レスポンスではなく再取得したGet APIの値を表示するよう、状態管理と表示更新処理を修正
    - Statusページで画像更新・削除後の表示を安定させるため、サムネイル関連stateを単一の状態表現に整理

## 経緯・意図・意思決定

この修正では、完了後の表示をRTK Queryの再フェッチ結果に寄せるため、SBOMManagementの編集状態を整理した。まず `isDirty`、`activeServiceDraft`、`detailsEditing`、`deploymentsEditing` を reducer にまとめ、編集状態の遷移を一箇所に集約した。
あわせて、画像更新・削除後の表示維持ロジックで使っていた複数の boolean/state を `thumbnailState` に統一し、プレビュー中・削除反映待ち・再フェッチ待ちを単一の状態として扱うようにした。

サービス名をspaceのみで送れてしまう submit 可否の問題は、このPRの対象外とした。今回は完了後表示とAPIエラー後の表示崩れの解消にスコープを限定している。

## 実施したテスト項目
- `npm run check`
- `npm run test`
- Statusページの既存テストで、詳細編集後の再表示、APIエラー時のタブ名維持、画像更新・削除後の表示維持を確認


<!-- I want to review in Japanese. -->