### PR TITLE
StatusページでサービスIDをコピー可能にする

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -64,6 +64,8 @@
     "descriptionPlaceholder": "Enter the target system or purpose of this SBOM",
     "tags": "Tags",
     "tagsPlaceholder": "backend, prod, critical",
+    "copyServiceId": "Copy service ID",
+    "copySuccess": "Copied!",
     "tooLongDescription": "Too long description. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width",
     "tooLongKeyword": "Too long keyword. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width",
     "tooLongServiceName": "Too long service name. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -52,6 +52,8 @@
     "description": "説明文",
     "descriptionPlaceholder": "SBOMの対象システムや用途を入力",
     "details": "詳細情報",
+    "copyServiceId": "サービスIDをコピー",
+    "copySuccess": "コピーしました！",
     "done": "完了",
     "edit": "編集",
     "image": "イメージ",

--- a/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
@@ -16,6 +16,7 @@ import { collapseSpaces } from "../../../utils/displayText";
 import { getLengthError, getTagsError } from "../../../utils/SBOMManagement/formValidation";
 import { normalizeTags } from "../../../utils/SBOMManagement/sbomManagementUtils";
 
+import { ServiceIdCopyButton } from "./ServiceIdCopyButton";
 import { AccordionHeader, AppButton, HeaderActionButton } from "./sharedUiParts";
 import { fieldSx, labelSx, slate } from "./styleTokens";
 
@@ -223,9 +224,23 @@ function DetailsForm({ editing, onUpdate, open, sbom }) {
       <Stack sx={{ display, gap: 2 }}>
         <Box>
           <Typography sx={labelSx}>{t("title")}</Typography>
-          <Typography sx={{ color: slate[800], fontSize: 14, fontWeight: 700, mt: 0.75 }}>
-            {sbom.title ? collapseSpaces(sbom.title) : emptyText}
-          </Typography>
+          <Box sx={{ alignItems: "center", display: "flex", gap: 0.5, mt: 0.75, minWidth: 0 }}>
+            <Typography
+              noWrap
+              sx={{
+                color: slate[800],
+                flex: "0 1 auto",
+                fontSize: 14,
+                fontWeight: 700,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {sbom.title ? collapseSpaces(sbom.title) : emptyText}
+            </Typography>
+            <ServiceIdCopyButton serviceId={sbom.id} />
+          </Box>
         </Box>
         <Box>
           <Typography sx={labelSx}>{t("description")}</Typography>

--- a/web/src/pages/Status/SBOMManagement/ServiceIdCopyButton.jsx
+++ b/web/src/pages/Status/SBOMManagement/ServiceIdCopyButton.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 
 export function ServiceIdCopyButton({ serviceId }) {
   const { t } = useTranslation("status", { keyPrefix: "DetailsPanel" });
-  const [tooltipText, setTooltipText] = useState(t("copyServiceId"));
+  const [tooltipKey, setTooltipKey] = useState("copyServiceId");
 
   if (!serviceId) return null;
 
@@ -13,15 +13,19 @@ export function ServiceIdCopyButton({ serviceId }) {
     <Tooltip
       arrow
       onClose={() => {
-        setTooltipText(t("copyServiceId"));
+        setTooltipKey("copyServiceId");
       }}
-      title={tooltipText}
+      title={t(tooltipKey)}
     >
       <IconButton
         aria-label={t("copyServiceId")}
-        onClick={() => {
-          navigator.clipboard.writeText(serviceId);
-          setTooltipText(t("copySuccess"));
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(serviceId);
+            setTooltipKey("copySuccess");
+          } catch {
+            setTooltipKey("copyServiceId");
+          }
         }}
         size="small"
         sx={{ color: "primary.main", flexShrink: 0, p: 0.5, "&:hover": { color: "primary.dark" } }}

--- a/web/src/pages/Status/SBOMManagement/ServiceIdCopyButton.jsx
+++ b/web/src/pages/Status/SBOMManagement/ServiceIdCopyButton.jsx
@@ -1,0 +1,33 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { IconButton, Tooltip } from "@mui/material";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export function ServiceIdCopyButton({ serviceId }) {
+  const { t } = useTranslation("status", { keyPrefix: "DetailsPanel" });
+  const [tooltipText, setTooltipText] = useState(t("copyServiceId"));
+
+  if (!serviceId) return null;
+
+  return (
+    <Tooltip
+      arrow
+      onClose={() => {
+        setTooltipText(t("copyServiceId"));
+      }}
+      title={tooltipText}
+    >
+      <IconButton
+        aria-label={t("copyServiceId")}
+        onClick={() => {
+          navigator.clipboard.writeText(serviceId);
+          setTooltipText(t("copySuccess"));
+        }}
+        size="small"
+        sx={{ color: "primary.main", flexShrink: 0, p: 0.5, "&:hover": { color: "primary.dark" } }}
+      >
+        <InfoOutlinedIcon sx={{ fontSize: 18 }} />
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -382,7 +382,7 @@ describe("StatusPage", () => {
         isFetching: false,
       });
 
-      const writeText = vi.fn();
+      const writeText = vi.fn().mockResolvedValue(undefined);
       Object.defineProperty(window.navigator, "clipboard", {
         configurable: true,
         value: { writeText },
@@ -392,7 +392,9 @@ describe("StatusPage", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Copy service ID" }));
 
-      expect(writeText).toHaveBeenCalledWith(testPTeamData.services[0].service_id);
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(testPTeamData.services[0].service_id);
+      });
     });
 
     it("shows system exposure and mission impact from the service API", () => {

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -360,6 +360,41 @@ describe("StatusPage", () => {
       expect(screen.getByText("Danger Zone")).toBeInTheDocument();
     });
 
+    it("copies the service id from the details title action", async () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      const writeText = vi.fn();
+      Object.defineProperty(window.navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+
+      renderStatusPage();
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy service ID" }));
+
+      expect(writeText).toHaveBeenCalledWith(testPTeamData.services[0].service_id);
+    });
+
     it("shows system exposure and mission impact from the service API", () => {
       const testLocation = {
         pathname: "/",


### PR DESCRIPTION
## PR の目的

- 機能追加
  - Statusページのサービスタブ内「詳細情報」において、サービス名右側のインフォメーションアイコンからサービスIDをコピー可能にする

## 実施したテスト項目

- `npm run check`
- `npm run test`
- 自動テスト追加
  - Statusページの詳細情報からサービスIDコピー操作が呼ばれることを確認
- 手動テスト
  - インフォメーションアイコンからサービスIDをコピーし、APIで確認したIDと一致することを確認
