### PR TITLE
fix(status): 依存パッケージの表示件数セレクタの件数ラベルを修正

### DIFF
--- a/web/src/pages/Status/SBOMManagement/DependenciesCard.jsx
+++ b/web/src/pages/Status/SBOMManagement/DependenciesCard.jsx
@@ -295,9 +295,9 @@ export function DependenciesCard({
                   sx={compactSelectSx}
                   value={pageSize}
                 >
-                  <MenuItem value={10}>{t("countItems", { count: 10 })}</MenuItem>
-                  <MenuItem value={20}>{t("countItems", { count: 20 })}</MenuItem>
-                  <MenuItem value={50}>{t("countItems", { count: 50 })}</MenuItem>
+                  <MenuItem value={10}>10</MenuItem>
+                  <MenuItem value={20}>20</MenuItem>
+                  <MenuItem value={50}>50</MenuItem>
                 </Select>
               </Box>
               <Box

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -339,6 +339,35 @@ describe("StatusPage", () => {
       expect(screen.getByText("Danger Zone")).toBeInTheDocument();
     });
 
+    it("shows the numeric row count in the dependencies page-size selector", () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      renderStatusPage();
+
+      expect(screen.getByText("Rows")).toBeInTheDocument();
+      expect(screen.getByRole("combobox")).toHaveTextContent("10");
+      expect(screen.queryByText("countItems")).toBeNull();
+    });
+
     it("copies the service id from the details title action", async () => {
       const testLocation = {
         pathname: "/",

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -363,9 +363,11 @@ describe("StatusPage", () => {
 
       renderStatusPage();
 
+      const pageSizeSelector = screen.getByRole("combobox");
+
       expect(screen.getByText("Rows")).toBeInTheDocument();
-      expect(screen.getByRole("combobox")).toHaveTextContent("10");
-      expect(screen.queryByText("countItems")).toBeNull();
+      expect(pageSizeSelector).toHaveTextContent("10");
+      expect(pageSizeSelector).not.toHaveTextContent("countItems");
     });
 
     it("copies the service id from the details title action", async () => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- バグ改修
  - Status ページの依存パッケージ一覧で、表示件数セレクタ（Rows）のラベルが正しく件数を表示していなかったため、各選択肢を数値（10 / 20 / 50）で表示するよう修正


## 実施したテスト項目

- `npm run check`
- `npm run test`
- 追加テスト: 依存パッケージの表示件数セレクタに数値（10）が表示され、`countItems` の文字列が表示されないことを確認
- 手動テスト: 表示確認。10から20、50に変更して、行数が変わることを確認。


<!-- I want to review in Japanese. -->