### PR TITLE
fix(pteam): チーム作成直後にis_adminを参照して落ちるバグを修正

### DIFF
--- a/web/src/pages/PTeam/PTeamMember.jsx
+++ b/web/src/pages/PTeam/PTeamMember.jsx
@@ -43,6 +43,7 @@ export function PTeamMember(props) {
     data: userMe,
     error: userMeError,
     isLoading: userMeIsLoading,
+    isFetching: userMeIsFetching,
   } = useGetUserMeQuery(undefined, { skip });
 
   if (skip) return <></>;
@@ -53,12 +54,19 @@ export function PTeamMember(props) {
 
   if (userMeIsLoading) return <>{t("loadingUserInfo")}</>;
 
-  const user = userMe.pteam_roles.find((pteam_role) => pteam_role.pteam.pteam_id === pteamId);
+  const currentMember = members.find((member) => member.user_id === userMe.user_id);
+  if (!currentMember) {
+    if (userMeIsFetching) return <>{t("loadingUserInfo")}</>;
+    throw new APIError(`Current user is not included in pteam members: ${pteamId}`, {
+      api: "getPTeamMembers",
+    });
+  }
+  const isCurrentUserAdmin = currentMember.is_admin;
 
   return (
     <>
       <Box display="flex" justifyContent="flex-end" mb={2}>
-        {user.is_admin && pteamId && <InvitationManageDialog pteamId={pteamId} />}
+        {isCurrentUserAdmin && pteamId && <InvitationManageDialog pteamId={pteamId} />}
       </Box>
       {isMdDown ? (
         <Stack spacing={2}>
@@ -92,7 +100,8 @@ export function PTeamMember(props) {
                     memberUserId={member.user_id}
                     userEmail={member.email}
                     isTargetMemberAdmin={member.is_admin}
-                    userMe={userMe}
+                    currentUserId={userMe.user_id}
+                    isCurrentUserAdmin={isCurrentUserAdmin}
                   />
                 </Box>
               </Box>
@@ -162,7 +171,8 @@ export function PTeamMember(props) {
                       memberUserId={member.user_id}
                       userEmail={member.email}
                       isTargetMemberAdmin={member.is_admin}
-                      userMe={userMe}
+                      currentUserId={userMe.user_id}
+                      isCurrentUserAdmin={isCurrentUserAdmin}
                     />
                   </TableCell>
                 </TableRow>
@@ -184,6 +194,7 @@ PTeamMember.propTypes = {
       email: PropTypes.string.isRequired,
       disabled: PropTypes.bool,
       years: PropTypes.number.isRequired,
+      is_admin: PropTypes.bool.isRequired,
     }),
   ).isRequired,
 };

--- a/web/src/pages/PTeam/PTeamMemberMenu.jsx
+++ b/web/src/pages/PTeam/PTeamMemberMenu.jsx
@@ -11,13 +11,20 @@ import { useTranslation } from "react-i18next";
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetPTeamQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
-import { errorToString, checkAdmin } from "../../utils/func";
+import { errorToString } from "../../utils/func";
 
 import { PTeamAuthEditor } from "./PTeamAuthEditor";
 import { PTeamMemberRemoveModal } from "./PTeamMemberRemoveModal";
 
 export function PTeamMemberMenu(props) {
-  const { pteamId, memberUserId, userEmail, isTargetMemberAdmin, userMe } = props;
+  const {
+    pteamId,
+    memberUserId,
+    userEmail,
+    isTargetMemberAdmin,
+    currentUserId,
+    isCurrentUserAdmin,
+  } = props;
   const { t } = useTranslation("pteam", { keyPrefix: "PTeamMemberMenu" });
 
   const [openAuth, setOpenAuth] = useState(false);
@@ -50,8 +57,6 @@ export function PTeamMemberMenu(props) {
     setOpenRemove(true);
   };
 
-  const isCurrentUserAdmin = checkAdmin(userMe, pteamId);
-
   return (
     <>
       <IconButton
@@ -76,7 +81,7 @@ export function PTeamMemberMenu(props) {
           <KeyIcon sx={{ mr: 1 }} />
           {t("authorities")}
         </MenuItem>
-        {(isCurrentUserAdmin || memberUserId === userMe.user_id) && (
+        {(isCurrentUserAdmin || memberUserId === currentUserId) && (
           <MenuItem onClick={handleRemoveMember}>
             <PersonOffIcon sx={{ mr: 1 }} />
             {t("removeFromTeam")}
@@ -95,7 +100,7 @@ export function PTeamMemberMenu(props) {
           />
         </DialogContent>
       </Dialog>
-      {(isCurrentUserAdmin || memberUserId === userMe.user_id) && (
+      {(isCurrentUserAdmin || memberUserId === currentUserId) && (
         <Dialog open={openRemove} onClose={() => setOpenRemove(false)}>
           <PTeamMemberRemoveModal
             memberUserId={memberUserId}
@@ -115,5 +120,6 @@ PTeamMemberMenu.propTypes = {
   memberUserId: PropTypes.string.isRequired,
   userEmail: PropTypes.string.isRequired,
   isTargetMemberAdmin: PropTypes.bool.isRequired,
-  userMe: PropTypes.object.isRequired,
+  currentUserId: PropTypes.string.isRequired,
+  isCurrentUserAdmin: PropTypes.bool.isRequired,
 };

--- a/web/src/pages/PTeam/__tests__/PTeamMember.test.jsx
+++ b/web/src/pages/PTeam/__tests__/PTeamMember.test.jsx
@@ -1,0 +1,130 @@
+import { createTheme, ThemeProvider } from "@mui/material";
+import { render, screen } from "@testing-library/react";
+import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
+
+import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
+import { useGetPTeamQuery, useGetUserMeQuery } from "../../../services/tcApi";
+import { PTeamMember } from "../PTeamMember";
+
+vi.mock("../../../hooks/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useSkipUntilAuthUserIsReady: vi.fn(),
+  };
+});
+
+vi.mock("../../../services/tcApi", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useGetPTeamQuery: vi.fn(),
+    useGetUserMeQuery: vi.fn(),
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+vi.mock("../InvitationManageDialog", () => ({
+  InvitationManageDialog: () => <button type="button">manage invitations</button>,
+}));
+
+vi.mock("../PTeamAuthEditor", () => ({
+  PTeamAuthEditor: ({ isCurrentUserAdmin }) => (
+    <label>
+      admin authority
+      <input type="checkbox" disabled={!isCurrentUserAdmin} />
+    </label>
+  ),
+}));
+
+vi.mock("../PTeamMemberRemoveModal", () => ({
+  PTeamMemberRemoveModal: () => <div>remove member modal</div>,
+}));
+
+const pteamId = "pteam-1";
+const currentUserId = "user-current";
+const theme = createTheme();
+
+const members = [
+  {
+    user_id: currentUserId,
+    email: "current@example.com",
+    disabled: false,
+    years: 3,
+    is_admin: false,
+  },
+  {
+    user_id: "user-member",
+    email: "member@example.com",
+    disabled: false,
+    years: 1,
+    is_admin: false,
+  },
+];
+
+const renderPTeamMember = ({ userMe = {}, memberOverrides = {} } = {}) => {
+  vi.mocked(useSkipUntilAuthUserIsReady).mockReturnValue(false);
+  vi.mocked(useGetUserMeQuery).mockReturnValue({
+    data: {
+      user_id: currentUserId,
+      pteam_roles: [],
+      ...userMe,
+    },
+    error: undefined,
+    isLoading: false,
+    isFetching: false,
+  });
+  vi.mocked(useGetPTeamQuery).mockReturnValue({
+    data: {
+      pteam_id: pteamId,
+      pteam_name: "Test PTeam",
+    },
+    error: undefined,
+    isLoading: false,
+  });
+
+  const testMembers = members.map((member) => ({
+    ...member,
+    ...memberOverrides[member.user_id],
+  }));
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <PTeamMember pteamId={pteamId} members={testMembers} />
+    </ThemeProvider>,
+  );
+};
+
+describe("PTeamMember", () => {
+  it("renders when userMe pteam roles do not include the current pteam yet", () => {
+    renderPTeamMember();
+
+    expect(screen.getByText("current@example.com")).toBeInTheDocument();
+    expect(screen.getByText("member@example.com")).toBeInTheDocument();
+  });
+
+  it("enables invitation management and member authority actions from the members response admin flag", async () => {
+    const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+    const { container } = renderPTeamMember({
+      memberOverrides: {
+        [currentUserId]: { is_admin: true },
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "manage invitations" })).toBeInTheDocument();
+
+    const memberMenuButton = container.querySelector("#pteam-member-button-user-member");
+    expect(memberMenuButton).not.toBeNull();
+    await ue.click(memberMenuButton);
+
+    expect(screen.getByText("removeFromTeam")).toBeInTheDocument();
+    await ue.click(screen.getByText("authorities"));
+
+    expect(screen.getByLabelText("admin authority")).toBeEnabled();
+  });
+});

--- a/web/src/utils/func.ts
+++ b/web/src/utils/func.ts
@@ -1,7 +1,6 @@
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
 import { SerializedError } from "@reduxjs/toolkit";
 
-import { UserResponse } from "../../types/types.gen";
 import { t } from "i18next";
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
@@ -76,12 +75,6 @@ export const blobToDataURL = async (blob: Blob) =>
     reader.onerror = (error) => reject(error);
     reader.readAsDataURL(blob);
   });
-
-export const checkAdmin = (member: UserResponse, pteamId: string) => {
-  return member.pteam_roles.some(
-    (pteam_role) => pteam_role.pteam.pteam_id === pteamId && pteam_role.is_admin,
-  );
-};
 
 export const countFullWidthAndHalfWidthCharacters = (string: string) => {
   let count = 0;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- バグ改修
  - チーム作成直後に管理者判定で `is_admin` を参照して落ちるバグを修正する
  - 現象
    - チームを作成すると「問題が発生しました」と表示される場合がある。
本番環境で4回中3回発生。
ローカル環境で3回中0回発生。

## 経緯・意図・意思決定

`PTeamMember` / `PTeamMemberMenu` では管理者判定に `checkAdmin(userMe, pteamId)`（`userMe.pteam_roles` から該当 pteam を検索）を使っていた。
しかしチーム作成直後は `userMe` のキャッシュがまだ更新されておらず、`pteam_roles` に作成したばかりの pteam が含まれないため、該当 role が見つからず `user.is_admin` 参照時にエラーになり画面が落ちていた。

対策として、`userMe.pteam_roles` ではなくメンバー一覧レスポンス（`members`）の `is_admin` を参照して管理者判定を行うよう変更した。

- `PTeamMember`: 自分自身を `members` から検索し、その `is_admin` を管理者判定に使用。`members` にまだ自分が含まれない場合は `isFetching` 中ならローディング表示、それ以外は `APIError` を送出。
- `PTeamMemberMenu`: `userMe` オブジェクトの受け渡しをやめ、`currentUserId` と `isCurrentUserAdmin` を props で受け取る形に変更。
- `func.ts`: 不要になった `checkAdmin` を削除。

## 実施したテスト項目

- `npm run check`（ESLint / Prettier / tsc）パス
- `npm run test`（追加した `PTeamMember.test.jsx` を含む）パス
  - `userMe.pteam_roles` に当該 pteam が含まれない状態でも画面が描画されること
  - メンバー一覧レスポンスの `is_admin` に基づき招待管理・メンバー権限操作が有効になること
- 手動テスト: チーム削除して正常に画面表示されること

## 参考文献

<!-- I want to review in Japanese. -->