### PR TITLE
fix(test): Supabaseのリフレッシュトークンローテーションに対応したテストを修正

### DIFF
--- a/api/app/tests/requests/test_auth.py
+++ b/api/app/tests/requests/test_auth.py
@@ -17,8 +17,18 @@ class TestLoginForAccessToken:
 
 class TestRefreshAccessToken:
     def test_refresh_token(self):
+        # Given
         old = get_access_token(USER1["email"], USER1["pass"])
+
+        # When
         new = refresh_access_token(old["refresh_token"])
+
+        # Then
         assert new["access_token"]
         assert new["token_type"].lower() == "bearer"
-        assert new["refresh_token"] == old["refresh_token"]
+        assert new["refresh_token"]
+
+        refreshed = refresh_access_token(new["refresh_token"])
+        assert refreshed["access_token"]
+        assert refreshed["token_type"].lower() == "bearer"
+        assert refreshed["refresh_token"]

--- a/api/app/tests/requests/test_auth.py
+++ b/api/app/tests/requests/test_auth.py
@@ -28,7 +28,10 @@ class TestRefreshAccessToken:
         assert new["token_type"].lower() == "bearer"
         assert new["refresh_token"]
 
+        # When
         refreshed = refresh_access_token(new["refresh_token"])
+
+        # Then
         assert refreshed["access_token"]
         assert refreshed["token_type"].lower() == "bearer"
         assert refreshed["refresh_token"]


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- Supabase のリフレッシュトークンローテーションにより失敗していたテストを修正
  - `api/app/tests/requests/test_auth.py::TestRefreshAccessToken::test_refresh_token` 

## 経緯・意図・意思決定
https://github.com/nttcom/threatconnectome/pull/1201/
でSupabaseにおける[Post /auth/refresh]APIを修正した際、自動テストがエラーになる状態となっていた。

Firebaseではrefreshの際に同じトークンを返すが、Supabase は `/auth/v1/token?grant_type=refresh_token` を呼び出すたびにリフレッシュトークンをローテーションする（新しいトークンを発行し、古いトークンを無効化する）。
公式 docs でも refresh token は基本的に一度だけ使われ、refresh  時に新しい access/refresh token pair と交換される扱いのため、APIは問題ないと判断した。

修正前のテストでは `new["refresh_token"] == old["refresh_token"]` と等値チェックをしていたため、ローテーション後に常にテストが失敗していた。

修正内容：
- リフレッシュトークンの等値チェックを削除し、存在チェック（`assert new["refresh_token"]`）に変更
- ローテーション後のリフレッシュトークンで再度リフレッシュが行えることを確認するアサーションを追加
- Given/When/Then 構造を付与

## 実施したテスト項目

- `api/app/tests/requests/test_auth.py::TestRefreshAccessToken::test_refresh_token` を実行して PASS を確認

## 参考文献
  - Supabase sessions: https://supabase.com/docs/guides/auth/sessions
  - Supabase Python refresh_session: https://supabase.com/docs/reference/python/auth-refreshsession

<!-- I want to review in Japanese. -->