### PR TITLE
Add verify-pr command and consolidate AGENTS.md policies

### DIFF
--- a/.claude/commands/verify-pr.md
+++ b/.claude/commands/verify-pr.md
@@ -37,6 +37,7 @@ arguments:
    全APIテストを実行する。
 
    ```bash
+   cd ..
    docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv app/tests/
    ```
 
@@ -54,5 +55,5 @@ arguments:
 
 - `api/` と `web/` の両方に変更がある場合は、両方の検証を実行する。
 - 失敗した検証がある場合は、原因を調査して修正を試み、同じ検証を再実行する。
-- API の endpoint signature、request/response schema、field name/type/nullability を変更している場合は、AGENTS.md の OpenAPI 再生成ルールに従い、必要に応じて `web/types` と `openapi.json` を更新してから再検証する。
+- API の endpoint signature、request/response schema、field name/type/nullability を変更している場合は、AGENTS.md の OpenAPI 再生成ルールに従い、必要に応じて `web/types` と `web/openapi.json` を更新してから再検証する。
 - 機微ファイル (`.env` 等) が差分に混ざっていたら停止して警告する。

--- a/.claude/commands/verify-pr.md
+++ b/.claude/commands/verify-pr.md
@@ -1,0 +1,58 @@
+---
+description: 修正差分を確認し、api/webに変更がある場合だけ該当領域の全チェック・全テストを実行する
+argument-hint: [補足メモ]
+arguments:
+  - 補足メモ
+---
+
+# PR前検証
+
+現在のブランチと作業ツリーの差分を確認し、`api` または `web` に変更がある場合だけ、その領域のフル検証を実行する。`$ARGUMENTS` は補足メモとして扱い、検証方針や結果報告に反映してよい。
+
+## 手順
+
+1. **差分把握**: `git status -sb` / `git diff --name-only main...HEAD` / `git diff --name-only` / `git diff --cached --name-only` / `git ls-files --others --exclude-standard` を実行し、変更ファイルを把握する。
+2. **対象判定**:
+   - `api/` 配下の変更が1件以上あれば API 検証を実行する。
+   - `web/` 配下の変更が1件以上あれば Web 検証を実行する。
+   - `api/` と `web/` のどちらにも変更がなければ、該当なしとして検証を実行しない。
+3. **API 検証**: `api/` に変更がある場合、まず `api/` で静的チェックを実行する。
+
+   ```bash
+   cd api
+   uv run --locked black --check --diff ./app
+   uv run --locked ruff check ./app
+   uv run --locked mypy ./app --show-error-codes --no-error-summary
+   uv run --locked codespell ./app
+   ```
+
+   続けてテスト用スタックを確認する。
+
+   リポジトリルートに戻ってから Docker Compose を操作する。
+
+   - `docker-compose-firebase-local.yml` が起動中なら、テスト前に停止する。
+   - `docker-compose-firebase-test.yml` が起動していなければ起動する。すでに起動中なら再起動しない。
+   - このコマンドで起動した test stack は検証後に停止する。元から起動していた場合は触らない。
+
+   全APIテストを実行する。
+
+   ```bash
+   docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv app/tests/
+   ```
+
+4. **Web 検証**: `web/` に変更がある場合、以下を実行する。
+
+   ```bash
+   cd ./web
+   npm run check
+   npm run test
+   ```
+
+5. **結果報告**: 実行した検証、pass/fail、失敗時の原因と修正状況を簡潔に報告する。未実行の領域がある場合は、変更がなかったため未実行であることを明記する。
+
+## 注意
+
+- `api/` と `web/` の両方に変更がある場合は、両方の検証を実行する。
+- 失敗した検証がある場合は、原因を調査して修正を試み、同じ検証を再実行する。
+- API の endpoint signature、request/response schema、field name/type/nullability を変更している場合は、AGENTS.md の OpenAPI 再生成ルールに従い、必要に応じて `web/types` と `openapi.json` を更新してから再検証する。
+- 機微ファイル (`.env` 等) が差分に混ざっていたら停止して警告する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,25 +51,24 @@ Reference URLs:
 - **Avoid ambiguous descriptions**: Vague wording causes inconsistent agent behavior. Write instructions that have only one reasonable interpretation.
 - **Avoid excessive detail**: Overly granular rules are hard to maintain. Focus on principles and key constraints rather than exhaustive step-by-step procedures.
 
+### Command Safety Policy
+
+Commands are subject to the execution environment's approval rules.
+Within those limits, treat these as normal project operations:
+
+- Read-only inspection
+- Repository-local file changes
+- Project-local format, lint, validation, and test commands
+- Starting or stopping Docker Compose services defined in this repository
+
+Do not affect external systems, global configuration, or data outside this repository without explicit approval.
+
 ---
 
 ## api — Rules for changes under `./api`
 
 This block applies to all changes under `./api`.
 Always operate from the repository root.
-
-### Command Safety Policy
-
-The agent may run the following commands without confirmation:
-
-- Read-only commands (e.g. grep, rg, cat, ls)
-- Commands that modify files within this repository only
-- Commands that start or stop local Docker containers defined in this repository
-- Test execution commands (e.g. pytest)
-
-Before running commands that affect anything outside the repository
-(e.g. global installs, system changes, external services, data deletion),
-the agent MUST ask for user confirmation.
 
 ### Mandatory Actions (Agent)
 
@@ -179,32 +178,6 @@ For Python tests under `./api`, follow the Given-When-Then structure where it im
 
 This block applies to all changes under `./web`.
 Always operate from the repository root.
-
-### Command Safety Policy
-
-The agent may run the following commands **without user confirmation**:
-
-- Read-only commands and inspection tools
-
-- Commands that modify files **only within this repository**
-
-- Project-scoped `npm` commands executed inside this repository
-  for **local formatting, linting, validation, or test execution**, including:
-  - `npm run check`
-  - `npm run test`
-  - `npm test`
-  - `npm run format`
-  - `npm run lint`
-  - `npx vitest`
-  - `npx vitest run`
-
-The agent MUST ask for user confirmation before running commands that:
-
-- affect files or systems outside this repository
-- install, update, or remove global packages
-- change system or environment configuration
-- access external services or networks
-- delete data outside the repository scope
 
 ### Mandatory Actions (Agent)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,32 +82,29 @@ If API schemas, models, or data structures change:
 - Find affected tests under `api/app/tests/`
 - Update them to match changed field names, types, and nullability
 
-#### 2. Run Static Checks
+#### 2. Run Targeted Verification
 
-Always execute:
+Run the smallest useful verification for the change before reporting completion.
+Choose commands based on the files and behavior changed:
 
-```bash
-cd api
-uv run --locked black --check --diff ./app
-uv run --locked ruff check ./app
-uv run --locked mypy ./app --show-error-codes --no-error-summary
-uv run --locked codespell ./app
-```
+- Static checks for touched Python modules when practical:
 
-#### 3. Run API Tests
+  ```bash
+  cd api
+  uv run --locked black --check --diff <changed files or ./app>
+  uv run --locked ruff check <changed files or ./app>
+  uv run --locked mypy <changed files or ./app> --show-error-codes --no-error-summary
+  uv run --locked codespell <changed files or ./app>
+  ```
 
-- If `docker-compose-firebase-local.yml` is running, stop it before running the tests
+- Related tests only, unless the change is broad or high risk:
 
-- Ensure `docker-compose-firebase-test.yml` is running  
-  (start it if not running; do NOT restart if already running)
+  ```bash
+  # Run from the repository root.
+  docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv <related test files or directories>
+  ```
 
-- Always execute tests:
-
-```bash
-docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv app/tests/
-```
-
-- Stop the test stack only if you started it
+- In the final response, explicitly list which checks/tests were run. If a relevant check was skipped, state why.
 
 ### Frontend Type Definitions (`./web/types`) and OpenAPI
 
@@ -208,27 +205,26 @@ Test locations:
 Use existing testing tools and patterns already used in the project
 (e.g. React Testing Library, Jest / Vitest).
 
-#### 2. Run Static Checks
+#### 2. Run Targeted Verification
 
-Always execute:
+Run the smallest useful verification for the change before reporting completion.
+Choose commands based on the files and behavior changed:
 
-```bash
-cd ./web
-npm run check
-```
+- Static checks when practical:
 
-This must pass with no errors.
+  ```bash
+  cd ./web
+  npm run check
+  ```
 
-#### 3. Run Web Tests
+- Related tests only, unless the change is broad or high risk:
 
-Always execute:
+  ```bash
+  cd ./web
+  npx vitest run <related test files>
+  ```
 
-```bash
-cd ./web
-npm run test
-```
-
-- All newly added or modified tests must pass
+- In the final response, explicitly list which checks/tests were run. If a relevant check was skipped, state why.
 
 ### UI and Logic Separation Rule (IMPORTANT)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,14 @@ Choose commands based on the files and behavior changed:
 
 - Related tests only, unless the change is broad or high risk:
 
+  Before running API tests:
+
+  - Run Docker Compose commands from the repository root.
+  - If `docker-compose-firebase-local.yml` is running, stop it first to avoid port conflicts.
+  - Ensure `docker-compose-firebase-test.yml` is running
+    (start it if not running; do NOT restart if already running).
+
   ```bash
-  # Run from the repository root.
   docker compose -f docker-compose-firebase-test.yml exec testapi pytest -s -vv <related test files or directories>
   ```
 
@@ -120,21 +126,35 @@ If any of the following change:
 
 #### How to regenerate
 
-- Ensure `docker-compose-firebase-local.yml` is running  
-  (start it if not running; do NOT restart if already running)
+- Run Docker Compose commands from the repository root.
 
-- Wait for API to be fully running:
+- If `docker-compose-firebase-test.yml` is running, stop it first to avoid port conflicts.
+
+- Ensure `docker-compose-firebase-local.yml` is running
+  (start it if not running; do NOT restart services other than `api` if already running).
+
+- Always restart the `api` service before fetching OpenAPI, so generated files reflect the latest source code:
 
   ```bash
-  docker compose -f docker-compose-firebase-local.yml logs api | grep -q "Application startup complete"
+  docker compose -f docker-compose-firebase-test.yml stop
+  docker compose -f docker-compose-firebase-local.yml up -d
+  docker compose -f docker-compose-firebase-local.yml restart api
   ```
 
-- Under this common condition (API running), always run:
+- Wait for the current API process to be reachable. Do not rely only on old `Application startup complete` logs:
+
+  ```bash
+  curl --fail --silent --show-error --output /tmp/openapi-check.json http://localhost/api/internal-api/openapi.json
+  ```
+
+- Then always run:
 
 ```bash
 cd web
 npm run openapi:update
 ```
+
+- After regeneration, verify `web/openapi.json` and `web/types` reflect the intended API schema changes.
 
 ### Python Test Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Choose commands based on the files and behavior changed:
 
 ### Frontend Type Definitions (`./web/types`) and OpenAPI
 
-The following files are auto-generated and must not be edited manually: `./web/types` and `./openapi.json`.
+The following files are auto-generated and must not be edited manually: `./web/types` and `./web/openapi.json`.
 
 #### When to regenerate
 
@@ -148,10 +148,10 @@ If any of the following change:
 
 - Then always run:
 
-```bash
-cd web
-npm run openapi:update
-```
+  ```bash
+  cd web
+  npm run openapi:update
+  ```
 
 - After regeneration, verify `web/openapi.json` and `web/types` reflect the intended API schema changes.
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- PR 前検証用スラッシュコマンド `/verify-pr` を `.claude/commands/verify-pr.md` として追加する
- AGENTS.md の Command Safety Policy を api/web セクション個別から Global Coding Rules へ集約し、記述の重複を排除する

## 経緯・意図・意思決定

### API 検証手順の改善

- 静的チェックとテストを「常に全実行」から「変更対象に絞った最小検証」に変更し、無駄な待ち時間を削減した。
- OpenAPI 再生成時に `docker-compose-firebase-test.yml` との競合ポートを避ける手順と、API プロセスの疎通確認 (`curl`) を明示した。
- `Application startup complete` ログへの依存（古いログが残ると誤判定）を廃止した。

### `/verify-pr` コマンドの追加

`api/` か `web/` に変更がある場合だけ当該領域のフル検証を走らせるコマンドを追加した。
変更のない領域は検証しないため、api のみ変更した PR で web テストを待つ必要がなくなる。

### Command Safety Policy の集約

api・web それぞれのブロックに同じ趣旨のポリシーが別々に書かれており、内容のズレや保守コストの増加が問題だった。
グローバルルールとして一本化することで、将来の追加ディレクトリにも自動適用される形にした。

## 実施したテスト項目

- 下記プロンプトを実行して意図通り動作することを確認
`get /pteams/{pteam_id}/ticket_counts APIのレスポンスの#sym:ssvc_priority_count をssvc_priority_count2にリネームして`

<!-- I want to review in Japanese. -->