### PR TITLE
ウェブアプリにSVGファビコンを追加

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Threatconnectome Web UI"
     />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg" />
     <title>Threatconnectome</title>
     <script type="module" src="/src/index.jsx"></script>
   </head>

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Threatconnectome Web UI"
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Threatconnectome</title>
     <script type="module" src="/src/index.jsx"></script>
   </head>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <!-- Background frame -->
+  <rect width="512" height="512" rx="112" fill="#FFFFFF" />
+  <rect x="22" y="22" width="468" height="468" rx="90" stroke="#cbd5e1" stroke-width="16" />
+
+  <!-- Top connection line -->
+  <path
+    d="M168 164 L344 164 L268 346"
+    stroke="#0B1220"
+    stroke-width="54"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+
+  <!-- Top left node -->
+  <circle cx="168" cy="164" r="60" fill="#0B1220" />
+
+  <!-- Top right node -->
+  <circle cx="344" cy="164" r="60" fill="#0B1220" />
+
+  <!-- Bottom node (primary focus) -->
+  <circle cx="268" cy="346" r="70" fill="#22C55E" />
+
+  <!-- Bottom node highlight -->
+  <circle cx="268" cy="346" r="26" fill="#FFFFFF" opacity="0.22" />
+</svg>

--- a/web/src/__tests__/indexHtml.test.ts
+++ b/web/src/__tests__/indexHtml.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const indexHtml = readFileSync(join(process.cwd(), "index.html"), "utf8");
+
+describe("index.html", () => {
+  it("declares the SVG favicon as scalable", () => {
+    const document = new DOMParser().parseFromString(indexHtml, "text/html");
+    const favicon = document.querySelector('link[rel="icon"]');
+
+    expect(favicon?.getAttribute("type")).toBe("image/svg+xml");
+    expect(favicon?.getAttribute("sizes")).toBe("any");
+    expect(favicon?.getAttribute("href")).toBe("/favicon.svg");
+  });
+});


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- 機能追加
  - ウェブアプリにSVGファビコン (`favicon.svg`) を追加し、ブラウザタブにアイコンが表示されるようにする


## 実施したテスト項目

- ブラウザで下記に設定したアイコンが表示されることを確認
  - ブラウザのタブ一覧
  - お気に入り登録後のお気に入り一覧
  - ウィンドウのタイトル


<!-- I want to review in Japanese. -->