### PR TITLE
共通スタイルトークンを導入し、重複した色・角丸・影の定義を統一

### DIFF
--- a/web/src/pages/App/Topbar/topbarStyles.js
+++ b/web/src/pages/App/Topbar/topbarStyles.js
@@ -1,27 +1,29 @@
+import { uiPalette, uiRadii, uiShadows } from "../../../styles/designTokens";
+
 export const colors = {
-  ink900: "#111827",
-  ink700: "#374151",
-  ink500: "#6B7280",
-  ink400: "#9CA3AF",
-  slate50: "#F8FAFC",
-  slate100: "#F1F5F9",
-  slate200: "#E2E8F0",
-  slate300: "#CBD5E1",
-  brand50: "#ECFDF5",
-  brand100: "#D1FAE5",
-  brand700: "#047857",
-  red50: "#FEF2F2",
-  red100: "#FEE2E2",
-  red600: "#DC2626",
-  amber50: "#FFFBEB",
-  amber100: "#FEF3C7",
-  amber700: "#B45309",
-  sky50: "#F0F9FF",
-  sky100: "#E0F2FE",
-  sky700: "#0369A1",
-  violet50: "#F5F3FF",
-  violet100: "#EDE9FE",
-  violet700: "#6D28D9",
+  ink900: uiPalette.gray[900],
+  ink700: uiPalette.gray[700],
+  ink500: uiPalette.gray[500],
+  ink400: uiPalette.gray[400],
+  slate50: uiPalette.slate[50],
+  slate100: uiPalette.slate[100],
+  slate200: uiPalette.slate[200],
+  slate300: uiPalette.slate[300],
+  brand50: uiPalette.brand[50],
+  brand100: uiPalette.brand[100],
+  brand700: uiPalette.brand[700],
+  red50: uiPalette.red[50],
+  red100: uiPalette.red[100],
+  red600: uiPalette.red[600],
+  amber50: uiPalette.amber[50],
+  amber100: uiPalette.amber[100],
+  amber700: uiPalette.amber[700],
+  sky50: uiPalette.sky[50],
+  sky100: uiPalette.sky[100],
+  sky700: uiPalette.sky[700],
+  violet50: uiPalette.violet[50],
+  violet100: uiPalette.violet[100],
+  violet700: uiPalette.violet[700],
 };
 
 export const tonePalette = {
@@ -41,8 +43,8 @@ export const menuWidths = {
 export const menuPaperSx = {
   mt: 1,
   border: `1px solid ${colors.slate200}`,
-  borderRadius: 3,
-  boxShadow: "0 18px 44px rgba(17, 24, 39, 0.14), 0 2px 8px rgba(17, 24, 39, 0.08)",
+  borderRadius: uiRadii.popover,
+  boxShadow: uiShadows.topbarMenu,
   overflow: "hidden",
 };
 
@@ -52,8 +54,8 @@ export const controlButtonSx = {
   borderColor: `${colors.slate300} !important`,
   color: colors.ink700,
   bgcolor: "#fff",
-  borderRadius: "8px",
-  boxShadow: "0 1px 2px rgba(17, 24, 39, 0.05)",
+  borderRadius: uiRadii.topbarControl,
+  boxShadow: uiShadows.xs,
   textTransform: "none",
   fontWeight: 600,
   lineHeight: 1,
@@ -109,7 +111,7 @@ export const compactMenuItemSx = {
   my: 0.25,
   px: 1.5,
   py: 1.25,
-  borderRadius: 2,
+  borderRadius: uiRadii.menuItem,
 };
 
 export const currentChipSx = {
@@ -129,7 +131,7 @@ export const teamMenuListSx = {
     width: 8,
   },
   "&::-webkit-scrollbar-thumb": {
-    borderRadius: 999,
+    borderRadius: uiRadii.pill,
     bgcolor: colors.ink400,
     border: "2px solid transparent",
     backgroundClip: "content-box",

--- a/web/src/pages/Status/SBOMManagement/DangerZone.jsx
+++ b/web/src/pages/Status/SBOMManagement/DangerZone.jsx
@@ -20,7 +20,16 @@ import { useTranslation } from "react-i18next";
 import { isDeleteConfirmationValid } from "../../../utils/SBOMManagement/sbomManagementUtils";
 
 import { AppButton } from "./sharedUiParts";
-import { fieldSx, labelSx, sectionIconBoxSx, sectionTitleTextSx, slate } from "./styleTokens";
+import {
+  fieldSx,
+  labelSx,
+  sectionIconBoxSx,
+  sectionTitleTextSx,
+  slate,
+  statusCardSx,
+  uiRadii,
+  uiTransitions,
+} from "./styleTokens";
 
 export function DangerZone({ disabled = false, onDelete, onToggle, open, sbomTitle }) {
   const { t } = useTranslation("status", { keyPrefix: "DangerZone" });
@@ -38,10 +47,7 @@ export function DangerZone({ disabled = false, onDelete, onToggle, open, sbomTit
     <Card
       sx={{
         bgcolor: slate[50],
-        border: `1px solid ${slate[200]}`,
-        borderRadius: 6,
-        boxShadow: "none",
-        minWidth: 0,
+        ...statusCardSx,
       }}
     >
       <Box
@@ -77,7 +83,7 @@ export function DangerZone({ disabled = false, onDelete, onToggle, open, sbomTit
           sx={{
             color: slate[400],
             transform: open ? "rotate(180deg)" : "rotate(0deg)",
-            transition: "transform 160ms ease",
+            transition: uiTransitions.transform,
           }}
         />
       </Box>
@@ -106,7 +112,7 @@ export function DangerZone({ disabled = false, onDelete, onToggle, open, sbomTit
         maxWidth="xs"
         onClose={closeDialog}
         open={dialogOpen}
-        PaperProps={{ sx: { borderRadius: 6, p: 1 } }}
+        PaperProps={{ sx: { borderRadius: uiRadii.statusCard, p: 1 } }}
       >
         <DialogContent sx={{ p: 2, position: "relative" }}>
           <Box sx={{ pr: 6 }}>
@@ -131,7 +137,7 @@ export function DangerZone({ disabled = false, onDelete, onToggle, open, sbomTit
           >
             <CloseIcon sx={{ fontSize: 20 }} />
           </IconButton>
-          <Box sx={{ bgcolor: slate[50], borderRadius: 4, mt: 2.5, p: 2 }}>
+          <Box sx={{ bgcolor: slate[50], borderRadius: uiRadii.field, mt: 2.5, p: 2 }}>
             <Typography sx={labelSx}>{t("deleteTarget")}</Typography>
             <Typography
               sx={{

--- a/web/src/pages/Status/SBOMManagement/DependenciesCard.jsx
+++ b/web/src/pages/Status/SBOMManagement/DependenciesCard.jsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import { SSVCPriorityStatusChip } from "../../../components/SSVCPriorityStatusChip";
 
 import { AppButton } from "./sharedUiParts";
-import { compactSelectSx, slate } from "./styleTokens";
+import { compactSelectSx, slate, statusCardSx, surfaceShadowSx, uiRadii } from "./styleTokens";
 
 function DependencyTable({ dependencies, onPackageClick, pageStartIndex }) {
   const { t } = useTranslation("status", { keyPrefix: "DependenciesCard" });
@@ -114,17 +114,14 @@ export function DependenciesCard({
   return (
     <Card
       sx={{
-        border: `1px solid ${slate[200]}`,
-        borderRadius: 6,
-        boxShadow: "none",
-        minWidth: 0,
+        ...statusCardSx,
       }}
     >
       <CardContent sx={{ minWidth: 0, p: 3 }}>
         <Box
           sx={{
             border: `1px solid ${slate[200]}`,
-            borderRadius: 4,
+            borderRadius: uiRadii.field,
             minWidth: 0,
             overflow: "hidden",
             width: "100%",
@@ -145,8 +142,8 @@ export function DependenciesCard({
               sx={{
                 bgcolor: "white",
                 border: `1px solid ${slate[200]}`,
-                borderRadius: 3,
-                boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
+                borderRadius: uiRadii.statusButton,
+                ...surfaceShadowSx,
                 height: 36,
                 maxWidth: 520,
                 position: "relative",

--- a/web/src/pages/Status/SBOMManagement/DeploymentsPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/DeploymentsPanel.jsx
@@ -9,7 +9,7 @@ import { Box, Card, CardContent, IconButton, Stack, TextField, Typography } from
 import { useTranslation } from "react-i18next";
 
 import { AccordionHeader, CountBadge, HeaderActionButton } from "./sharedUiParts";
-import { fieldSx, slate } from "./styleTokens";
+import { fieldSx, slate, statusCardSx, uiRadii } from "./styleTokens";
 
 function DeploymentList({ deployments, editing, onRemove, onUpdate, open }) {
   const { t } = useTranslation("status", { keyPrefix: "DeploymentsPanel" });
@@ -25,7 +25,7 @@ function DeploymentList({ deployments, editing, onRemove, onUpdate, open }) {
               sx={{
                 bgcolor: slate[50],
                 border: `1px solid ${slate[200]}`,
-                borderRadius: 4,
+                borderRadius: uiRadii.field,
                 p: 1.5,
               }}
             >
@@ -110,7 +110,7 @@ function DeploymentList({ deployments, editing, onRemove, onUpdate, open }) {
           <Box
             sx={{
               border: `1px dashed ${slate[300]}`,
-              borderRadius: 4,
+              borderRadius: uiRadii.field,
               color: slate[500],
               fontSize: 14,
               p: 2.5,
@@ -140,10 +140,7 @@ export function DeploymentsPanel({
   return (
     <Card
       sx={{
-        border: `1px solid ${slate[200]}`,
-        borderRadius: 6,
-        boxShadow: "none",
-        minWidth: 0,
+        ...statusCardSx,
       }}
     >
       <AccordionHeader

--- a/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
@@ -18,7 +18,7 @@ import { normalizeTags } from "../../../utils/SBOMManagement/sbomManagementUtils
 
 import { ServiceIdCopyButton } from "./ServiceIdCopyButton";
 import { AccordionHeader, AppButton, HeaderActionButton } from "./sharedUiParts";
-import { fieldSx, labelSx, slate } from "./styleTokens";
+import { fieldSx, floatingSurfaceSx, labelSx, slate, statusCardSx, uiRadii } from "./styleTokens";
 
 function SbomImage({ editing, imageUrl, onImageUpload, onRemoveImage, title }) {
   const { t } = useTranslation("status", { keyPrefix: "DetailsPanel" });
@@ -134,8 +134,8 @@ function SbomImage({ editing, imageUrl, onImageUpload, onRemoveImage, title }) {
           sx={{
             bgcolor: "white",
             border: `1px solid ${slate[200]}`,
-            borderRadius: 4,
-            boxShadow: "0 10px 15px rgba(15, 23, 42, 0.1)",
+            borderRadius: uiRadii.field,
+            ...floatingSurfaceSx,
             left: 12,
             p: 1.5,
             position: "absolute",
@@ -380,10 +380,7 @@ export function DetailsPanel({
   return (
     <Card
       sx={{
-        border: `1px solid ${slate[200]}`,
-        borderRadius: 6,
-        boxShadow: "none",
-        minWidth: 0,
+        ...statusCardSx,
         overflow: "hidden",
       }}
     >

--- a/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
@@ -5,26 +5,27 @@ import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 import { AppButton } from "./sharedUiParts";
-import { slate } from "./styleTokens";
+import {
+  slate,
+  statusCardSx,
+  surfaceShadowSx,
+  tabPanelSx,
+  uiRadii,
+  uiTransitions,
+} from "./styleTokens";
 
 export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel = true }) {
   const { t } = useTranslation("status", { keyPrefix: "NewSbomRegistrationPanel" });
   return (
     <Box
       sx={{
-        bgcolor: "white",
-        borderBottomLeftRadius: 24,
-        borderBottomRightRadius: 24,
-        borderTopRightRadius: 24,
-        boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
+        ...tabPanelSx,
         p: { sm: 4, xs: 2 },
       }}
     >
       <Card
         sx={{
-          border: `1px solid ${slate[200]}`,
-          borderRadius: 6,
-          boxShadow: "none",
+          ...statusCardSx,
           maxWidth: 768,
           mx: "auto",
           overflow: "hidden",
@@ -35,8 +36,8 @@ export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel =
             sx={{
               alignItems: "center",
               bgcolor: "white",
-              borderRadius: 6,
-              boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
+              borderRadius: uiRadii.statusCard,
+              ...surfaceShadowSx,
               display: "flex",
               height: 64,
               justifyContent: "center",
@@ -76,7 +77,7 @@ export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel =
                 alignItems: "center",
                 bgcolor: slate[50],
                 border: `1px dashed ${slate[300]}`,
-                borderRadius: 6,
+                borderRadius: uiRadii.statusCard,
                 cursor: "pointer",
                 display: "flex",
                 flexDirection: "column",
@@ -85,7 +86,7 @@ export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel =
                 px: 3,
                 py: 5,
                 textAlign: "center",
-                transition: "background-color 160ms ease, border-color 160ms ease",
+                transition: uiTransitions.borderOnly,
                 width: "100%",
               }}
               type="button"

--- a/web/src/pages/Status/SBOMManagement/RiskSettingsCard.jsx
+++ b/web/src/pages/Status/SBOMManagement/RiskSettingsCard.jsx
@@ -6,7 +6,14 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { HeaderActionButton } from "./sharedUiParts";
-import { labelSx, sectionTitleTextSx, slate } from "./styleTokens";
+import {
+  labelSx,
+  sectionTitleTextSx,
+  slate,
+  statusCardSx,
+  uiRadii,
+  uiTransitions,
+} from "./styleTokens";
 
 function ImpactOptionButton({ onSelect, option, selected }) {
   return (
@@ -23,7 +30,7 @@ function ImpactOptionButton({ onSelect, option, selected }) {
         bgcolor: selected ? "#eef6ff" : "white",
         border: "1px solid",
         borderColor: selected ? "#2563eb" : slate[200],
-        borderRadius: 4,
+        borderRadius: uiRadii.field,
         boxShadow: selected ? "0 1px 2px rgba(37, 99, 235, 0.14)" : "none",
         color: slate[800],
         cursor: "pointer",
@@ -33,7 +40,7 @@ function ImpactOptionButton({ onSelect, option, selected }) {
         minHeight: 104,
         p: 1.5,
         textAlign: "left",
-        transition: "background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease",
+        transition: uiTransitions.borderAndShadow,
         width: "100%",
       }}
       type="button"
@@ -59,7 +66,7 @@ function ImpactOptionButton({ onSelect, option, selected }) {
             alignItems: "center",
             bgcolor: selected ? "#2563eb" : slate[100],
             border: `1px solid ${selected ? "#2563eb" : slate[200]}`,
-            borderRadius: 999,
+            borderRadius: uiRadii.pill,
             color: selected ? "white" : "transparent",
             display: "flex",
             flexShrink: 0,
@@ -129,7 +136,7 @@ function ServiceImpactSummaryRow({ option, summaryLabel, title }) {
       sx={{
         bgcolor: slate[50],
         border: `1px solid ${slate[200]}`,
-        borderRadius: 4,
+        borderRadius: uiRadii.field,
         minWidth: 0,
         p: 1.5,
       }}
@@ -282,10 +289,7 @@ export function RiskSettingsCard({ onSave, sbom }) {
   return (
     <Card
       sx={{
-        border: `1px solid ${slate[200]}`,
-        borderRadius: 6,
-        boxShadow: "none",
-        minWidth: 0,
+        ...statusCardSx,
       }}
     >
       <CardContent sx={{ minWidth: 0, p: 2 }}>

--- a/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
+++ b/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
@@ -12,7 +12,7 @@ import { DetailsPanel } from "./DetailsPanel";
 import { NewSbomRegistrationPanel } from "./NewSbomRegistrationPanel";
 import { RiskSettingsCard } from "./RiskSettingsCard";
 import { TabButton } from "./sharedUiParts";
-import { slate } from "./styleTokens";
+import { slate, tabButtonSx, tabPanelSx, uiRadii } from "./styleTokens";
 import { useSBOMManagementController } from "./useSBOMManagementController";
 
 export function SBOMManagement({
@@ -87,9 +87,6 @@ export function SBOMManagement({
               border: "1px solid",
               borderColor: isCreatingSbom ? slate[200] : slate[300],
               borderStyle: isCreatingSbom ? "solid" : "dashed",
-              borderTopLeftRadius: 16,
-              borderTopRightRadius: 16,
-              boxShadow: isCreatingSbom ? "0 1px 2px rgba(15, 23, 42, 0.05)" : "none",
               color: isCreatingSbom ? slate[950] : slate[500],
               cursor: "pointer",
               display: "flex",
@@ -100,8 +97,8 @@ export function SBOMManagement({
               ml: 0.5,
               px: 2.5,
               py: 1.5,
-              transition: "background-color 160ms ease, color 160ms ease, border-color 160ms ease",
-              whiteSpace: "nowrap",
+              ...tabButtonSx,
+              boxShadow: isCreatingSbom ? tabButtonSx.boxShadow : "none",
             }}
             type="button"
           >
@@ -119,21 +116,15 @@ export function SBOMManagement({
         ) : isActiveServicePending ? (
           <Box
             sx={{
-              bgcolor: "white",
-              borderBottomLeftRadius: 24,
-              borderBottomRightRadius: 24,
-              borderTopRightRadius: 24,
-              boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
-              minWidth: 0,
+              ...tabPanelSx,
               p: { sm: 2.5, xs: 1.5 },
-              width: "100%",
             }}
           >
             <Box
               sx={{
                 alignItems: "center",
                 border: `1px solid ${slate[200]}`,
-                borderRadius: 6,
+                borderRadius: uiRadii.statusCard,
                 color: slate[500],
                 display: "flex",
                 fontSize: 14,
@@ -149,11 +140,7 @@ export function SBOMManagement({
         ) : (
           <Box
             sx={{
-              bgcolor: "white",
-              borderBottomLeftRadius: 24,
-              borderBottomRightRadius: 24,
-              borderTopRightRadius: 24,
-              boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
+              ...tabPanelSx,
               display: "grid",
               gap: 3,
               gridTemplateColumns: {
@@ -161,9 +148,7 @@ export function SBOMManagement({
                 xl: "minmax(320px, 0.75fr) minmax(0, 2.35fr)",
                 xs: "1fr",
               },
-              minWidth: 0,
               p: { sm: 2.5, xs: 1.5 },
-              width: "100%",
             }}
           >
             <Box sx={{ display: "flex", flexDirection: "column", gap: 1, minWidth: 0 }}>

--- a/web/src/pages/Status/SBOMManagement/sharedUiParts.jsx
+++ b/web/src/pages/Status/SBOMManagement/sharedUiParts.jsx
@@ -5,7 +5,15 @@ import { useTranslation } from "react-i18next";
 
 import { collapseSpaces } from "../../../utils/displayText";
 
-import { sectionIconBoxSx, sectionTitleTextSx, slate, textButtonSx } from "./styleTokens";
+import {
+  sectionIconBoxSx,
+  sectionTitleTextSx,
+  slate,
+  tabButtonSx,
+  textButtonSx,
+  uiRadii,
+  uiTransitions,
+} from "./styleTokens";
 
 export function CountBadge({ children }) {
   return (
@@ -14,7 +22,7 @@ export function CountBadge({ children }) {
       sx={{
         alignItems: "center",
         bgcolor: slate[100],
-        borderRadius: 999,
+        borderRadius: uiRadii.pill,
         color: slate[600],
         display: "inline-flex",
         flexShrink: 0,
@@ -44,7 +52,7 @@ export function HeaderActionButton({ active = false, children, icon: Icon, sx, .
         alignItems: "center",
         bgcolor: active ? slate[950] : "white",
         border: `1px solid ${active ? slate[950] : slate[300]}`,
-        borderRadius: 999,
+        borderRadius: uiRadii.pill,
         color: active ? "white" : slate[900],
         cursor: "pointer",
         display: "inline-flex",
@@ -104,9 +112,6 @@ export function TabButton({ active, onClick, sbom }) {
         backgroundColor: active ? "white" : slate[100],
         border: "1px solid",
         borderColor: active ? slate[200] : "transparent",
-        borderTopLeftRadius: 16,
-        borderTopRightRadius: 16,
-        boxShadow: active ? "0 1px 2px rgba(15, 23, 42, 0.05)" : "none",
         color: active ? slate[950] : slate[500],
         cursor: "pointer",
         font: "inherit",
@@ -114,8 +119,8 @@ export function TabButton({ active, onClick, sbom }) {
         fontWeight: 600,
         px: 2.5,
         py: 1.5,
-        transition: "background-color 160ms ease, color 160ms ease, border-color 160ms ease",
-        whiteSpace: "nowrap",
+        ...tabButtonSx,
+        boxShadow: active ? tabButtonSx.boxShadow : "none",
       }}
       type="button"
     >
@@ -174,7 +179,7 @@ export function AccordionHeader({ action, icon: Icon, onToggle, open, title }) {
             height: 22,
             ml: "auto",
             transform: open ? "rotate(180deg)" : "rotate(0deg)",
-            transition: "transform 160ms ease",
+            transition: uiTransitions.transform,
             width: 22,
           }}
         />

--- a/web/src/pages/Status/SBOMManagement/styleTokens.js
+++ b/web/src/pages/Status/SBOMManagement/styleTokens.js
@@ -1,22 +1,12 @@
-export const slate = {
-  50: "#f8fafc",
-  100: "#f1f5f9",
-  200: "#e2e8f0",
-  300: "#cbd5e1",
-  400: "#94a3b8",
-  500: "#64748b",
-  600: "#475569",
-  700: "#334155",
-  800: "#1e293b",
-  900: "#0f172a",
-  950: "#020617",
-};
+import { uiPalette, uiRadii, uiShadows, uiTransitions } from "../../../styles/designTokens";
+
+export const slate = uiPalette.slate;
 
 export const fieldSx = {
   "& .MuiOutlinedInput-root": {
     backgroundColor: "white",
-    borderRadius: 4,
-    boxShadow: "0 1px 2px rgba(15, 23, 42, 0.05)",
+    borderRadius: uiRadii.field,
+    boxShadow: uiShadows.xs,
     fontSize: 14,
   },
 };
@@ -32,7 +22,7 @@ export const labelSx = {
 export const textButtonSx = {
   "& .MuiButton-endIcon": { ml: 0.75 },
   "& .MuiButton-startIcon": { mr: 0.75 },
-  borderRadius: 3,
+  borderRadius: uiRadii.statusButton,
   fontWeight: 600,
   lineHeight: 1,
   textTransform: "none",
@@ -46,7 +36,7 @@ export const compactSelectSx = {
     minHeight: 0,
     py: 0,
   },
-  borderRadius: 3,
+  borderRadius: uiRadii.statusButton,
   color: slate[700],
   fontSize: 13,
   height: 32,
@@ -72,3 +62,38 @@ export const sectionTitleTextSx = {
   letterSpacing: 0,
   lineHeight: "20px",
 };
+
+export const statusCardSx = {
+  border: `1px solid ${slate[200]}`,
+  borderRadius: uiRadii.statusCard,
+  boxShadow: "none",
+  minWidth: 0,
+};
+
+export const tabButtonSx = {
+  borderTopLeftRadius: 16,
+  borderTopRightRadius: 16,
+  boxShadow: uiShadows.xs,
+  transition: uiTransitions.colorAndBorder,
+  whiteSpace: "nowrap",
+};
+
+export const tabPanelSx = {
+  bgcolor: "white",
+  borderBottomLeftRadius: 24,
+  borderBottomRightRadius: 24,
+  borderTopRightRadius: 24,
+  boxShadow: uiShadows.xs,
+  minWidth: 0,
+  width: "100%",
+};
+
+export const surfaceShadowSx = {
+  boxShadow: uiShadows.xs,
+};
+
+export const floatingSurfaceSx = {
+  boxShadow: uiShadows.floating,
+};
+
+export { uiRadii, uiShadows, uiTransitions };

--- a/web/src/styles/__tests__/designTokens.test.jsx
+++ b/web/src/styles/__tests__/designTokens.test.jsx
@@ -3,13 +3,13 @@ import { slate, statusCardSx, uiRadii } from "../../pages/Status/SBOMManagement/
 import { uiPalette, uiShadows } from "../designTokens";
 
 describe("designTokens", () => {
-  it("keeps Topbar color exports backed by shared tokens", () => {
+  it("keeps Topbar color exports aligned with shared token values", () => {
     expect(colors.ink900).toBe(uiPalette.gray[900]);
     expect(colors.slate200).toBe(uiPalette.slate[200]);
     expect(colors.brand700).toBe(uiPalette.brand[700]);
   });
 
-  it("keeps Status style exports backed by shared tokens", () => {
+  it("keeps Status style exports aligned with shared token values", () => {
     expect(slate).toBe(uiPalette.slate);
     expect(statusCardSx.borderRadius).toBe(uiRadii.statusCard);
     expect(uiShadows.xs).toBe("0 1px 2px rgba(15, 23, 42, 0.05)");

--- a/web/src/styles/__tests__/designTokens.test.jsx
+++ b/web/src/styles/__tests__/designTokens.test.jsx
@@ -1,0 +1,17 @@
+import { colors } from "../../pages/App/Topbar/topbarStyles";
+import { slate, statusCardSx, uiRadii } from "../../pages/Status/SBOMManagement/styleTokens";
+import { uiPalette, uiShadows } from "../designTokens";
+
+describe("designTokens", () => {
+  it("keeps Topbar color exports backed by shared tokens", () => {
+    expect(colors.ink900).toBe(uiPalette.gray[900]);
+    expect(colors.slate200).toBe(uiPalette.slate[200]);
+    expect(colors.brand700).toBe(uiPalette.brand[700]);
+  });
+
+  it("keeps Status style exports backed by shared tokens", () => {
+    expect(slate).toBe(uiPalette.slate);
+    expect(statusCardSx.borderRadius).toBe(uiRadii.statusCard);
+    expect(uiShadows.xs).toBe("0 1px 2px rgba(15, 23, 42, 0.05)");
+  });
+});

--- a/web/src/styles/designTokens.ts
+++ b/web/src/styles/designTokens.ts
@@ -1,0 +1,69 @@
+export const uiPalette = {
+  gray: {
+    400: "#9CA3AF",
+    500: "#6B7280",
+    700: "#374151",
+    900: "#111827",
+  },
+  slate: {
+    50: "#f8fafc",
+    100: "#f1f5f9",
+    200: "#e2e8f0",
+    300: "#cbd5e1",
+    400: "#94a3b8",
+    500: "#64748b",
+    600: "#475569",
+    700: "#334155",
+    800: "#1e293b",
+    900: "#0f172a",
+    950: "#020617",
+  },
+  brand: {
+    50: "#ECFDF5",
+    100: "#D1FAE5",
+    700: "#047857",
+  },
+  red: {
+    50: "#FEF2F2",
+    100: "#FEE2E2",
+    600: "#DC2626",
+  },
+  amber: {
+    50: "#FFFBEB",
+    100: "#FEF3C7",
+    700: "#B45309",
+  },
+  sky: {
+    50: "#F0F9FF",
+    100: "#E0F2FE",
+    700: "#0369A1",
+  },
+  violet: {
+    50: "#F5F3FF",
+    100: "#EDE9FE",
+    700: "#6D28D9",
+  },
+};
+
+export const uiRadii = {
+  topbarControl: "8px",
+  menuItem: 2,
+  popover: 3,
+  statusButton: 3,
+  field: 4,
+  statusCard: 6,
+  pill: 999,
+};
+
+export const uiShadows = {
+  xs: "0 1px 2px rgba(15, 23, 42, 0.05)",
+  topbarMenu: "0 18px 44px rgba(17, 24, 39, 0.14), 0 2px 8px rgba(17, 24, 39, 0.08)",
+  floating: "0 10px 15px rgba(15, 23, 42, 0.1)",
+};
+
+export const uiTransitions = {
+  colorAndBorder: "background-color 160ms ease, color 160ms ease, border-color 160ms ease",
+  borderAndShadow: "background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease",
+  borderOnly: "background-color 160ms ease, border-color 160ms ease",
+  transform: "transform 160ms ease",
+};


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- トップバー用のスタイル`topbarStyles.js` とStatusページ用のスタイル `styleTokens.js` で個別にハードコードされていた色・角丸・影・トランジション値が重複していたため、`web/src/styles/designTokens.ts` として共通トークンに切り出して統一する
  - 修正は共通化がメインで見た目はほぼ変わっていない。唯一変わったのが、Topbarの通常ボタンの影の色が rgba(17, 24, 39, 0.05) から rgba(15, 23, 42, 0.05) になった

## 経緯・意図・意思決定

主な変更内容：
- `designTokens.ts` に `uiPalette`・`uiRadii`・`uiShadows`・`uiTransitions` を定義
- `topbarStyles.js` と `styleTokens.js` がこれらを参照するよう更新
- `styleTokens.js` に `statusCardSx`・`tabPanelSx`・`surfaceShadowSx`・`floatingSurfaceSx` などのコンポーザブルな sx オブジェクトを追加し、各 SBOMManagement コンポーネントから重複したインライン sx を削除


<!-- I want to review in Japanese. -->