### PR TITLE
ユーザーメニューにサインイン中のメールアドレスを表示

### DIFF
--- a/web/src/pages/App/Topbar/Topbar.jsx
+++ b/web/src/pages/App/Topbar/Topbar.jsx
@@ -43,6 +43,7 @@ export function Topbar() {
         onSelectTeam={topbar.onSelectTeam}
         pageItems={topbar.pageItems}
         teamItems={topbar.teamItems}
+        userEmail={topbar.hasUserMe ? topbar.userMe.email : null}
       />
       {topbar.userMe ? (
         <AccountSettings

--- a/web/src/pages/App/Topbar/Topbar.stories.jsx
+++ b/web/src/pages/App/Topbar/Topbar.stories.jsx
@@ -50,6 +50,7 @@ function ThreatconnectomeTopbarMuiStory() {
     <TopbarView
       currentPage={pageItems[0]}
       currentTeam={teamItems[0]}
+      hasUserMe
       labels={labels}
       languageSwitcher={<LanguageSwitcher />}
       onCreateTeam={() => undefined}
@@ -60,6 +61,7 @@ function ThreatconnectomeTopbarMuiStory() {
       onSelectTeam={() => undefined}
       pageItems={pageItems}
       teamItems={teamItems}
+      userEmail="admin@threatconnectome.example"
     />
   );
 }

--- a/web/src/pages/App/Topbar/TopbarView.jsx
+++ b/web/src/pages/App/Topbar/TopbarView.jsx
@@ -29,6 +29,7 @@ export function TopbarView({
   onSelectTeam,
   pageItems,
   teamItems,
+  userEmail,
 }) {
   const { anchorEl, close, toggle, isOpen } = useTopbarMenu();
 
@@ -166,6 +167,7 @@ export function TopbarView({
         onClose={close}
         onLogout={onLogout}
         onOpenAccountSettings={onOpenAccountSettings}
+        userEmail={userEmail}
       />
     </>
   );
@@ -185,8 +187,10 @@ TopbarView.propTypes = {
   onSelectTeam: PropTypes.func.isRequired,
   pageItems: PropTypes.arrayOf(pageItemType).isRequired,
   teamItems: PropTypes.arrayOf(teamItemType).isRequired,
+  userEmail: PropTypes.string,
 };
 
 TopbarView.defaultProps = {
   currentTeam: null,
+  userEmail: null,
 };

--- a/web/src/pages/App/Topbar/UserMenu.jsx
+++ b/web/src/pages/App/Topbar/UserMenu.jsx
@@ -1,16 +1,18 @@
 import LogoutIcon from "@mui/icons-material/Logout";
 import SettingsIcon from "@mui/icons-material/Settings";
 import {
+  Box,
   Divider,
   ListItemIcon,
   ListItemText,
   Menu,
   MenuItem,
+  Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
 
-import { compactMenuItemSx, menuPaperSx, menuWidths } from "./topbarStyles";
+import { colors, compactMenuItemSx, ellipsisTextSx, menuPaperSx, menuWidths } from "./topbarStyles";
 
 export function UserMenu({
   accountSettingsEnabled,
@@ -20,9 +22,11 @@ export function UserMenu({
   onClose,
   onLogout,
   onOpenAccountSettings,
+  userEmail,
 }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const displayEmail = userEmail?.trim() || null;
   const mobileSlotProps = isMobile
     ? {
         list: { sx: { p: 0.75 } },
@@ -63,6 +67,32 @@ export function UserMenu({
       }}
       slotProps={mobileSlotProps}
     >
+      {displayEmail ? (
+        <>
+          <Box
+            role="presentation"
+            sx={{
+              px: isMobile ? 1.5 : 2,
+              py: isMobile ? 1.25 : 1.5,
+              maxWidth: isMobile ? menuWidths.default.xs : menuWidths.default.sm,
+            }}
+          >
+            <Typography
+              title={displayEmail}
+              sx={{
+                ...ellipsisTextSx,
+                color: colors.ink700,
+                fontSize: 14,
+                fontWeight: 600,
+                lineHeight: 1.35,
+              }}
+            >
+              {displayEmail}
+            </Typography>
+          </Box>
+          <Divider sx={isMobile ? { my: 0.75 } : undefined} />
+        </>
+      ) : null}
       <MenuItem
         disabled={!accountSettingsEnabled}
         onClick={handleAccountSettings}

--- a/web/src/pages/App/__tests__/Topbar.test.jsx
+++ b/web/src/pages/App/__tests__/Topbar.test.jsx
@@ -232,6 +232,18 @@ describe("Topbar", () => {
     expect(screen.queryByRole("menuitem", { name: "Create Team" })).not.toBeInTheDocument();
   });
 
+  it("shows the signed-in email at the top of the user menu", async () => {
+    const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+    renderTopbar();
+
+    expect(screen.queryByText(mockUserMe.email)).not.toBeInTheDocument();
+
+    await ue.click(screen.getAllByRole("button", { name: "User menu" })[0]);
+
+    expect(screen.getByText(mockUserMe.email)).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: mockUserMe.email })).not.toBeInTheDocument();
+  });
+
   it("opens account settings from the user menu", async () => {
     const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
     renderTopbar();


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- サインイン中のアカウントのメールアドレスをユーザーメニューの上部に表示できるようにする

## 経緯・意図・意思決定

`UserMenu` のメニュー上部にメールアドレス表示領域を追加した。長いアドレスはメニュー幅に合わせて省略表示（ellipsis）する。
マウスホバーでツールチップによりメールアドレス全文を表示。

<!-- I want to review in Japanese. -->