### PR TITLE
TopbarのUI更新に伴うE2EテストのセレクタエラーをFix

### DIFF
--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -37,9 +37,8 @@ def login(page: Page, user: dict):
     page.get_by_label("Password").fill(user["pass"])
     page.get_by_role("button", name="Log In with Email").click()
 
-    # Wait for the authenticated app shell to finish rendering.
-    # https://playwright.dev/python/docs/api/class-locator#locator-wait-for
-    page.get_by_role("button", name="Page menu").wait_for(timeout=10000)
+    # Wait for user data to load so the team selector is ready.
+    expect(page.get_by_role("button", name="Team menu")).to_be_enabled(timeout=10000)
 
 
 def test_login_first_time(page: Page):

--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -37,10 +37,9 @@ def login(page: Page, user: dict):
     page.get_by_label("Password").fill(user["pass"])
     page.get_by_role("button", name="Log In with Email").click()
 
-    # Wait login process finish and print menu button
+    # Wait for the authenticated app shell to finish rendering.
     # https://playwright.dev/python/docs/api/class-locator#locator-wait-for
-    drawer_status = page.locator("text=Status")
-    drawer_status.wait_for(timeout=10000)
+    page.get_by_role("button", name="Page menu").wait_for(timeout=10000)
 
 
 def test_login_first_time(page: Page):
@@ -110,7 +109,7 @@ def test_show_package_page(page: Page):
     print_console(page)
     login(page, USER1)
 
-    page.locator("#team-selector-button").click()
+    page.get_by_role("button", name="Team menu").click()
     page.get_by_role("menuitem", name=str(PTEAM1["pteam_name"])).click()
     # status page
     package_row = page.get_by_role("button").filter(has_text=str(PACKAGE1["package_name"]))


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- TopbarのUI更新により壊れたE2Eテストのセレクタを修正

## 経緯・意図・意思決定

Topbarコンポーネントのリファクタリング（#1323 等）によって、E2Eテスト内で参照していたセレクタが動作しなくなった。

具体的には以下の2箇所:

1. `login()` 関数内のログイン完了待機: `text=Status` (drawer要素) → `get_by_role("button", name="Page menu")` に変更
2. `test_show_package_page` 内のチームセレクタ: `#team-selector-button` (ID指定) → `get_by_role("button", name="Team menu")` に変更

## 実施したテスト項目

- ローカルでテスト実行
- 本ブランチ上でGitHubActionsからテスト実行


<!-- I want to review in Japanese. -->