### PR TITLE
Fix openapi-ts binary file type generation

### DIFF
--- a/web/openapi-ts.config.ts
+++ b/web/openapi-ts.config.ts
@@ -1,16 +1,16 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
-import { defineConfig } from '@hey-api/openapi-ts';
-import { normalizeBinarySchema } from './src/utils/openapi/normalizeBinarySchema';
+import { defineConfig } from "@hey-api/openapi-ts";
+import { normalizeBinarySchema } from "./src/utils/openapi/normalizeBinarySchema";
 
 const openApiDocument = JSON.parse(
-  readFileSync(fileURLToPath(new URL('./openapi.json', import.meta.url)), 'utf-8')
+  readFileSync(fileURLToPath(new URL("./openapi.json", import.meta.url)), "utf8"),
 ) as Record<string, unknown>;
 
 normalizeBinarySchema(openApiDocument);
 
 export default defineConfig({
   input: openApiDocument,
-  output: './types',
+  output: "./types",
 });

--- a/web/openapi-ts.config.ts
+++ b/web/openapi-ts.config.ts
@@ -1,6 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from '@hey-api/openapi-ts';
+import { normalizeBinarySchema } from './src/utils/openapi/normalizeBinarySchema';
+
+const openApiDocument = JSON.parse(
+  readFileSync(fileURLToPath(new URL('./openapi.json', import.meta.url)), 'utf-8')
+) as Record<string, unknown>;
+
+normalizeBinarySchema(openApiDocument);
 
 export default defineConfig({
-  input: './openapi.json',
+  input: openApiDocument,
   output: './types',
 });

--- a/web/src/utils/openapi/__tests__/normalizeBinarySchema.test.ts
+++ b/web/src/utils/openapi/__tests__/normalizeBinarySchema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeBinarySchema } from "../normalizeBinarySchema";
+
+describe("normalizeBinarySchema", () => {
+  it("converts contentMediaType application/octet-stream to format binary", () => {
+    const document = {
+      components: {
+        schemas: {
+          UploadRequest: {
+            type: "object",
+            properties: {
+              file: {
+                type: "string",
+                contentMediaType: "application/octet-stream",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    normalizeBinarySchema(document);
+
+    expect(document.components.schemas.UploadRequest.properties.file).toEqual({
+      type: "string",
+      contentMediaType: "application/octet-stream",
+      format: "binary",
+    });
+  });
+
+  it("does not overwrite existing format", () => {
+    const document = {
+      schema: {
+        type: "string",
+        contentMediaType: "application/octet-stream",
+        format: "date-time",
+      },
+    };
+
+    normalizeBinarySchema(document);
+
+    expect(document.schema.format).toBe("date-time");
+  });
+});

--- a/web/src/utils/openapi/normalizeBinarySchema.ts
+++ b/web/src/utils/openapi/normalizeBinarySchema.ts
@@ -1,0 +1,25 @@
+export const normalizeBinarySchema = (node: unknown): void => {
+  if (!node || typeof node !== "object") {
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    for (const value of node) {
+      normalizeBinarySchema(value);
+    }
+    return;
+  }
+
+  const record = node as Record<string, unknown>;
+  if (
+    record.type === "string" &&
+    record.contentMediaType === "application/octet-stream" &&
+    record.format === undefined
+  ) {
+    record.format = "binary";
+  }
+
+  for (const value of Object.values(record)) {
+    normalizeBinarySchema(value);
+  }
+};


### PR DESCRIPTION
## PR の目的

- バグ改修
  - multipart upload の OpenAPI 3.1 (`contentMediaType: application/octet-stream`) から生成される型が `string` になる問題のため、openapi-typescript 生成前に binary 正規化を実施

## 経緯・意図・意思決定

`npm run openapi:update` 後に自動生成される `web/types/types.gen.ts` において、fileの型である multipart upload 型が `Blob | File` から `string` に変更され、既存実装との型不整合が発生していました。

`web/openapi-ts.config.ts` で OpenAPI ドキュメントを読み込み、`type: "string"` かつ `contentMediaType: "application/octet-stream"` のスキーマに `format: "binary"` を補完してから生成する方式に変更しました。

## 実施したテスト項目
- `npm run openapi:update`を実行し、fileの型が`string` ではなく `Blob | File` になること

