### PR TITLE
protobufjs・ws の脆弱性対応: package-lock.json を更新

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3664,31 +3664,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -11051,24 +11044,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -13901,9 +13893,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -114,9 +114,5 @@
     "workerDirectory": [
       "public"
     ]
-  },
-  "overrides": {
-    "protobufjs": "^7.6.4",
-    "ws": "^8.21.0"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -116,7 +116,7 @@
     ]
   },
   "overrides": {
-    "protobufjs": "^7.6.1",
-    "ws": "^8.21.0"
+    "protobufjs": "7.6.4",
+    "ws": "8.21.0"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -114,5 +114,9 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "overrides": {
+    "protobufjs": "^7.6.1",
+    "ws": "^8.21.0"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -116,7 +116,7 @@
     ]
   },
   "overrides": {
-    "protobufjs": "7.6.4",
-    "ws": "8.21.0"
+    "protobufjs": "^7.6.4",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- CVE-2026-48712 (protobufjs) および CVE-2026-48779 (ws) に対応するため、`package-lock.json` を更新する。

## 経緯・意図・意思決定

https://github.com/nttcom/threatconnectome/pull/1325 において、CI で脆弱性エラーが発生したため、本 PR で対応する。

`npm update protobufjs ws` を実行し、`package-lock.json` のみを更新した。

| パッケージ | 更新前 | 更新後 | 対応 CVE |
|---|---|---|---|
| protobufjs | 7.5.8 | 7.6.4 | CVE-2026-48712 (fixed: 7.6.1+) |
| ws | 8.20.1 | 8.21.0 | CVE-2026-48779 (fixed: 8.21.0+) |

どちらも直接依存のバージョン範囲内に収まっているため、`package.json` の変更は不要。

## 実施したテスト項目

- `npm update` 後、`package-lock.json` 内のバージョンが修正済みバージョン以上であることを確認。

<!-- I want to review in Japanese. -->