### PR TITLE
fix(web): unify service/SBOM terminology in Status page UI labels

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -61,7 +61,7 @@
     "title": "Service Name",
     "titlePlaceholder": "e.g. Payment Service SBOM",
     "description": "Description",
-    "descriptionPlaceholder": "Enter the target system or purpose of this SBOM",
+    "descriptionPlaceholder": "Enter the target system or purpose of this service",
     "tags": "Tags",
     "tagsPlaceholder": "backend, prod, critical",
     "copyServiceId": "Copy service ID",

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -59,7 +59,7 @@
     "confirmRemoveImageTitle": "Remove image?",
     "confirmRemoveImageBody": "After removal it goes back to not set.",
     "title": "Service Name",
-    "titlePlaceholder": "e.g. Payment Service SBOM",
+    "titlePlaceholder": "e.g. Payment Service",
     "description": "Description",
     "descriptionPlaceholder": "Enter the target system or purpose of this service",
     "tags": "Tags",

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -107,10 +107,10 @@
     "confirmDelete": "Delete",
     "dangerZone": "Danger Zone",
     "dangerZoneDesc": "Delete the currently open service.",
-    "deleteSbomTitle": "Delete SBOM",
+    "deleteSbomTitle": "Delete service",
     "deleteTarget": "Target",
-    "enterSbomName": "Enter SBOM name",
-    "enterSbomNameHelp": "Type the SBOM name exactly to confirm deletion.",
+    "enterSbomName": "Enter service name",
+    "enterSbomNameHelp": "Type the service name exactly to confirm deletion.",
     "openDeleteDialog": "Open delete dialog",
     "untitledSbom": "Untitled SBOM"
   },

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -58,7 +58,7 @@
     "deleteImage": "Delete image",
     "confirmRemoveImageTitle": "Remove image?",
     "confirmRemoveImageBody": "After removal it goes back to not set.",
-    "title": "Title",
+    "title": "Service Name",
     "titlePlaceholder": "e.g. Payment Service SBOM",
     "description": "Description",
     "descriptionPlaceholder": "Enter the target system or purpose of this SBOM",

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -70,7 +70,7 @@
     "tooLongKeyword": "Too long keyword. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width",
     "tooLongServiceName": "Too long service name. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width",
     "tooManyKeywords": "Too many tags. Max count is {{max}}.",
-    "untitledSbom": "Untitled SBOM",
+    "untitledSbom": "Untitled service",
     "details": "Details"
   },
   "DeploymentsPanel": {
@@ -112,7 +112,7 @@
     "enterSbomName": "Enter service name",
     "enterSbomNameHelp": "Type the service name exactly to confirm deletion.",
     "openDeleteDialog": "Open delete dialog",
-    "untitledSbom": "Untitled SBOM"
+    "untitledSbom": "Untitled service"
   },
   "NewSbomRegistrationPanel": {
     "cancel": "Cancel",
@@ -153,12 +153,12 @@
     "systemExposureTitle": "System Exposure"
   },
   "sharedUiParts": {
-    "untitledSbom": "Untitled SBOM"
+    "untitledSbom": "Untitled service"
   },
   "useSBOMManagementMutations": {
     "confirmRemoveDeployment": "Delete this deployment. Are you sure?",
     "deleteFailed": "Delete failed: {{error}}",
-    "deleteSuccess": "SBOM deleted",
+    "deleteSuccess": "Service deleted",
     "imageProcessFailed": "Failed to process image",
     "imageTooLarge": "Image is too large",
     "imageTooLargeAfterConvert": "Image size after conversion exceeds the limit",

--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -106,7 +106,7 @@
     "close": "Close",
     "confirmDelete": "Delete",
     "dangerZone": "Danger Zone",
-    "dangerZoneDesc": "Delete the currently open SBOM tab.",
+    "dangerZoneDesc": "Delete the currently open service.",
     "deleteSbomTitle": "Delete SBOM",
     "deleteTarget": "Target",
     "enterSbomName": "Enter SBOM name",

--- a/web/public/locales/ja/eol.json
+++ b/web/public/locales/ja/eol.json
@@ -2,7 +2,7 @@
     "EolTable": {
         "status": "サポート状況",
         "productVersion": "製品名 / バージョン",
-        "service": "サービス名",
+        "service": "サービス",
         "category": "区分",
         "eolDate": "サポート終了日"
     },

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -64,7 +64,7 @@
     "serviceNameRequired": "サービス名は空にできません。",
     "tags": "タグ",
     "tagsPlaceholder": "backend, prod, critical",
-    "title": "タイトル",
+    "title": "サービス名",
     "titlePlaceholder": "例: Payment Service SBOM",
     "tooLongDescription": "説明が長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",
     "tooLongKeyword": "キーワードが長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -50,7 +50,7 @@
     "delete": "削除",
     "deleteImage": "画像を削除",
     "description": "説明文",
-    "descriptionPlaceholder": "SBOMの対象システムや用途を入力",
+    "descriptionPlaceholder": "サービスの対象システムや用途を入力",
     "details": "詳細情報",
     "copyServiceId": "サービスIDをコピー",
     "copySuccess": "コピーしました！",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -107,10 +107,10 @@
     "confirmDelete": "削除する",
     "dangerZone": "危険操作",
     "dangerZoneDesc": "現在開いているサービスを削除します。",
-    "deleteSbomTitle": "SBOMを削除",
+    "deleteSbomTitle": "サービスを削除",
     "deleteTarget": "削除対象",
-    "enterSbomName": "SBOM名を入力",
-    "enterSbomNameHelp": "削除対象のSBOM名を完全一致で入力してください。",
+    "enterSbomName": "サービス名を入力",
+    "enterSbomNameHelp": "削除対象のサービス名を完全一致で入力してください。",
     "openDeleteDialog": "削除ダイアログを開く",
     "untitledSbom": "Untitled SBOM"
   },

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -65,7 +65,7 @@
     "tags": "タグ",
     "tagsPlaceholder": "backend, prod, critical",
     "title": "サービス名",
-    "titlePlaceholder": "例: Payment Service SBOM",
+    "titlePlaceholder": "例: Payment Service",
     "tooLongDescription": "説明が長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",
     "tooLongKeyword": "キーワードが長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",
     "tooLongServiceName": "サービス名が長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -106,7 +106,7 @@
     "close": "閉じる",
     "confirmDelete": "削除する",
     "dangerZone": "危険操作",
-    "dangerZoneDesc": "現在開いているSBOMタブを削除します。",
+    "dangerZoneDesc": "現在開いているサービスを削除します。",
     "deleteSbomTitle": "SBOMを削除",
     "deleteTarget": "削除対象",
     "enterSbomName": "SBOM名を入力",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -70,7 +70,7 @@
     "tooLongKeyword": "キーワードが長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",
     "tooLongServiceName": "サービス名が長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。",
     "tooManyKeywords": "タグは最大{{max}}個までです。",
-    "untitledSbom": "Untitled SBOM",
+    "untitledSbom": "名称未設定のサービス",
     "uploadImage": "画像をアップロード"
   },
   "DeploymentsPanel": {
@@ -112,7 +112,7 @@
     "enterSbomName": "サービス名を入力",
     "enterSbomNameHelp": "削除対象のサービス名を完全一致で入力してください。",
     "openDeleteDialog": "削除ダイアログを開く",
-    "untitledSbom": "Untitled SBOM"
+    "untitledSbom": "名称未設定のサービス"
   },
   "NewSbomRegistrationPanel": {
     "cancel": "キャンセル",
@@ -153,12 +153,12 @@
     "systemExposureTitle": "System Exposure"
   },
   "sharedUiParts": {
-    "untitledSbom": "Untitled SBOM"
+    "untitledSbom": "名称未設定のサービス"
   },
   "useSBOMManagementMutations": {
     "confirmRemoveDeployment": "このデプロイ先を削除します。よろしいですか？",
     "deleteFailed": "削除に失敗しました: {{error}}",
-    "deleteSuccess": "SBOMを削除しました",
+    "deleteSuccess": "サービスを削除しました",
     "imageProcessFailed": "画像の処理に失敗しました",
     "imageTooLarge": "画像サイズが大きすぎます",
     "imageTooLargeAfterConvert": "変換後の画像サイズが上限を超えました",

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -493,7 +493,7 @@ describe("StatusPage", () => {
       renderStatusPage();
 
       await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
-      fireEvent.change(screen.getByPlaceholderText("e.g. Payment Service SBOM"), {
+      fireEvent.change(screen.getByPlaceholderText("e.g. Payment Service"), {
         target: { value: "unsaved service title" },
       });
 
@@ -655,7 +655,7 @@ describe("StatusPage", () => {
       renderStatusPage();
 
       await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
-      const titleInput = screen.getByPlaceholderText("e.g. Payment Service SBOM");
+      const titleInput = screen.getByPlaceholderText("e.g. Payment Service");
       fireEvent.change(titleInput, { target: { value: "Updated service name" } });
 
       await ue.click(screen.getByRole("button", { name: "Done" }));
@@ -698,7 +698,7 @@ describe("StatusPage", () => {
       renderStatusPage();
 
       await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
-      const titleInput = screen.getByPlaceholderText("e.g. Payment Service SBOM");
+      const titleInput = screen.getByPlaceholderText("e.g. Payment Service");
       fireEvent.change(titleInput, { target: { value: "   " } });
 
       expect(screen.getByRole("button", { name: "Done" })).toBeDisabled();
@@ -752,7 +752,7 @@ describe("StatusPage", () => {
 
       await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
 
-      const titleInput = screen.getByPlaceholderText("e.g. Payment Service SBOM");
+      const titleInput = screen.getByPlaceholderText("e.g. Payment Service");
       fireEvent.change(titleInput, { target: { value: "Payment Service SBOM V2" } });
 
       const descriptionInput = screen.getByPlaceholderText(
@@ -1005,7 +1005,7 @@ describe("StatusPage", () => {
 
       await ue.click(screen.getAllByRole("button", { name: "Edit" })[0]);
 
-      const titleInput = screen.getByPlaceholderText("e.g. Payment Service SBOM");
+      const titleInput = screen.getByPlaceholderText("e.g. Payment Service");
       const validServiceName = "a".repeat(255);
       fireEvent.change(titleInput, { target: { value: validServiceName } });
       expect(titleInput).toHaveValue(validServiceName);

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -756,7 +756,7 @@ describe("StatusPage", () => {
       fireEvent.change(titleInput, { target: { value: "Payment Service SBOM V2" } });
 
       const descriptionInput = screen.getByPlaceholderText(
-        "Enter the target system or purpose of this SBOM",
+        "Enter the target system or purpose of this service",
       );
       fireEvent.change(descriptionInput, {
         target: { value: "Updated service description" },
@@ -1013,7 +1013,7 @@ describe("StatusPage", () => {
       expect(titleInput).toHaveValue(validServiceName);
 
       const descriptionInput = screen.getByPlaceholderText(
-        "Enter the target system or purpose of this SBOM",
+        "Enter the target system or purpose of this service",
       );
       const validDescription = "b".repeat(300);
       fireEvent.change(descriptionInput, { target: { value: validDescription } });

--- a/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
+++ b/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
@@ -4,6 +4,7 @@ import {
   buildCurrentServiceFromPTeam,
   buildDependencyRows,
   buildServiceTabsFromPTeam,
+  isDeleteConfirmationValid,
 } from "../sbomManagementUtils";
 
 const services = [
@@ -94,5 +95,27 @@ describe("sbomManagementUtils", () => {
         ssvcPriority: "no_known_vulnerability",
       },
     ]);
+  });
+});
+
+describe("isDeleteConfirmationValid", () => {
+  it("returns true when input matches title exactly", () => {
+    expect(isDeleteConfirmationValid("My Service", "My Service")).toBe(true);
+  });
+
+  it("returns false when input does not match title", () => {
+    expect(isDeleteConfirmationValid("Other Service", "My Service")).toBe(false);
+  });
+
+  it("trims leading and trailing whitespace from input", () => {
+    expect(isDeleteConfirmationValid("  My Service  ", "My Service")).toBe(true);
+  });
+
+  it("returns false when input is empty", () => {
+    expect(isDeleteConfirmationValid("", "My Service")).toBe(false);
+  });
+
+  it("returns false when input is only whitespace", () => {
+    expect(isDeleteConfirmationValid("   ", "My Service")).toBe(false);
   });
 });

--- a/web/src/utils/SBOMManagement/sbomManagementUtils.js
+++ b/web/src/utils/SBOMManagement/sbomManagementUtils.js
@@ -27,7 +27,7 @@ export function getNextActiveIdAfterRemoval(items, removedId) {
 }
 
 export function isDeleteConfirmationValid(input, title) {
-  return input.trim() === (title || "Untitled SBOM");
+  return input.trim() === title;
 }
 
 export function buildServiceTabsFromPTeam(services) {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- StatusページのDetailsPanel・DangerZoneにおいて、UIラベルの表記を「SBOM」から「サービス」に統一する。

## 経緯・意図・意思決定

DetailsPanel のタイトルフィールドラベルが「タイトル」となっていたが、バリデーションメッセージは「サービス名は空にできません。」のまま残っており、表記が不統一だった。

あわせて DangerZone にも「SBOMタブを削除」「SBOM名を入力」など SBOM 寄りの表現が残っていたため、ユーザー向けの表記を「サービス」に統一した。

変更は翻訳ファイル（`web/public/locales/`）の値のみで、JSX コードの変更はなし。

### 変更箇所

**DetailsPanel（ja/en）**
- `title`: `タイトル` → `サービス名` / `Title` → `Service Name`

**DangerZone（ja/en）**
- `dangerZoneDesc`: `現在開いているSBOMタブを削除します。` → `現在開いているサービスを削除します。` / `Delete the currently open SBOM tab.` → `Delete the currently open service.`
- `deleteSbomTitle`: `SBOMを削除` → `サービスを削除` / `Delete SBOM` → `Delete service`
- `enterSbomName`: `SBOM名を入力` → `サービス名を入力` / `Enter SBOM name` → `Enter service name`
- `enterSbomNameHelp`: `削除対象のSBOM名を完全一致で入力してください。` → `削除対象のサービス名を完全一致で入力してください。` / `Type the SBOM name exactly to confirm deletion.` → `Type the service name exactly to confirm deletion.`

## 実施したテスト項目

- `npm run check`（ESLint / Prettier / TypeScript）: パス
- `StatusPage.test.jsx` 23件: パス

## 参考文献

<!-- I want to review in Japanese. -->