### PR TITLE
feat(web): add drag-and-drop support to SBOM upload panel and dialog

### DIFF
--- a/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
@@ -2,10 +2,9 @@
 import DescriptionIcon from "@mui/icons-material/Description";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
-import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { validateSbomFileSelection } from "../SbomDrop/sbomFileValidation";
+import { useSbomFileDrop } from "../SbomDrop/useSbomFileDrop";
 
 import { AppButton } from "./sharedUiParts";
 import {
@@ -26,40 +25,11 @@ export function NewSbomRegistrationPanel({
   const { t } = useTranslation("status", { keyPrefix: "NewSbomRegistrationPanel" });
   const { t: tFileDropZone } = useTranslation("status", { keyPrefix: "FileDropZone" });
 
-  const dragCounterRef = useRef(0);
-  const [isDragOver, setIsDragOver] = useState(false);
-
-  const handleDragEnter = (event) => {
-    event.preventDefault();
-    dragCounterRef.current++;
-    setIsDragOver(true);
-  };
-
-  const handleDragOver = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  const handleDragLeave = () => {
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragOver(false);
-  };
-
-  const handleDrop = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    dragCounterRef.current = 0;
-    setIsDragOver(false);
-
-    const result = validateSbomFileSelection(event.dataTransfer.files);
-    if (result.error) {
-      alert(tFileDropZone(result.error));
-      return;
-    }
-    if (result.file) {
-      onDropFile?.(result.file);
-    }
-  };
+  const { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } =
+    useSbomFileDrop({
+      onFile: (file) => onDropFile?.(file),
+      onError: (key) => alert(tFileDropZone(key)),
+    });
 
   return (
     <Box

--- a/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
@@ -2,7 +2,10 @@
 import DescriptionIcon from "@mui/icons-material/Description";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import { validateSbomFileSelection } from "../SbomDrop/sbomFileValidation";
 
 import { AppButton } from "./sharedUiParts";
 import {
@@ -14,8 +17,50 @@ import {
   uiTransitions,
 } from "./styleTokens";
 
-export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel = true }) {
+export function NewSbomRegistrationPanel({
+  onCancel,
+  onDropFile,
+  onUploadClick,
+  showCancel = true,
+}) {
   const { t } = useTranslation("status", { keyPrefix: "NewSbomRegistrationPanel" });
+  const { t: tFileDropZone } = useTranslation("status", { keyPrefix: "FileDropZone" });
+
+  const dragCounterRef = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDragEnter = (event) => {
+    event.preventDefault();
+    dragCounterRef.current++;
+    setIsDragOver(true);
+  };
+
+  const handleDragOver = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleDragLeave = () => {
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragOver(false);
+  };
+
+  const handleDrop = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+
+    const result = validateSbomFileSelection(event.dataTransfer.files);
+    if (result.error) {
+      alert(tFileDropZone(result.error));
+      return;
+    }
+    if (result.file) {
+      onDropFile?.(result.file);
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -24,11 +69,17 @@ export function NewSbomRegistrationPanel({ onCancel, onUploadClick, showCancel =
       }}
     >
       <Card
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
         sx={{
           ...statusCardSx,
+          borderColor: isDragOver ? slate[400] : slate[200],
           maxWidth: 768,
           mx: "auto",
           overflow: "hidden",
+          transition: uiTransitions.borderOnly,
         }}
       >
         <Box sx={{ bgcolor: slate[50], px: { sm: 5, xs: 3 }, py: 5, textAlign: "center" }}>

--- a/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
+++ b/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
@@ -110,6 +110,7 @@ export function SBOMManagement({
         {isCreatingSbom ? (
           <NewSbomRegistrationPanel
             onCancel={newSbom.onCancel}
+            onDropFile={pendingUpload.onCreateWithFile}
             onUploadClick={newSbom.onUploadClick}
             showCancel={!isEmpty}
           />
@@ -216,6 +217,7 @@ export function SBOMManagement({
         )}
       </Box>
       <SBOMUpdateDialog
+        initialFile={pendingUpload.value?.initialFile}
         open={!!pendingUpload.value}
         onClose={pendingUpload.onClose}
         pteamId={pteamId}

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
@@ -100,6 +100,7 @@ export function useSBOMManagementController({
         ? undefined
         : state.serviceTabs.map((service) => service.title),
       onClose: () => state.setPendingUpload(null),
+      onCreateWithFile: (file) => state.setPendingUpload({ initialFile: file }),
       onUploaded: () => state.setPendingUpload(null),
       value: state.pendingUpload,
     },

--- a/web/src/pages/Status/SbomDrop/FileDropZone.tsx
+++ b/web/src/pages/Status/SbomDrop/FileDropZone.tsx
@@ -1,11 +1,12 @@
 import { UploadFile as UploadFileIcon } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import { uiPalette, uiTransitions } from "../../../styles/designTokens";
 
 import { validateSbomFileSelection } from "./sbomFileValidation";
+import { useSbomFileDrop } from "./useSbomFileDrop";
 
 type FileDropZoneProps = {
   onFileSelected: (file: File) => void;
@@ -21,10 +22,14 @@ export function FileDropZone({
   const { t } = useTranslation("status", { keyPrefix: "FileDropZone" });
   const dropRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const dragCounterRef = useRef(0);
-  const [isDragOver, setIsDragOver] = useState(false);
 
-  const validateAndSetFile = (files: FileList | null) => {
+  const { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } =
+    useSbomFileDrop({
+      onFile: onFileSelected,
+      onError: (key) => alert(t(key)),
+    });
+
+  const handleFileInputChange = (files: FileList | null) => {
     const result = validateSbomFileSelection(files);
     if (result.error) {
       alert(t(result.error));
@@ -35,36 +40,12 @@ export function FileDropZone({
     }
   };
 
-  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    dragCounterRef.current++;
-    setIsDragOver(true);
-  };
-
-  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  const handleDragLeave = () => {
-    dragCounterRef.current--;
-    if (dragCounterRef.current === 0) setIsDragOver(false);
-  };
-
-  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    dragCounterRef.current = 0;
-    setIsDragOver(false);
-    validateAndSetFile(event.dataTransfer.files);
-  };
-
   const handleClick = () => {
     fileInputRef.current?.click();
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    validateAndSetFile(event.target.files);
+    handleFileInputChange(event.target.files);
     event.target.value = "";
   };
 

--- a/web/src/pages/Status/SbomDrop/FileDropZone.tsx
+++ b/web/src/pages/Status/SbomDrop/FileDropZone.tsx
@@ -1,7 +1,11 @@
 import { UploadFile as UploadFileIcon } from "@mui/icons-material";
 import { Box, Typography } from "@mui/material";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+
+import { uiPalette, uiTransitions } from "../../../styles/designTokens";
+
+import { validateSbomFileSelection } from "./sbomFileValidation";
 
 type FileDropZoneProps = {
   onFileSelected: (file: File) => void;
@@ -17,19 +21,24 @@ export function FileDropZone({
   const { t } = useTranslation("status", { keyPrefix: "FileDropZone" });
   const dropRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCounterRef = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   const validateAndSetFile = (files: FileList | null) => {
-    if (!files || !files.length) return;
+    const result = validateSbomFileSelection(files);
+    if (result.error) {
+      alert(t(result.error));
+      return;
+    }
+    if (result.file) {
+      onFileSelected(result.file);
+    }
+  };
 
-    if (files.length > 1) {
-      alert(t("alertOnlyOneFile"));
-      return;
-    }
-    if (!files[0].name.endsWith(".json")) {
-      alert(t("alertOnlyJson"));
-      return;
-    }
-    onFileSelected(files[0]);
+  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragCounterRef.current++;
+    setIsDragOver(true);
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -37,9 +46,16 @@ export function FileDropZone({
     event.stopPropagation();
   };
 
+  const handleDragLeave = () => {
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) setIsDragOver(false);
+  };
+
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
     validateAndSetFile(event.dataTransfer.files);
   };
 
@@ -55,6 +71,8 @@ export function FileDropZone({
   return (
     <Box
       ref={dropRef}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       onClick={handleClick}
@@ -65,8 +83,12 @@ export function FileDropZone({
         flexDirection: "column",
         width: "100%",
         minHeight: "300px",
-        border: "4px dotted #888",
+        border: isDragOver
+          ? `4px dashed ${uiPalette.slate[600]}`
+          : `4px dotted ${uiPalette.slate[400]}`,
+        bgcolor: isDragOver ? uiPalette.slate[50] : "transparent",
         cursor: "pointer",
+        transition: uiTransitions.borderOnly,
       }}
     >
       <input

--- a/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
+++ b/web/src/pages/Status/SbomDrop/SBOMUpdateDialog.tsx
@@ -31,6 +31,7 @@ type Props = {
   onUploaded?: () => void;
   existingServiceNames?: string[];
   showWarning?: boolean;
+  initialFile?: File | null;
 };
 
 export function SBOMUpdateDialog({
@@ -41,6 +42,7 @@ export function SBOMUpdateDialog({
   onUploaded,
   existingServiceNames,
   showWarning = true,
+  initialFile = null,
 }: Props) {
   const { t } = useTranslation("status", { keyPrefix: "SBOMUpdateDialog" });
   const { enqueueSnackbar } = useSnackbar();
@@ -59,10 +61,10 @@ export function SBOMUpdateDialog({
 
   useEffect(() => {
     if (open) {
-      setSbomFile(null);
+      setSbomFile(initialFile);
       setServiceNameInput("");
     }
-  }, [open]);
+  }, [initialFile, open]);
 
   const [uploadSBOMFile] = useUploadSBOMFileMutation();
 

--- a/web/src/pages/Status/SbomDrop/__tests__/sbomFileValidation.test.ts
+++ b/web/src/pages/Status/SbomDrop/__tests__/sbomFileValidation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { validateSbomFileSelection } from "../sbomFileValidation";
+
+describe("validateSbomFileSelection", () => {
+  it("returns { file: null, error: null } when files is null", () => {
+    expect(validateSbomFileSelection(null)).toEqual({ file: null, error: null });
+  });
+
+  it("returns { file: null, error: null } when files is an empty array", () => {
+    expect(validateSbomFileSelection([])).toEqual({ file: null, error: null });
+  });
+
+  it("returns alertOnlyOneFile error when multiple files are given", () => {
+    const files = [
+      new File(["{}"], "a.json", { type: "application/json" }),
+      new File(["{}"], "b.json", { type: "application/json" }),
+    ];
+    expect(validateSbomFileSelection(files)).toEqual({ file: null, error: "alertOnlyOneFile" });
+  });
+
+  it("returns alertOnlyJson error when the file does not have a .json extension", () => {
+    const files = [new File(["text"], "sbom.txt", { type: "text/plain" })];
+    expect(validateSbomFileSelection(files)).toEqual({ file: null, error: "alertOnlyJson" });
+  });
+
+  it("returns the file when a single .json file is given", () => {
+    const file = new File(["{}"], "sbom.json", { type: "application/json" });
+    expect(validateSbomFileSelection([file])).toEqual({ file, error: null });
+  });
+});

--- a/web/src/pages/Status/SbomDrop/sbomFileValidation.ts
+++ b/web/src/pages/Status/SbomDrop/sbomFileValidation.ts
@@ -1,0 +1,14 @@
+export type SbomFileValidationError = "alertOnlyOneFile" | "alertOnlyJson";
+
+type SbomFileValidationResult =
+  | { file: File; error: null }
+  | { file: null; error: SbomFileValidationError | null };
+
+export function validateSbomFileSelection(
+  files: FileList | File[] | null,
+): SbomFileValidationResult {
+  if (!files || !files.length) return { file: null, error: null };
+  if (files.length > 1) return { file: null, error: "alertOnlyOneFile" };
+  if (!files[0].name.endsWith(".json")) return { file: null, error: "alertOnlyJson" };
+  return { file: files[0], error: null };
+}

--- a/web/src/pages/Status/SbomDrop/useSbomFileDrop.ts
+++ b/web/src/pages/Status/SbomDrop/useSbomFileDrop.ts
@@ -1,0 +1,40 @@
+import { useRef, useState } from "react";
+
+import { validateSbomFileSelection } from "./sbomFileValidation";
+
+type UseSbomFileDropOptions = {
+  onFile: (file: File) => void;
+  onError: (errorKey: string) => void;
+};
+
+export function useSbomFileDrop({ onFile, onError }: UseSbomFileDropOptions) {
+  const dragCounterRef = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDragEnter = (event: React.DragEvent) => {
+    event.preventDefault();
+    dragCounterRef.current++;
+    setIsDragOver(true);
+  };
+
+  const handleDragOver = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleDragLeave = () => {
+    if (--dragCounterRef.current === 0) setIsDragOver(false);
+  };
+
+  const handleDrop = (event: React.DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+    const result = validateSbomFileSelection(event.dataTransfer.files);
+    if (result.error) onError(result.error);
+    else if (result.file) onFile(result.file);
+  };
+
+  return { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop };
+}

--- a/web/src/pages/Status/SbomDrop/useSbomFileDrop.ts
+++ b/web/src/pages/Status/SbomDrop/useSbomFileDrop.ts
@@ -23,7 +23,8 @@ export function useSbomFileDrop({ onFile, onError }: UseSbomFileDropOptions) {
   };
 
   const handleDragLeave = () => {
-    if (--dragCounterRef.current === 0) setIsDragOver(false);
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+    if (dragCounterRef.current === 0) setIsDragOver(false);
   };
 
   const handleDrop = (event: React.DragEvent) => {

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -945,6 +945,123 @@ describe("StatusPage", () => {
       ).toBeInTheDocument();
     });
 
+    it("opens upload dialog with dropped file when a json is dropped on the upload box in new SBOM panel", async () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      const ue = userEvent.setup();
+      renderStatusPage();
+
+      await ue.click(screen.getByRole("button", { name: "New" }));
+      expect(screen.getByText("Register a new SBOM")).toBeInTheDocument();
+
+      const uploadBox = screen.getByText("Upload an SBOM").closest("button");
+      const file = new File(["{}"], "sbom.json", { type: "application/json" });
+      fireEvent.drop(uploadBox, { dataTransfer: { files: [file] } });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("Upload SBOM")).toBeInTheDocument();
+      expect(screen.getByText("sbom.json")).toBeInTheDocument();
+    });
+
+    it("shows alert and does not open dialog when a non-json is dropped on the upload box in new SBOM panel", async () => {
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      const ue = userEvent.setup();
+      renderStatusPage();
+
+      await ue.click(screen.getByRole("button", { name: "New" }));
+
+      const uploadBox = screen.getByText("Upload an SBOM").closest("button");
+      fireEvent.drop(uploadBox, {
+        dataTransfer: { files: [new File(["text"], "sbom.txt", { type: "text/plain" })] },
+      });
+
+      expect(alertSpy).toHaveBeenCalledWith("Only *.json is supported");
+      expect(screen.queryByRole("dialog")).toBeNull();
+      alertSpy.mockRestore();
+    });
+
+    it("shows alert and does not open dialog when multiple files are dropped on the upload box in new SBOM panel", async () => {
+      const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      useGetPTeamQuery.mockReturnValue({
+        data: testPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      });
+      useGetPTeamPackagesSummaryQuery.mockReturnValue({
+        currentData: testPackagesData,
+        error: false,
+        isFetching: false,
+      });
+
+      const ue = userEvent.setup();
+      renderStatusPage();
+
+      await ue.click(screen.getByRole("button", { name: "New" }));
+
+      const uploadBox = screen.getByText("Upload an SBOM").closest("button");
+      fireEvent.drop(uploadBox, {
+        dataTransfer: {
+          files: [
+            new File(["{}"], "first.json", { type: "application/json" }),
+            new File(["{}"], "second.json", { type: "application/json" }),
+          ],
+        },
+      });
+
+      expect(alertSpy).toHaveBeenCalledWith("Please select only 1 file");
+      expect(screen.queryByRole("dialog")).toBeNull();
+      alertSpy.mockRestore();
+    });
+
     it("show SBOM upload progress button when the service is registered", async () => {
       const testLocation = {
         pathname: "/",


### PR DESCRIPTION
## Summary

SBOMアップロードパネル（`NewSbomRegistrationPanel`）にドラッグ&ドロップ対応を追加し、関連コードをリファクタリングしました。

### 変更内容

**feat: ドラッグ&ドロップ対応**
- `NewSbomRegistrationPanel` の Card 全体をドロップターゲットとして機能させ、JSONファイルをドラッグ&ドロップするとアップロードダイアログが開き、ファイルが事前にセットされた状態で表示される
- `FileDropZone` にもドラッグ中のビジュアルフィードバック（border スタイル変更・背景色変化）を追加
- `SBOMUpdateDialog` に `initialFile` prop を追加し、ダイアログを開いた際にファイルを事前セット可能にした
- ファイルバリデーションロジックを `sbomFileValidation.ts` に切り出して共有化

**refactor: ドラッグ&ドロップロジックの共通化**
- `dragCounterRef + isDragOver + handleDragEnter/Over/Leave/Drop` が `NewSbomRegistrationPanel` と `FileDropZone` に重複していたため、`useSbomFileDrop` カスタムフックとして抽出

### 新規ファイル

| ファイル | 概要 |
|---|---|
| `SbomDrop/sbomFileValidation.ts` | ファイル選択バリデーションユーティリティ |
| `SbomDrop/useSbomFileDrop.ts` | ドラッグ&ドロップカスタムフック |
| `SbomDrop/__tests__/sbomFileValidation.test.ts` | `validateSbomFileSelection` の単体テスト（5件） |

### テスト

- `StatusPage.test.jsx` に統合テスト3件追加（正常ドロップ・非JSONエラー・複数ファイルエラー）
- `sbomFileValidation.test.ts` に単体テスト5件追加
