### PR TITLE
fix(web): 新規SBOMクリック時にファイルピッカーを先に開くよう修正

### DIFF
--- a/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/NewSbomRegistrationPanel.jsx
@@ -2,8 +2,10 @@
 import DescriptionIcon from "@mui/icons-material/Description";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import { validateSbomFileSelection } from "../SbomDrop/sbomFileValidation";
 import { useSbomFileDrop } from "../SbomDrop/useSbomFileDrop";
 
 import { AppButton } from "./sharedUiParts";
@@ -16,20 +18,32 @@ import {
   uiTransitions,
 } from "./styleTokens";
 
-export function NewSbomRegistrationPanel({
-  onCancel,
-  onDropFile,
-  onUploadClick,
-  showCancel = true,
-}) {
+export function NewSbomRegistrationPanel({ onCancel, onDropFile, showCancel = true }) {
   const { t } = useTranslation("status", { keyPrefix: "NewSbomRegistrationPanel" });
   const { t: tFileDropZone } = useTranslation("status", { keyPrefix: "FileDropZone" });
+  const fileInputRef = useRef(null);
 
   const { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } =
     useSbomFileDrop({
       onFile: (file) => onDropFile?.(file),
       onError: (key) => alert(tFileDropZone(key)),
     });
+
+  const handleClickUpload = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event) => {
+    const result = validateSbomFileSelection(event.target.files);
+    event.target.value = "";
+    if (result.error) {
+      alert(tFileDropZone(result.error));
+      return;
+    }
+    if (result.file) {
+      onDropFile?.(result.file);
+    }
+  };
 
   return (
     <Box
@@ -92,7 +106,7 @@ export function NewSbomRegistrationPanel({
           <Stack sx={{ gap: 2.5 }}>
             <Box
               component="button"
-              onClick={onUploadClick}
+              onClick={handleClickUpload}
               sx={{
                 "&:hover": { bgcolor: "white", borderColor: slate[400] },
                 alignItems: "center",
@@ -123,6 +137,13 @@ export function NewSbomRegistrationPanel({
                 CycloneDX JSON / SPDX JSON
               </Typography>
             </Box>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json"
+              style={{ display: "none" }}
+              onChange={handleFileChange}
+            />
             {showCancel && (
               <Box sx={{ display: "flex", justifyContent: "center" }}>
                 <AppButton onClick={onCancel} variant="outlined">

--- a/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
+++ b/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
@@ -111,7 +111,6 @@ export function SBOMManagement({
           <NewSbomRegistrationPanel
             onCancel={newSbom.onCancel}
             onDropFile={pendingUpload.onCreateWithFile}
-            onUploadClick={newSbom.onUploadClick}
             showCancel={!isEmpty}
           />
         ) : isActiveServicePending ? (

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
@@ -93,7 +93,6 @@ export function useSBOMManagementController({
     isEmpty: state.isEmpty,
     newSbom: {
       onCancel: state.cancelCreateSbom,
-      onUploadClick: mutations.openCreateSbomDialog,
     },
     pendingUpload: {
       existingServiceNames: state.pendingUpload?.serviceName

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
@@ -240,16 +240,11 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
     }
   };
 
-  const openCreateSbomDialog = () => {
-    setPendingUpload({});
-  };
-
   return {
     addDeployment,
     commitDeploymentsEdit,
     commitDetailsEdit,
     commitServiceImpactEdit,
-    openCreateSbomDialog,
     openUpdateSbomDialog,
     handleImageUpload,
     handleRemoveImage,

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -889,17 +889,23 @@ describe("StatusPage", () => {
       useGetPTeamPackagesSummaryQuery.mockReturnValue(testPackagesSummary);
 
       const ue = userEvent.setup();
-      const renderResult = renderStatusPage();
+      renderStatusPage();
 
       await ue.click(screen.getByRole("button", { name: "New" }));
       expect(screen.getByText("Register a new SBOM")).toBeInTheDocument();
 
+      // Clicking the upload area opens the native file picker (hidden input), not the dialog directly.
       const uploadButton = screen.getByText("Upload an SBOM").closest("button");
       expect(uploadButton).not.toBeNull();
-      await ue.click(uploadButton);
+      expect(screen.queryByRole("dialog")).toBeNull();
+
+      // Simulate selecting a file via the hidden file input — this triggers the upload dialog.
+      const fileInput = document.querySelector('input[type="file"][accept=".json"]');
+      expect(fileInput).not.toBeNull();
+      const testFile = new File(["{}"], "sbom.json", { type: "application/json" });
+      await ue.upload(fileInput, testFile);
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText("Upload SBOM")).toBeInTheDocument();
-      expect(screen.getByText("Drop or click to select")).toBeInTheDocument();
     });
 
     it("opens the upload dialog with warning text when the SBOM update button is clicked", async () => {

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -897,6 +897,7 @@ describe("StatusPage", () => {
       // Clicking the upload area opens the native file picker (hidden input), not the dialog directly.
       const uploadButton = screen.getByText("Upload an SBOM").closest("button");
       expect(uploadButton).not.toBeNull();
+      await ue.click(uploadButton);
       expect(screen.queryByRole("dialog")).toBeNull();
 
       // Simulate selecting a file via the hidden file input — this triggers the upload dialog.


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- バグ改修の場合
  - 新規SBOMアップロードで「クリックしてファイル指定」が2回クリック必要になっていたため、1回のクリックでファイル選択できるよう修正

## 経緯・意図・意思決定

以前、StatusページではD&Dが使えなかったため、クリック時に直接「SBOMをアップロード」ダイアログを開く動作（フローB）に変更した。

その後、D&Dサポートが追加されたことで、クリック時もD&Dと同様に「ネイティブファイルピッカー → ダイアログ」の動作（フローA）の方が操作ステップが少なくなった。

**フローA（本PR後）:**
1. 「Upload an SBOM」をクリック → OSのファイル選択ダイアログが開く
2. ファイルを選択 → SBOMUpdateDialogがファイル事前セット済みで開く

**フローB（修正前）:**
1. 「Upload an SBOM」をクリック → SBOMUpdateDialogが開く
2. ダイアログ内でファイルを選択

D&Dの動作（ファイルをドロップ → ダイアログが開く）は変更なし。

`openCreateSbomDialog` / `onUploadClick` はフローBのために追加された関数・propであり、フローAでは不要なため合わせて削除した。

## 実施したテスト項目

- `npm run check`（ESLint / Prettier / TypeScript）: ✅ パス
- `npm run test -- src/pages/Status/__tests__/StatusPage.test.jsx`: ✅ 26件全パス
  - 対象テスト「show new SBOM registration panel when the new registration button is clicked」をフローAに合わせて更新済み

## 参考文献

<!-- I want to review in Japanese. -->