### PR TITLE
Fix: service_id省略時にpteamでチケットをフィルタするよう修正

### DIFF
--- a/api/app/command.py
+++ b/api/app/command.py
@@ -49,6 +49,7 @@ def expire_pteam_invitations(db: Session) -> None:
 
 def get_sorted_tickets_related_to_service_and_package_and_vuln(
     db: Session,
+    pteam_id: UUID | str,
     service_id: UUID | str | None,
     package_id: UUID | str | None,
     vuln_id: UUID | str | None,
@@ -92,6 +93,15 @@ def get_sorted_tickets_related_to_service_and_package_and_vuln(
                 models.Dependency.dependency_id == models.Ticket.dependency_id,
                 models.Dependency.service_id == str(service_id),
             ),
+        )
+    else:
+        select_stmt = (
+            select_stmt.join(
+                models.Dependency,
+                models.Dependency.dependency_id == models.Ticket.dependency_id,
+            )
+            .join(models.Service, models.Service.service_id == models.Dependency.service_id)
+            .where(models.Service.pteam_id == str(pteam_id))
         )
 
     select_stmt = select_stmt.order_by(

--- a/api/app/routers/pteams.py
+++ b/api/app/routers/pteams.py
@@ -946,11 +946,11 @@ def get_tickets_by_service_id_and_package_id_and_vuln_id(
 
     if assigned_to_me:
         tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
-            db, service_id, package_id, vuln_id, package_version_id, current_user.user_id
+            db, pteam_id, service_id, package_id, vuln_id, package_version_id, current_user.user_id
         )
     else:
         tickets = command.get_sorted_tickets_related_to_service_and_package_and_vuln(
-            db, service_id, package_id, vuln_id, package_version_id
+            db, pteam_id, service_id, package_id, vuln_id, package_version_id
         )
 
     ret = [

--- a/api/app/tests/requests/pteams/test_pteam_tickets.py
+++ b/api/app/tests/requests/pteams/test_pteam_tickets.py
@@ -359,6 +359,35 @@ class TestGetTickets:
             assert response.status_code == 200
             assert response.json()[0] == self.expected_ticket_response1
 
+        def test_it_should_filter_by_pteam_when_service_id_is_not_specified(self, testdb):
+            # Given
+            pteam2 = create_pteam(USER1, PTEAM2)
+            service2 = models.Service(
+                service_name="test_service2",
+                pteam_id=str(pteam2.pteam_id),
+            )
+            testdb.add(service2)
+            testdb.flush()
+            dependency2 = models.Dependency(
+                target="test target 2",
+                package_manager="npm",
+                package_version_id=self.package_version1.package_version_id,
+                service=service2,
+            )
+            testdb.add(dependency2)
+            testdb.flush()
+            ticket_business.fix_ticket_by_threat(testdb, self.threat1)
+
+            # When
+            response = client.get(
+                f"/pteams/{self.pteam1.pteam_id}/tickets?package_id={self.package1.package_id}",
+                headers=headers(USER1),
+            )
+
+            # Then
+            assert response.status_code == 200
+            assert response.json() == [self.expected_ticket_response1]
+
         def test_it_should_return_200_when_package_version_id_is_specified(self):
             # When
             response = client.get(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- `service_id` を省略してチケット取得した際に他 pteam のチケットが混入するバグを修正

## 経緯・意図・意思決定

`get_sorted_tickets_related_to_service_and_package_and_vuln` に `service_id` が渡されなかった場合、`Dependency` テーブルを JOIN せずにチケットを取得していた。そのため、異なる pteam に属するサービスのチケットが結果に混入する可能性があった。

修正として、`service_id` が省略された際にも `Dependency` → `Service` を JOIN し、`pteam_id` でフィルタリングするようにした。関数シグネチャに `pteam_id` パラメータを追加し、呼び出し元 (`routers/pteams.py`) からも渡すよう対応した。

## 実施したテスト項目

- `service_id` 未指定時に他 pteam のチケットが混入しないことを確認するテストを追加


<!-- I want to review in Japanese. -->