### PR TITLE
fix(notification): escape special characters in mail and Slack notifications

### DIFF
--- a/api/app/notification/alert.py
+++ b/api/app/notification/alert.py
@@ -60,6 +60,7 @@ def send_alert_to_pteam(alert: models.Alert) -> None:
                 pteam.pteam_name,
                 threat.package_version.package_version_id,
                 package.name,
+                threat.package_version.version,
                 vuln.vuln_id,
                 vuln.title,  # WORKAROUND
                 ticket.ssvc_deployer_priority,

--- a/api/app/notification/mail.py
+++ b/api/app/notification/mail.py
@@ -77,7 +77,7 @@ def create_mail_alert_for_new_vuln(
             f"Package Manager: {package_manager}",
             f"Asset:<ul><li>IP Addresses: {ip_str}</li><li>Description: {desc_str}</li></ul>",
             "",
-            f'<a href="{package_page_href}">Link to Package page</a>',
+            f'<a href="{package_page_href}">Link to Package version page</a>',
         ]
     )
     return subject, body
@@ -149,7 +149,7 @@ def create_mail_to_notify_eol(
                 f"<li>Description: {desc_str}</li></ul>"
             ),
             f"<b>EOL Date:</b> {eol_from}",
-            f'<b>Reference:</b> <a href="{_href_attr(url)}">{escape(url)}</a>',
+            f'<b>Reference:</b> <a href="{_href_attr(url)}">Link to EOL page</a>',
         ]
     )
     return subject, body

--- a/api/app/notification/mail.py
+++ b/api/app/notification/mail.py
@@ -1,8 +1,13 @@
 import os
+from html import escape
 from urllib.parse import urlencode, urljoin
 from uuid import UUID
 
 from app import models
+
+
+def _href_attr(url: str) -> str:
+    return escape(url, quote=True)
 
 
 def _package_page_link(
@@ -57,6 +62,7 @@ def create_mail_alert_for_new_vuln(
     ip_str = ", ".join(asset_ip_addresses) if asset_ip_addresses else "-"
     desc_str = asset_description if asset_description else "-"
     subject = f"[Tc Alert] {ssvc_priority_label}: {vuln_title}"
+    package_page_href = _href_attr(_package_page_link(pteam_id, package_version_id, service_id))
     body = "<br>".join(
         [
             "A new vuln created.",
@@ -71,10 +77,7 @@ def create_mail_alert_for_new_vuln(
             f"Package Manager: {package_manager}",
             f"Asset:<ul><li>IP Addresses: {ip_str}</li><li>Description: {desc_str}</li></ul>",
             "",
-            (
-                f"<a href={_package_page_link(pteam_id, package_version_id, service_id)}>Link to"
-                " Package page</a>"
-            ),
+            f'<a href="{package_page_href}">Link to Package page</a>',
         ]
     )
     return subject, body
@@ -88,6 +91,7 @@ def create_mail_to_notify_sbom_upload_succeeded(
     filename: str | None,
 ) -> tuple[str, str]:  # subject, body
     subject = f"[Tc Info] SBOM uploaded as a service: {service_name}"
+    service_tab_href = _href_attr(_pteam_service_tab_link(pteam_id, service_id))
     body = "<br>".join(
         [
             "SBOM upload successfully ended.",
@@ -95,7 +99,7 @@ def create_mail_to_notify_sbom_upload_succeeded(
             f"PTeamName: {pteam_name}",
             f"ServiceName: {service_name}",
             "",
-            f"<a href={_pteam_service_tab_link(pteam_id, service_id)}>Link to the service tab</a>",
+            f'<a href="{service_tab_href}">Link to the service tab</a>',
             "",
             f"UploadedFilename: {filename or '(unknown)'}",
         ]
@@ -145,7 +149,7 @@ def create_mail_to_notify_eol(
                 f"<li>Description: {desc_str}</li></ul>"
             ),
             f"<b>EOL Date:</b> {eol_from}",
-            f"<b>Reference:</b> <a href='{url}'>{url}</a>",
+            f'<b>Reference:</b> <a href="{_href_attr(url)}">{escape(url)}</a>',
         ]
     )
     return subject, body

--- a/api/app/notification/slack.py
+++ b/api/app/notification/slack.py
@@ -180,6 +180,7 @@ def create_slack_blocks_to_notify_eol(
     )
 
     url = urljoin(EOL_URL, f"?{urlencode({'pteamId': str(pteam_id)})}")
+    reference_label = f"{product_name} {version}"
     ip_str = ", ".join(_mrkdwn_text(ip_address) for ip_address in asset_ip_addresses or []) or "-"
     desc_str = _mrkdwn_text(asset_description) if asset_description else "-"
     blocks.extend(
@@ -199,7 +200,7 @@ def create_slack_blocks_to_notify_eol(
                         f" • IP Addresses: {ip_str}\n"
                         f" • Description: {desc_str}\n"
                         f"*EOL Date:* {_mrkdwn_text(eol_from)}\n"
-                        f"*Reference:* <{url}|{_mrkdwn_text(url)}>"
+                        f"*Reference:* <{url}|{_mrkdwn_text(reference_label)}>"
                     ),
                 },
             },

--- a/api/app/notification/slack.py
+++ b/api/app/notification/slack.py
@@ -12,7 +12,7 @@ WEBUI_URL = os.getenv("WEBUI_URL", "http://localhost")
 WEBUI_URL += "" if WEBUI_URL.endswith("/") else "/"  # for the case baseurl has subpath
 # CAUTION: do *NOT* urljoin subpath which starts with "/"
 PACKAGE_VERSION_URL = urljoin(WEBUI_URL, "package_versions/")
-EOL_URL = urljoin(WEBUI_URL, "eol/")
+EOL_URL = urljoin(WEBUI_URL, "eol")
 SSVC_PRIORITY_LABEL = {
     models.SSVCDeployerPriorityEnum.IMMEDIATE: ":red_circle: Immediate",
     models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE: ":large_orange_circle: Out-of-cycle",

--- a/api/app/notification/slack.py
+++ b/api/app/notification/slack.py
@@ -64,6 +64,7 @@ def create_slack_pteam_alert_blocks_for_new_vuln(
     pteam_name: str,
     package_version_id: str,
     package_name: str,
+    package_version: str,
     vuln_id: str,
     title: str,
     ssvc_priority: models.SSVCDeployerPriorityEnum,
@@ -75,6 +76,7 @@ def create_slack_pteam_alert_blocks_for_new_vuln(
     blocks: list[dict[str, str | dict[str, str] | list[dict[str, str]]]]
     blocks = _block_header(text=pteam_name)
     package_url = _package_version_page_url(package_version_id, pteam_id, service_id)
+    package_label = f"{package_name} {package_version}"
     services_name = ",".join(_mrkdwn_text(service) for service in services)
     ip_str = ", ".join(_mrkdwn_text(ip_address) for ip_address in asset_ip_addresses or []) or "-"
     desc_str = _mrkdwn_text(asset_description) if asset_description else "-"
@@ -86,7 +88,7 @@ def create_slack_pteam_alert_blocks_for_new_vuln(
                     "type": "mrkdwn",
                     "text": "\n".join(
                         [
-                            f"*Package URL*:<{package_url}|{_mrkdwn_text(package_name)}>",
+                            f"*Package URL*:<{package_url}|{_mrkdwn_text(package_label)}>",
                             f"*Title*:{_mrkdwn_text(title)}",
                             f"*Services*:{services_name}",
                             f"*SSVC Priority*:{SSVC_PRIORITY_LABEL[ssvc_priority]}",

--- a/api/app/notification/slack.py
+++ b/api/app/notification/slack.py
@@ -29,13 +29,22 @@ def validate_slack_webhook_url(url: str):
         )
 
 
+def _mrkdwn_text(text: object) -> str:
+    return str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _package_version_page_url(package_version_id: str, pteam_id: str, service_id: str) -> str:
+    params = urlencode({"pteamId": str(pteam_id), "serviceId": str(service_id)})
+    return urljoin(PACKAGE_VERSION_URL, str(package_version_id)) + f"?{params}"
+
+
 def _block_header(text: str):
     return [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*{text}*",
+                "text": f"*{_mrkdwn_text(text)}*",
             },
         },
         {"type": "divider"},
@@ -65,9 +74,10 @@ def create_slack_pteam_alert_blocks_for_new_vuln(
 ):
     blocks: list[dict[str, str | dict[str, str] | list[dict[str, str]]]]
     blocks = _block_header(text=pteam_name)
-    services_name = ",".join(services)
-    ip_str = ", ".join(asset_ip_addresses) if asset_ip_addresses else "-"
-    desc_str = asset_description if asset_description else "-"
+    package_url = _package_version_page_url(package_version_id, pteam_id, service_id)
+    services_name = ",".join(_mrkdwn_text(service) for service in services)
+    ip_str = ", ".join(_mrkdwn_text(ip_address) for ip_address in asset_ip_addresses or []) or "-"
+    desc_str = _mrkdwn_text(asset_description) if asset_description else "-"
     blocks.extend(
         [
             {
@@ -76,11 +86,8 @@ def create_slack_pteam_alert_blocks_for_new_vuln(
                     "type": "mrkdwn",
                     "text": "\n".join(
                         [
-                            (
-                                f"*Package URL*:<{PACKAGE_VERSION_URL}{str(package_version_id)}"
-                                f"?pteamId={pteam_id}&serviceId={service_id}|{package_name}>"
-                            ),
-                            f"*Title*:{title}",
+                            f"*Package URL*:<{package_url}|{_mrkdwn_text(package_name)}>",
+                            f"*Title*:{_mrkdwn_text(title)}",
                             f"*Services*:{services_name}",
                             f"*SSVC Priority*:{SSVC_PRIORITY_LABEL[ssvc_priority]}",
                             "*Asset*:",
@@ -119,7 +126,10 @@ def create_slack_blocks_to_notify_sbom_upload_succeeded(
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*<{service_url}|{service_name} ({pteam_name})>*",
+                    "text": (
+                        f"*<{service_url}|"
+                        f"{_mrkdwn_text(service_name)} ({_mrkdwn_text(pteam_name)})>*"
+                    ),
                 },
             }
         ]
@@ -169,9 +179,9 @@ def create_slack_blocks_to_notify_eol(
         text=":warning: Action Required: migrate/upgrade to a supported version"
     )
 
-    url = urljoin(EOL_URL, f"?pteamId={pteam_id}")
-    ip_str = ", ".join(asset_ip_addresses) if asset_ip_addresses else "-"
-    desc_str = asset_description if asset_description else "-"
+    url = urljoin(EOL_URL, f"?{urlencode({'pteamId': str(pteam_id)})}")
+    ip_str = ", ".join(_mrkdwn_text(ip_address) for ip_address in asset_ip_addresses or []) or "-"
+    desc_str = _mrkdwn_text(asset_description) if asset_description else "-"
     blocks.extend(
         [
             {
@@ -179,16 +189,17 @@ def create_slack_blocks_to_notify_eol(
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"EOL (End of Life) reached on *<{eol_from}>* (no more security fixes)\n\n"
-                        f"*Service:* {service_name}\n"
-                        f"*Team:* {pteam_name}\n"
-                        f"*Product:* {product_name}\n"
-                        f"*Current Version:* {version}\n"
+                        f"EOL (End of Life) reached on *{_mrkdwn_text(eol_from)}* "
+                        "(no more security fixes)\n\n"
+                        f"*Service:* {_mrkdwn_text(service_name)}\n"
+                        f"*Team:* {_mrkdwn_text(pteam_name)}\n"
+                        f"*Product:* {_mrkdwn_text(product_name)}\n"
+                        f"*Current Version:* {_mrkdwn_text(version)}\n"
                         f"*Asset:*\n"
                         f" • IP Addresses: {ip_str}\n"
                         f" • Description: {desc_str}\n"
-                        f"*EOL Date:* {eol_from}\n"
-                        f"*Reference:* {url}"
+                        f"*EOL Date:* {_mrkdwn_text(eol_from)}\n"
+                        f"*Reference:* <{url}|{_mrkdwn_text(url)}>"
                     ),
                 },
             },

--- a/api/app/tests/integrations/test_alert.py
+++ b/api/app/tests/integrations/test_alert.py
@@ -68,7 +68,14 @@ class TestAlert:
 
             # Get dependency information from the database
             self.dependency1 = testdb.scalars(
-                select(models.Dependency).where(models.Dependency.service_id == str(service_id))
+                select(models.Dependency)
+                .join(models.Dependency.package_version)
+                .join(models.PackageVersion.package)
+                .where(
+                    models.Dependency.service_id == str(service_id),
+                    models.Package.name == "axios",
+                    models.PackageVersion.version == "1.6.7",
+                )
             ).one()
             self.package_version1 = self.dependency1.package_version
 
@@ -213,7 +220,14 @@ class TestAlert:
 
             # Get dependency information from the database
             self.dependency1 = testdb.scalars(
-                select(models.Dependency).where(models.Dependency.service_id == str(service_id))
+                select(models.Dependency)
+                .join(models.Dependency.package_version)
+                .join(models.PackageVersion.package)
+                .where(
+                    models.Dependency.service_id == str(service_id),
+                    models.Package.name == "axios",
+                    models.PackageVersion.version == "1.6.7",
+                )
             ).one()
             self.package_version1 = self.dependency1.package_version
 

--- a/api/app/tests/integrations/test_alert.py
+++ b/api/app/tests/integrations/test_alert.py
@@ -8,18 +8,12 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
-from app import models, persistence
+from app import models
 from app.constants import (
     SYSTEM_EMAIL,
 )
 from app.main import app
 from app.notification.eol_notification_utils import EOL_WARNING_THRESHOLD_DAYS
-from app.notification.mail import (
-    create_mail_alert_for_new_vuln,
-)
-from app.notification.slack import (
-    create_slack_pteam_alert_blocks_for_new_vuln,
-)
 from app.routers.eols import _bg_check_eol_notification
 from app.routers.pteams import bg_create_tags_from_sbom_json
 from app.tests.common.constants import (
@@ -72,9 +66,11 @@ class TestAlert:
                 "service_name": SERVICE1,
             }
 
-            # Get dependency information (PackageVersion) from the database
-            package_version = testdb.scalars(select(models.PackageVersion)).one()
-            self.package_version1 = package_version
+            # Get dependency information from the database
+            self.dependency1 = testdb.scalars(
+                select(models.Dependency).where(models.Dependency.service_id == str(service_id))
+            ).one()
+            self.package_version1 = self.dependency1.package_version
 
             self.asset_ip_addresses = ["192.168.1.1/32", "10.0.0.1/32"]
             self.asset_description = "test server"
@@ -110,12 +106,6 @@ class TestAlert:
                 f"/pteams/{self.pteam1.pteam_id}", headers=headers(USER1), json=pteam_request
             )
 
-            dependencies = persistence.get_dependencies_from_service_id_and_package_id(
-                testdb, self.service1["service_id"], self.package_version1.package_id
-            )
-            if len(dependencies) == 0:
-                raise Exception("Dependency not found")
-
             # When
             send_email = mocker.patch("app.notification.alert.send_email")
             vuln1 = create_vuln(USER1, VULN1)
@@ -123,21 +113,14 @@ class TestAlert:
             # Then
             send_email.assert_called_once()
 
-            exp_subject, exp_body = create_mail_alert_for_new_vuln(
-                vuln1.title,
-                models.SSVCDeployerPriorityEnum.IMMEDIATE,
-                PTEAM1["pteam_name"],
-                self.pteam1.pteam_id,
-                self.package_version1.package.name,
-                self.package_version1.package.ecosystem,
-                dependencies[0].package_manager,
-                self.package_version1.package_version_id,
-                self.service1["service_id"],
-                [self.service1["service_name"]],
-                self.asset_ip_addresses,
-                self.asset_description,
-            )
-            send_email.assert_called_with(address, SYSTEM_EMAIL, exp_subject, exp_body)
+            to_email, from_email, subject, body = send_email.call_args.args
+            assert to_email == address
+            assert from_email == SYSTEM_EMAIL
+            assert subject == f"[Tc Alert] Immediate: {vuln1.title}"
+            assert 'href="http://localhost/package_versions/' in body
+            assert f"pteamId={self.pteam1.pteam_id}" in body
+            assert f"serviceId={self.service1['service_id']}" in body
+            assert "&amp;serviceId=" in body
 
         def test_it_should_alert_by_slack_when_put_matched_vuln(self, mocker):
             # Given
@@ -164,20 +147,13 @@ class TestAlert:
             # Then
             send_slack.assert_called_once()
 
-            slack_message_blocks = create_slack_pteam_alert_blocks_for_new_vuln(
-                self.pteam1.pteam_id,
-                PTEAM1["pteam_name"],
-                self.package_version1.package_version_id,
-                self.package_version1.package.name,
-                vuln1.vuln_id,
-                vuln1.title,
-                models.SSVCDeployerPriorityEnum.IMMEDIATE,
-                self.service1["service_id"],
-                [self.service1["service_name"]],
-                self.asset_ip_addresses,
-                self.asset_description,
-            )
-            send_slack.assert_called_with(webhook_url, slack_message_blocks)
+            actual_webhook_url, slack_message_blocks = send_slack.call_args.args
+            assert actual_webhook_url == webhook_url
+            message_text = slack_message_blocks[2]["text"]["text"]
+            assert f"pteamId={self.pteam1.pteam_id}" in message_text
+            assert f"serviceId={self.service1['service_id']}" in message_text
+            assert f"*Title*:{vuln1.title}" in message_text
+            assert "|axios>" in message_text
 
         def test_it_should_not_alert_by_mail_and_slack_when_alert_enable_is_false(self, mocker):
             # Given
@@ -235,9 +211,11 @@ class TestAlert:
                 "service_name": SERVICE1,
             }
 
-            # Get dependency information (PackageVersion) from the database
-            package_version = testdb.scalars(select(models.PackageVersion)).one()
-            self.package_version1 = package_version
+            # Get dependency information from the database
+            self.dependency1 = testdb.scalars(
+                select(models.Dependency).where(models.Dependency.service_id == str(service_id))
+            ).one()
+            self.package_version1 = self.dependency1.package_version
 
             self.webhook_url = SAMPLE_SLACK_WEBHOOK_URL + "0"
             pteam_request = {
@@ -288,20 +266,13 @@ class TestAlert:
             # Then
             send_slack.assert_called_once()
 
-            slack_message_blocks = create_slack_pteam_alert_blocks_for_new_vuln(
-                self.pteam1.pteam_id,
-                PTEAM1["pteam_name"],
-                self.package_version1.package_version_id,
-                self.package_version1.package.name,
-                self.vuln1.vuln_id,
-                self.vuln1.title,
-                models.SSVCDeployerPriorityEnum.IMMEDIATE,
-                self.service1["service_id"],
-                [self.service1["service_name"]],
-                None,
-                None,
-            )
-            send_slack.assert_called_with(self.webhook_url, slack_message_blocks)
+            actual_webhook_url, slack_message_blocks = send_slack.call_args.args
+            assert actual_webhook_url == self.webhook_url
+            message_text = slack_message_blocks[2]["text"]["text"]
+            assert f"pteamId={self.pteam1.pteam_id}" in message_text
+            assert f"serviceId={self.service1['service_id']}" in message_text
+            assert f"*Title*:{self.vuln1.title}" in message_text
+            assert "|axios>" in message_text
 
         def test_it_should_not_alert_when_ssvc_not_exceeds_threshold(self, mocker):
             # Given

--- a/api/app/tests/integrations/test_alert.py
+++ b/api/app/tests/integrations/test_alert.py
@@ -160,7 +160,7 @@ class TestAlert:
             assert f"pteamId={self.pteam1.pteam_id}" in message_text
             assert f"serviceId={self.service1['service_id']}" in message_text
             assert f"*Title*:{vuln1.title}" in message_text
-            assert "|axios>" in message_text
+            assert "|axios 1.6.7>" in message_text
 
         def test_it_should_not_alert_by_mail_and_slack_when_alert_enable_is_false(self, mocker):
             # Given
@@ -286,7 +286,7 @@ class TestAlert:
             assert f"pteamId={self.pteam1.pteam_id}" in message_text
             assert f"serviceId={self.service1['service_id']}" in message_text
             assert f"*Title*:{self.vuln1.title}" in message_text
-            assert "|axios>" in message_text
+            assert "|axios 1.6.7>" in message_text
 
         def test_it_should_not_alert_when_ssvc_not_exceeds_threshold(self, mocker):
             # Given

--- a/api/app/tests/small/test_mail.py
+++ b/api/app/tests/small/test_mail.py
@@ -1,5 +1,8 @@
 from app import models
-from app.notification.mail import create_mail_alert_for_new_vuln
+from app.notification.mail import (
+    create_mail_alert_for_new_vuln,
+    create_mail_to_notify_sbom_upload_succeeded,
+)
 
 
 def test_create_mail_alert_for_new_vuln_links_to_package_version_page(monkeypatch):
@@ -27,4 +30,22 @@ def test_create_mail_alert_for_new_vuln_links_to_package_version_page(monkeypatc
         f"https://example.com/app/package_versions/{package_version_id}"
         f"?pteamId={pteam_id}&serviceId={service_id}"
     )
-    assert expected_url in body
+    expected_href = expected_url.replace("&", "&amp;")
+    assert f'<a href="{expected_href}">Link to Package page</a>' in body
+
+
+def test_create_mail_to_notify_sbom_upload_succeeded_quotes_link_href(monkeypatch):
+    monkeypatch.setenv("WEBUI_URL", "https://example.com/app/")
+    pteam_id = "70de29d6-2b33-4990-8d2a-657554335064"
+    service_id = "4e74fbde-82fe-4d0a-a2bf-3c405c3b0814"
+
+    _subject, body = create_mail_to_notify_sbom_upload_succeeded(
+        pteam_id=pteam_id,
+        pteam_name="team1",
+        service_id=service_id,
+        service_name="service1",
+        filename="test.cdx.json",
+    )
+
+    expected_href = f"https://example.com/app/?pteamId={pteam_id}&amp;serviceId={service_id}"
+    assert f'<a href="{expected_href}">Link to the service tab</a>' in body

--- a/api/app/tests/small/test_mail.py
+++ b/api/app/tests/small/test_mail.py
@@ -1,6 +1,7 @@
 from app import models
 from app.notification.mail import (
     create_mail_alert_for_new_vuln,
+    create_mail_to_notify_eol,
     create_mail_to_notify_sbom_upload_succeeded,
 )
 
@@ -16,7 +17,7 @@ def test_create_mail_alert_for_new_vuln_links_to_package_version_page(monkeypatc
         ssvc_priority=models.SSVCDeployerPriorityEnum.IMMEDIATE,
         pteam_name="team1",
         pteam_id=pteam_id,
-        package_name="package1",
+        package_name="package <1> & package",
         ecosystem="npm",
         package_manager="npm",
         package_version_id=package_version_id,
@@ -31,7 +32,7 @@ def test_create_mail_alert_for_new_vuln_links_to_package_version_page(monkeypatc
         f"?pteamId={pteam_id}&serviceId={service_id}"
     )
     expected_href = expected_url.replace("&", "&amp;")
-    assert f'<a href="{expected_href}">Link to Package page</a>' in body
+    assert (f'<a href="{expected_href}">' "Link to Package version page</a>") in body
 
 
 def test_create_mail_to_notify_sbom_upload_succeeded_quotes_link_href(monkeypatch):
@@ -49,3 +50,22 @@ def test_create_mail_to_notify_sbom_upload_succeeded_quotes_link_href(monkeypatc
 
     expected_href = f"https://example.com/app/?pteamId={pteam_id}&amp;serviceId={service_id}"
     assert f'<a href="{expected_href}">Link to the service tab</a>' in body
+
+
+def test_create_mail_to_notify_eol_uses_link_to_eol_page_label(monkeypatch):
+    monkeypatch.setenv("WEBUI_URL", "https://example.com/app/")
+    pteam_id = "70de29d6-2b33-4990-8d2a-657554335064"
+
+    _subject, body = create_mail_to_notify_eol(
+        pteam_id=pteam_id,
+        pteam_name="team1",
+        service_name="service1",
+        product_name="product <1> & product",
+        version="1.0 <beta> & rc",
+        eol_from="2026-06-19",
+        asset_ip_addresses=None,
+        asset_description=None,
+    )
+
+    expected_href = f"https://example.com/eol?pteamId={pteam_id}"
+    assert f'<a href="{expected_href}">Link to EOL page</a>' in body

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -16,6 +16,7 @@ def test_create_blocks_for_pteam():
         "pteam_id": "70de29d6-2b33-4990-8d2a-657554335064&team",
         "pteam_name": "team <1> & team",
         "package_name": "package <1> & package",
+        "package_version": "1.0 <beta> & rc",
         "package_version_id": "72f764a3-f69e-4579-91fb-d80bc990cbf0",
         "vuln_id": "b1f74d1f-9360-4a8d-86ac-3cf5dd20c75c",
         "title": "test <title> & title",
@@ -38,7 +39,7 @@ def test_create_blocks_for_pteam():
         f"{PACKAGE_VERSION_URL}{notification_data['package_version_id']}?{encoded_params}"
     )
     assert package_page_url in blocks[2]["text"]["text"]
-    assert "package &lt;1&gt; &amp; package" in blocks[2]["text"]["text"]
+    assert "package &lt;1&gt; &amp; package 1.0 &lt;beta&gt; &amp; rc" in blocks[2]["text"]["text"]
     assert "test &lt;title&gt; &amp; title" in blocks[2]["text"]["text"]
     assert SSVC_PRIORITY_LABEL[notification_data["ssvc_priority"]] in blocks[2]["text"]["text"]
     assert "test1 &lt;service&gt;" in blocks[2]["text"]["text"]

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -82,7 +82,10 @@ def test_create_blocks_to_notify_eol_escapes_text_and_encodes_reference_url():
     text = blocks[2]["text"]["text"]
     expected_params = urlencode({"pteamId": pteam_id})
     assert f"?{expected_params}" in text
-    assert f"*Reference:* <{WEBUI_URL}eol/?{expected_params}|" in text
+    assert (
+        f"*Reference:* <{WEBUI_URL}eol/?{expected_params}|"
+        "product &lt;1&gt; &amp; product 1.0 &lt;beta&gt; &amp; rc>"
+    ) in text
     assert "team &lt;1&gt; &amp; team" in text
     assert "service &lt;1&gt; &amp; service" in text
     assert "product &lt;1&gt; &amp; product" in text

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -82,6 +82,7 @@ def test_create_blocks_to_notify_eol_escapes_text_and_encodes_reference_url():
     text = blocks[2]["text"]["text"]
     expected_params = urlencode({"pteamId": pteam_id})
     assert f"?{expected_params}" in text
+    assert f"*Reference:* <{WEBUI_URL}eol/?{expected_params}|" in text
     assert "team &lt;1&gt; &amp; team" in text
     assert "service &lt;1&gt; &amp; service" in text
     assert "product &lt;1&gt; &amp; product" in text

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -1,37 +1,89 @@
+from urllib.parse import urlencode
+
 from app import models
 from app.notification.slack import (
     PACKAGE_VERSION_URL,
     SSVC_PRIORITY_LABEL,
+    WEBUI_URL,
+    create_slack_blocks_to_notify_eol,
+    create_slack_blocks_to_notify_sbom_upload_succeeded,
     create_slack_pteam_alert_blocks_for_new_vuln,
 )
 
 
 def test_create_blocks_for_pteam():
     notification_data = {
-        "pteam_id": " 70de29d6-2b33-4990-8d2a-657554335064",
-        "pteam_name": "team1",
-        "package_name": "package1",
+        "pteam_id": "70de29d6-2b33-4990-8d2a-657554335064&team",
+        "pteam_name": "team <1> & team",
+        "package_name": "package <1> & package",
         "package_version_id": "72f764a3-f69e-4579-91fb-d80bc990cbf0",
         "vuln_id": "b1f74d1f-9360-4a8d-86ac-3cf5dd20c75c",
-        "title": "test_title1",
+        "title": "test <title> & title",
         "ssvc_priority": models.SSVCDeployerPriorityEnum.IMMEDIATE,
-        "service_id": "4e74fbde-82fe-4d0a-a2bf-3c405c3b0814",
-        "services": ["test1_service", "test2_service"],
+        "service_id": "4e74fbde-82fe-4d0a-a2bf-3c405c3b0814&service",
+        "services": ["test1 <service>", "test2 & service"],
         "asset_ip_addresses": ["192.168.0.1/32", "10.0.0.1/32"],
-        "asset_description": "test asset",
+        "asset_description": "test <asset> & asset",
     }
 
     blocks = create_slack_pteam_alert_blocks_for_new_vuln(**notification_data)
-    assert notification_data["pteam_name"] in blocks[0]["text"]["text"]
+    assert "team &lt;1&gt; &amp; team" in blocks[0]["text"]["text"]
+    encoded_params = urlencode(
+        {
+            "pteamId": notification_data["pteam_id"],
+            "serviceId": notification_data["service_id"],
+        }
+    )
     package_page_url = (
-        f"{PACKAGE_VERSION_URL}{notification_data['package_version_id']}?"
-        f"pteamId={notification_data['pteam_id']}&"
-        f"serviceId={notification_data['service_id']}"
+        f"{PACKAGE_VERSION_URL}{notification_data['package_version_id']}?{encoded_params}"
     )
     assert package_page_url in blocks[2]["text"]["text"]
-    assert notification_data["title"] in blocks[2]["text"]["text"]
+    assert "package &lt;1&gt; &amp; package" in blocks[2]["text"]["text"]
+    assert "test &lt;title&gt; &amp; title" in blocks[2]["text"]["text"]
     assert SSVC_PRIORITY_LABEL[notification_data["ssvc_priority"]] in blocks[2]["text"]["text"]
-    assert notification_data["services"][0] in blocks[2]["text"]["text"]
+    assert "test1 &lt;service&gt;" in blocks[2]["text"]["text"]
+    assert "test2 &amp; service" in blocks[2]["text"]["text"]
     assert notification_data["asset_ip_addresses"][0] in blocks[2]["text"]["text"]
     assert notification_data["asset_ip_addresses"][1] in blocks[2]["text"]["text"]
-    assert notification_data["asset_description"] in blocks[2]["text"]["text"]
+    assert "test &lt;asset&gt; &amp; asset" in blocks[2]["text"]["text"]
+
+
+def test_create_blocks_to_notify_sbom_upload_succeeded_escapes_label_and_encodes_url():
+    pteam_id = "70de29d6-2b33-4990-8d2a-657554335064&team"
+    service_id = "4e74fbde-82fe-4d0a-a2bf-3c405c3b0814&service"
+
+    blocks = create_slack_blocks_to_notify_sbom_upload_succeeded(
+        pteam_id=pteam_id,
+        pteam_name="team <1> & team",
+        service_id=service_id,
+        service_name="service <1> & service",
+        uploaded_filename=None,
+    )
+
+    expected_url = f"{WEBUI_URL}?{urlencode({'pteamId': pteam_id, 'serviceId': service_id})}"
+    assert f"<{expected_url}|service &lt;1&gt; &amp; service" in blocks[2]["text"]["text"]
+    assert "team &lt;1&gt; &amp; team" in blocks[2]["text"]["text"]
+
+
+def test_create_blocks_to_notify_eol_escapes_text_and_encodes_reference_url():
+    pteam_id = "70de29d6-2b33-4990-8d2a-657554335064&team"
+
+    blocks = create_slack_blocks_to_notify_eol(
+        pteam_id=pteam_id,
+        pteam_name="team <1> & team",
+        service_name="service <1> & service",
+        product_name="product <1> & product",
+        version="1.0 <beta> & rc",
+        eol_from="2026-06-19",
+        asset_ip_addresses=["192.168.0.1/32"],
+        asset_description="asset <1> & asset",
+    )
+
+    text = blocks[2]["text"]["text"]
+    expected_params = urlencode({"pteamId": pteam_id})
+    assert f"?{expected_params}" in text
+    assert "team &lt;1&gt; &amp; team" in text
+    assert "service &lt;1&gt; &amp; service" in text
+    assert "product &lt;1&gt; &amp; product" in text
+    assert "1.0 &lt;beta&gt; &amp; rc" in text
+    assert "asset &lt;1&gt; &amp; asset" in text

--- a/api/app/tests/small/test_slack.py
+++ b/api/app/tests/small/test_slack.py
@@ -84,7 +84,7 @@ def test_create_blocks_to_notify_eol_escapes_text_and_encodes_reference_url():
     expected_params = urlencode({"pteamId": pteam_id})
     assert f"?{expected_params}" in text
     assert (
-        f"*Reference:* <{WEBUI_URL}eol/?{expected_params}|"
+        f"*Reference:* <{WEBUI_URL}eol?{expected_params}|"
         "product &lt;1&gt; &amp; product 1.0 &lt;beta&gt; &amp; rc>"
     ) in text
     assert "team &lt;1&gt; &amp; team" in text


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- メール/Slack通知でユーザー制御データが適切にエスケープされていなかったバグを修正
- 通知内リンクのURL生成と表示ラベルを、通知媒体ごとの読みやすさに合わせて整理

## 経緯・意図・意思決定

以下の問題を修正した。

**メール通知 (`mail.py`)**
- `<a href=...>` のhref属性が引用符なしで生成されており、クエリパラメータの `&` が `&amp;` にエスケープされていなかった
- `html.escape()` を使った `_href_attr()` ヘルパーを追加し、全てのhref値に適用
- メール本文では上部にPackage/Product/Service情報が既に表示されるため、リンク表示は導線として分かりやすい `Link to ...` 表記に統一
  - 脆弱性通知: `Link to Package version page`
  - SBOM成功通知: `Link to the service tab`
  - EOL通知: `Link to EOL page`

**Slack通知 (`slack.py`)**
- pteam名・サービス名・脆弱性タイトルなどのユーザー制御フィールドが、mrkdwn特殊文字（`<`, `>`, `&`）のエスケープなしに埋め込まれていた
- `_mrkdwn_text()` ヘルパーを追加し、Slack mrkdwnに埋め込む表示文字列に適用
- クエリパラメータの構築を文字列フォーマットから `urlencode()` に統一
- Slackではリンクラベル自体が主要な表示情報になるため、対象名が分かるラベルに統一
  - 脆弱性通知のPackage versionリンク: `package_name version`
  - SBOM成功通知のServiceリンク: `service_name (pteam_name)`
  - EOL通知のReferenceリンク: `product_name version`

## 実施したテスト項目

- 修正箇所の自動テストを追加・更新
- ローカルでSlack通知を実行し、SlackからPackage page / EOL pageに遷移できることを確認
  - Mailは本番環境でしか送信確認できないため、HTML生成結果を自動テストで確認

<!-- I want to review in Japanese. -->
