### PR TITLE
Remove redundant index=True from primary key columns

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -241,7 +241,7 @@ class AccountDefaultPTeam(Base):
     __tablename__ = "accountdefaultpteam"
 
     user_id: Mapped[StrUUID] = mapped_column(
-        ForeignKey("account.user_id", ondelete="CASCADE"), primary_key=True, index=True
+        ForeignKey("account.user_id", ondelete="CASCADE"), primary_key=True
     )
     default_pteam_id: Mapped[StrUUID] = mapped_column(
         ForeignKey("pteam.pteam_id", ondelete="CASCADE"), index=True
@@ -499,7 +499,7 @@ class ServiceThumbnail(Base):
     __tablename__ = "servicethumbnail"
 
     service_id: Mapped[StrUUID] = mapped_column(
-        ForeignKey("service.service_id", ondelete="CASCADE"), primary_key=True, index=True
+        ForeignKey("service.service_id", ondelete="CASCADE"), primary_key=True
     )
     media_type: Mapped[Str255]
     image_data: Mapped[bytes]
@@ -662,7 +662,7 @@ class PTeamMail(Base):
     __tablename__ = "pteammail"
 
     pteam_id: Mapped[StrUUID] = mapped_column(
-        ForeignKey("pteam.pteam_id", ondelete="CASCADE"), primary_key=True, index=True
+        ForeignKey("pteam.pteam_id", ondelete="CASCADE"), primary_key=True
     )
     enable: Mapped[bool]
     address: Mapped[Str255]
@@ -674,7 +674,7 @@ class PTeamSlack(Base):
     __tablename__ = "pteamslack"
 
     pteam_id: Mapped[StrUUID] = mapped_column(
-        ForeignKey("pteam.pteam_id", ondelete="CASCADE"), primary_key=True, index=True
+        ForeignKey("pteam.pteam_id", ondelete="CASCADE"), primary_key=True
     )
     enable: Mapped[bool] = mapped_column(default=True)
     webhook_url: Mapped[Str255]


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- プライマリーキー列に付与されていた冗長な `index=True` を除去する

## 経緯・意図・意思決定

`AccountDefaultPTeam.user_id`、`ServiceThumbnail.service_id`、`PTeamMail.pteam_id`、`PTeamSlack.pteam_id` の各プライマリーキー列に `index=True` が付与されていたが、プライマリーキーは SQLAlchemy により自動的にインデックスが作成されるため、重複インデックスが生成されていた。この冗長な指定を除去した。

既存の 2026_03_26_0913-993a4b0c7487_delete_index.py でDB側の index drop は済んでいる。
この3/26修正の際には、今回修正したmodels.pyの問題には気付いていなかったため、今回追加修正する。

<!-- I want to review in Japanese. -->