### PR TITLE
fix(ssvc): PackageページでのVuln一覧テーブルにおけるSSVCソートが文字列順になるバグを修正

### DIFF
--- a/api/app/business/ssvc_business.py
+++ b/api/app/business/ssvc_business.py
@@ -94,7 +94,7 @@ def _create_vuln_ids_summary(vuln_ids_dict: dict) -> dict:
     vuln_ids_sorted = sorted(
         vuln_ids_dict.values(),
         key=lambda x: (
-            x["highest_ssvc_priority"].value,
+            x["highest_ssvc_priority"],
             -(_dt.timestamp() if (_dt := x["vuln_updated_at"]) else 0),
         ),
     )

--- a/api/app/tests/small/test_ssvc_order.py
+++ b/api/app/tests/small/test_ssvc_order.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
 import pytest
 
 from app import models
+from app.business.ssvc_business import _create_vuln_ids_summary
 
 
 def test_ssvc_priority_enum_comparison_with_different_type():
@@ -38,3 +42,46 @@ def test_comparison_operators(left, right, operator):
 
     expected = operator in expected_true_operators
     assert eval(f"left {operator} right") is expected
+
+
+def test_vuln_ids_summary_sorts_ssvc_priority_from_worst_to_best():
+    # Given
+    now = datetime.now(timezone.utc)
+    defer_vuln_id = uuid4()
+    immediate_vuln_id = uuid4()
+    out_of_cycle_vuln_id = uuid4()
+    scheduled_vuln_id = uuid4()
+
+    vuln_ids_dict = {
+        defer_vuln_id: {
+            "highest_ssvc_priority": models.SSVCDeployerPriorityEnum.DEFER,
+            "vuln_updated_at": now,
+            "vuln_id": defer_vuln_id,
+        },
+        immediate_vuln_id: {
+            "highest_ssvc_priority": models.SSVCDeployerPriorityEnum.IMMEDIATE,
+            "vuln_updated_at": now,
+            "vuln_id": immediate_vuln_id,
+        },
+        out_of_cycle_vuln_id: {
+            "highest_ssvc_priority": models.SSVCDeployerPriorityEnum.OUT_OF_CYCLE,
+            "vuln_updated_at": now,
+            "vuln_id": out_of_cycle_vuln_id,
+        },
+        scheduled_vuln_id: {
+            "highest_ssvc_priority": models.SSVCDeployerPriorityEnum.SCHEDULED,
+            "vuln_updated_at": now,
+            "vuln_id": scheduled_vuln_id,
+        },
+    }
+
+    # When
+    summary = _create_vuln_ids_summary(vuln_ids_dict)
+
+    # Then
+    assert summary["vuln_ids"] == [
+        immediate_vuln_id,
+        out_of_cycle_vuln_id,
+        scheduled_vuln_id,
+        defer_vuln_id,
+    ]


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- PackageページでのVuln一覧テーブルにおいて、ワーストSSVCでソートする仕様だが、SSVC値の文字列順になっていたバグを修正

## 経緯・意図・意思決定

`ssvc_business.py` の `_create_vuln_ids_summary` 内のソートキーで `highest_ssvc_priority.value` を使用していた。
`SSVCDeployerPriorityEnum` は `ComparableStringEnum` を継承しており、定義順 (IMMEDIATE=0, OUT_OF_CYCLE=1, SCHEDULED=2, DEFER=3) に基づいた比較演算子 (`__lt__` 等) を持つ。

しかし `.value` を取ると plain な `str` ("immediate" 等) に戻るため、enum の比較演算子が機能せず文字列アルファベット順 (defer < immediate < out_of_cycle < scheduled) でソートされていた。
これにより、最も優先度の高い IMMEDIATE が先頭に来ず、意図したソート順になっていた。

`.value` を除去することで enum インスタンス同士の比較になり、定義順 (IMMEDIATE → OUT_OF_CYCLE → SCHEDULED → DEFER) でソートされる。

## 実施したテスト項目

- `test_vuln_ids_summary_sorts_ssvc_priority_from_worst_to_best` を追加し、ソート順が IMMEDIATE → OUT_OF_CYCLE → SCHEDULED → DEFER になることを確認


<!-- I want to review in Japanese. -->