### PR TITLE
fix(e2etests): パッケージページのE2EテストのURLパスを修正

### DIFF
--- a/e2etests/api_utils.py
+++ b/e2etests/api_utils.py
@@ -121,7 +121,7 @@ def get_pteam_package_versions_summary(
     response = requests.get(
         f"{api_url}/pteams/{pteam_id}/package_versions/summary",
         headers=file_upload_headers(user),
-        params={"service_id": service_id},
+        params={"service_id": str(service_id)},
     )
     if response.status_code != 200:
         raise HTTPError(response)

--- a/e2etests/api_utils.py
+++ b/e2etests/api_utils.py
@@ -113,3 +113,16 @@ def get_pteam_services(user: dict, pteam_id: UUID | str):
     if response.status_code != 200:
         raise HTTPError(response)
     return response.json()
+
+
+def get_pteam_package_versions_summary(
+    user: dict, pteam_id: UUID | str, service_id: UUID | str
+) -> dict:
+    response = requests.get(
+        f"{api_url}/pteams/{pteam_id}/package_versions/summary",
+        headers=file_upload_headers(user),
+        params={"service_id": service_id},
+    )
+    if response.status_code != 200:
+        raise HTTPError(response)
+    return response.json()

--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -76,10 +76,10 @@ def test_show_package_page_directly(page: Page):
     services = get_pteam_services(USER1, pteam1["pteam_id"])
     service_id = services[0]["service_id"]
 
-    # goto tag page directly
+    # goto package page directly
     params = urlencode({"pteamId": pteam1["pteam_id"], "serviceId": service_id})
     # packages[0] is PACKAGE2 because sort by package name and ecosystem
-    path = "/packages/" + packages[0]["package_id"]
+    path = "/package_versions/" + packages[0]["package_version_id"]
     url = urljoin(base_url, path) + "?" + params
     page.goto(url)
 

--- a/e2etests/test_e2e.py
+++ b/e2etests/test_e2e.py
@@ -4,7 +4,13 @@ from urllib.parse import urlencode, urljoin
 
 from playwright.sync_api import Page, expect
 
-from api_utils import create_pteam, create_vuln, get_pteam_services, upload_pteam_packages
+from api_utils import (
+    create_pteam,
+    create_vuln,
+    get_pteam_package_versions_summary,
+    get_pteam_services,
+    upload_pteam_packages,
+)
 from constants import PACKAGE1, PACKAGE2, PTEAM1, USER1, VULN1, VULN2
 
 base_url = os.getenv("BASE_URL", "http://localhost")
@@ -68,7 +74,7 @@ def test_show_package_page_directly(page: Page):
             "references": [{"target": "target1", "version": "1.0"}],
         },
     ]
-    packages = upload_pteam_packages(USER1, pteam1["pteam_id"], "repoA", ext_packages)
+    upload_pteam_packages(USER1, pteam1["pteam_id"], "repoA", ext_packages)
     create_vuln(USER1, VULN1)
     create_vuln(USER1, VULN2)
 
@@ -77,9 +83,18 @@ def test_show_package_page_directly(page: Page):
     service_id = services[0]["service_id"]
 
     # goto package page directly
+    package_versions_summary = get_pteam_package_versions_summary(
+        USER1, pteam1["pteam_id"], service_id
+    )
+    package_version = next(
+        package_version
+        for package_version in package_versions_summary["package_versions"]
+        if package_version["package_name"] == PACKAGE2["package_name"]
+        and package_version["ecosystem"] == PACKAGE2["ecosystem"]
+        and package_version["package_version"] == "1.0"
+    )
+    path = "/package_versions/" + package_version["package_version_id"]
     params = urlencode({"pteamId": pteam1["pteam_id"], "serviceId": service_id})
-    # packages[0] is PACKAGE2 because sort by package name and ecosystem
-    path = "/package_versions/" + packages[0]["package_version_id"]
     url = urljoin(base_url, path) + "?" + params
     page.goto(url)
 
@@ -92,7 +107,7 @@ def test_show_package_page_directly(page: Page):
     # package page
     expect(page).to_have_url(re.compile(path))
 
-    package_title = packages[0]["package_name"]
+    package_title = package_version["package_name"]
     heading = page.get_by_role("heading", name=package_title)
     heading.wait_for(timeout=10000)
     expect(heading).to_have_text(package_title)


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- #1337 のE2Eテスト修正（後続対応）
  - パッケージページへの直接遷移テストで、旧パス `/packages/<package_id>` を使用していたため、新パス `/package_versions/<package_version_id>` へ修正

## 実施したテスト項目

- ローカル環境でe2etests実行
- 本ブランチ上のCIでe2etests実行


<!-- I want to review in Japanese. -->