### PR TITLE
最後のチーム退出後の古いチームURLを補正する

### DIFF
--- a/web/src/pages/App/OutletWithCheckedParams.jsx
+++ b/web/src/pages/App/OutletWithCheckedParams.jsx
@@ -6,7 +6,7 @@ import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetUserMeQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
-import { navigateSpecifiedPteam } from "../../utils/locationNavigator";
+import { getSpecifiedPteamNavigationTarget } from "../../utils/locationNavigator";
 
 export function OutletWithCheckedParams() {
   const { t } = useTranslation("app", { keyPrefix: "OutletWithCheckedParams" });
@@ -22,14 +22,17 @@ export function OutletWithCheckedParams() {
     isFetching: userMeIsFetching,
   } = useGetUserMeQuery(undefined, { skip });
 
+  const navigationTarget =
+    userMe && !userMeIsFetching ? getSpecifiedPteamNavigationTarget(location, userMe) : null;
+
   useEffect(() => {
-    if (!userMe || userMeIsFetching) return;
-    navigateSpecifiedPteam(location, userMe, navigate);
-  }, [navigate, location, userMe, userMeIsFetching]);
+    if (navigationTarget) navigate(navigationTarget);
+  }, [navigate, navigationTarget]);
 
   if (skip) return <></>;
   if (userMeError) throw new APIError(errorToString(userMeError), { api: "getUserMe" });
   if (userMeIsLoading) return <>{t("loading")}</>;
+  if (navigationTarget) return <></>;
 
   return <Outlet />;
 }

--- a/web/src/pages/App/__tests__/OutletWithCheckedParams.test.jsx
+++ b/web/src/pages/App/__tests__/OutletWithCheckedParams.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
+import { useGetUserMeQuery } from "../../../services/tcApi";
+import { OutletWithCheckedParams } from "../OutletWithCheckedParams";
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Outlet: () => <main>Checked outlet</main>,
+    useLocation: vi.fn(),
+    useNavigate: vi.fn(),
+  };
+});
+
+vi.mock("../../../hooks/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useSkipUntilAuthUserIsReady: vi.fn(),
+  };
+});
+
+vi.mock("../../../services/tcApi", () => ({
+  useGetUserMeQuery: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+describe("OutletWithCheckedParams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useSkipUntilAuthUserIsReady).mockReturnValue(false);
+    vi.mocked(useNavigate).mockReturnValue(vi.fn());
+    vi.mocked(useLocation).mockReturnValue({
+      pathname: "/pteam",
+      search: "?pteamId=removed-team",
+    });
+    vi.mocked(useGetUserMeQuery).mockReturnValue({
+      data: {
+        user_id: "user-1",
+        default_pteam_id: null,
+        pteam_roles: [],
+      },
+      error: undefined,
+      isLoading: false,
+      isFetching: false,
+    });
+  });
+
+  it("redirects invalid team URLs before rendering child routes", async () => {
+    const navigate = vi.fn();
+    vi.mocked(useNavigate).mockReturnValue(navigate);
+
+    render(<OutletWithCheckedParams />);
+
+    expect(screen.queryByText("Checked outlet")).not.toBeInTheDocument();
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith("/pteam"));
+  });
+
+  it("renders child routes when the current team is valid", () => {
+    vi.mocked(useLocation).mockReturnValue({
+      pathname: "/pteam",
+      search: "?pteamId=team-1",
+    });
+    vi.mocked(useGetUserMeQuery).mockReturnValue({
+      data: {
+        user_id: "user-1",
+        default_pteam_id: null,
+        pteam_roles: [{ pteam: { pteam_id: "team-1" } }],
+      },
+      error: undefined,
+      isLoading: false,
+      isFetching: false,
+    });
+
+    render(<OutletWithCheckedParams />);
+
+    expect(screen.getByText("Checked outlet")).toBeInTheDocument();
+  });
+});

--- a/web/src/utils/__tests__/locationNavigator.test.ts
+++ b/web/src/utils/__tests__/locationNavigator.test.ts
@@ -1,84 +1,99 @@
-import { expect, test, vi } from "vitest";
+import { expect, test } from "vitest";
 
-import { navigateSpecifiedPteam } from "../locationNavigator";
+import { getSpecifiedPteamNavigationTarget } from "../locationNavigator";
 
 type TestCase = {
   locationPathname: string;
   locationSearch: string;
   pteamRoles: {
     pteam_roles: Array<{ pteam: { pteam_id: string } }>;
+    default_pteam_id?: string | null;
   };
-  navigateCallCount: number;
-  expectedParam: string;
+  expectedTarget: string | null;
 };
 
 const cases: TestCase[] = [
-  // not navigate
   {
     locationPathname: "/",
     locationSearch: "?pteamId=dummyPteamId1",
     pteamRoles: { pteam_roles: [{ pteam: { pteam_id: "dummyPteamId1" } }] },
-    navigateCallCount: 0,
-    expectedParam: "",
+    expectedTarget: null,
   },
-  // navigate location.pathname in status page
   {
     locationPathname: "/",
     locationSearch: "?pteamId=dummyPteamId1",
     pteamRoles: { pteam_roles: [] },
-    navigateCallCount: 1,
-    expectedParam: "",
+    expectedTarget: "/",
   },
-  // navigate location.pathname in package page
   {
     locationPathname: "/package_versions/dummyPackageVersionId1",
     locationSearch: "?pteamId=dummyPteamId1",
     pteamRoles: { pteam_roles: [] },
-    navigateCallCount: 1,
-    expectedParam: "",
+    expectedTarget: "/package_versions/dummyPackageVersionId1",
   },
-  // navigate location.pathname in pteam page
   {
     locationPathname: "/pteam",
     locationSearch: "?pteamId=dummyPteamId1",
     pteamRoles: { pteam_roles: [] },
-    navigateCallCount: 1,
-    expectedParam: "",
+    expectedTarget: "/pteam",
   },
-  // not navigate in other page
   {
     locationPathname: "/other",
     locationSearch: "?pteamId=dummyPteamId1",
     pteamRoles: { pteam_roles: [] },
-    navigateCallCount: 0,
-    expectedParam: "",
+    expectedTarget: null,
   },
-  // navigate location.pathname and pteamId in status page
   {
     locationPathname: "/",
     locationSearch: "",
     pteamRoles: { pteam_roles: [{ pteam: { pteam_id: "pteamId1" } }] },
-    navigateCallCount: 1,
-    expectedParam: "pteamId=pteamId1",
+    expectedTarget: "/?pteamId=pteamId1",
+  },
+  {
+    locationPathname: "/pteam",
+    locationSearch: "?pteamId=removedPteamId",
+    pteamRoles: { pteam_roles: [] },
+    expectedTarget: "/pteam",
+  },
+  {
+    locationPathname: "/pteam",
+    locationSearch: "?pteamId=removedPteamId&serviceId=serviceId1",
+    pteamRoles: {
+      pteam_roles: [{ pteam: { pteam_id: "defaultPteamId" } }],
+      default_pteam_id: "defaultPteamId",
+    },
+    expectedTarget: "/pteam?pteamId=defaultPteamId&serviceId=serviceId1",
+  },
+  {
+    locationPathname: "/pteam",
+    locationSearch: "?pteamId=removedPteamId",
+    pteamRoles: {
+      pteam_roles: [{ pteam: { pteam_id: "fallbackPteamId" } }],
+      default_pteam_id: "removedPteamId",
+    },
+    expectedTarget: "/pteam?pteamId=fallbackPteamId",
   },
 ];
 
 test.each(cases)(
-  "navigateSpecifiedPteam test",
-  ({ locationPathname, locationSearch, pteamRoles, navigateCallCount, expectedParam }) => {
+  "getSpecifiedPteamNavigationTarget returns the correction target",
+  ({ locationPathname, locationSearch, pteamRoles, expectedTarget }) => {
     const location = {
       pathname: locationPathname,
       search: locationSearch,
     };
-    const mockNavigate = vi.fn();
 
-    navigateSpecifiedPteam(location, pteamRoles, mockNavigate);
+    const target = getSpecifiedPteamNavigationTarget(location, pteamRoles);
 
-    expect(mockNavigate).toBeCalledTimes(navigateCallCount);
-    if (navigateCallCount === 1) {
-      const expectNavigatePath =
-        expectedParam === "" ? locationPathname : locationPathname + "?" + expectedParam;
-      expect(mockNavigate).toHaveBeenCalledWith(expectNavigatePath);
-    }
+    expect(target).toBe(expectedTarget);
   },
 );
+
+test("getSpecifiedPteamNavigationTarget returns null when pteam does not need correction", () => {
+  const target = getSpecifiedPteamNavigationTarget(
+    { pathname: "/pteam", search: "?pteamId=pteamId1" },
+    { pteam_roles: [{ pteam: { pteam_id: "pteamId1" } }] },
+  );
+
+  expect(target).toBeNull();
+});

--- a/web/src/utils/locationNavigator.ts
+++ b/web/src/utils/locationNavigator.ts
@@ -1,4 +1,4 @@
-import type { Location, NavigateFunction } from "react-router-dom";
+import type { Location } from "react-router-dom";
 
 import { LocationReader } from "./LocationReader";
 
@@ -7,30 +7,35 @@ type UserMe = {
   default_pteam_id?: string | null;
 };
 
-export const navigateSpecifiedPteam = (
+export const getSpecifiedPteamNavigationTarget = (
   location: Pick<Location, "pathname" | "search">,
   userMe: UserMe,
-  navigate: NavigateFunction,
-): void => {
+): string | null => {
   const params = new URLSearchParams(location.search);
   const locationReader = new LocationReader(location);
 
-  if (
-    locationReader.isStatusPage() ||
-    locationReader.isPackagePage() ||
-    locationReader.isPTeamPage()
-  ) {
-    if (userMe.pteam_roles.length === 0) {
-      if (params.get("pteamId")) {
-        navigate(location.pathname);
-      }
-      return;
-    }
-    const pteamIdx =
-      params.get("pteamId") || userMe.default_pteam_id || userMe.pteam_roles[0].pteam.pteam_id;
-    if (params.get("pteamId") !== pteamIdx) {
-      params.set("pteamId", pteamIdx);
-      navigate(location.pathname + "?" + params.toString());
-    }
+  const needsPteam =
+    locationReader.isStatusPage() || locationReader.isPackagePage() || locationReader.isPTeamPage();
+
+  if (!needsPteam) return null;
+
+  const currentPteamId = params.get("pteamId");
+  const pteamIds = userMe.pteam_roles.map((pteamRole) => pteamRole.pteam.pteam_id);
+
+  if (pteamIds.length === 0) {
+    return currentPteamId ? location.pathname : null;
   }
+
+  const defaultPteamId = userMe.default_pteam_id;
+  const pteamId =
+    currentPteamId && pteamIds.includes(currentPteamId)
+      ? currentPteamId
+      : defaultPteamId && pteamIds.includes(defaultPteamId)
+        ? defaultPteamId
+        : pteamIds[0];
+
+  if (currentPteamId === pteamId) return null;
+
+  params.set("pteamId", pteamId);
+  return location.pathname + "?" + params.toString();
 };


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- バグ改修
  - 最後に所属しているチームからUIで抜けた後、古い `pteamId` が残った `/pteam` 画面で `getPTeamMembers` のエラー画面になる問題を修正

## 経緯・意図・意思決定

チームメンバー削除後は RTK Query のタグ invalidation により `userMe` と `getPTeamMembers` が再取得される。
その際、URL補正を `useEffect` だけに任せると、古い `pteamId` の子画面が先に描画され、`getPTeamMembers` の再取得結果によって ErrorBoundary に落ちる問題があった。

そのため、`OutletWithCheckedParams` で現在の `pteamId` が `userMe.pteam_roles` に含まれるかを描画前に判定し、補正が必要な間は子 route を描画しないようにした。
補正先は、有効な `default_pteam_id`、なければ先頭の所属チーム、所属チームがなければクエリなしの同一パスとした。

## 実施したテスト項目

- 1件のチームに所属する状態で、チームから抜ける

<!-- I want to review in Japanese. -->