### PR TITLE
Statusページでサービスのロケーションを編集可能にする

### DIFF
--- a/web/public/locales/en/status.json
+++ b/web/public/locales/en/status.json
@@ -80,11 +80,19 @@
     "deploymentN": "Deployment {{n}}",
     "done": "Done",
     "edit": "Edit",
+    "address": "Address",
+    "addressPlaceholder": "Tokyo office, production region, etc.",
+    "countryCode": "Country Code",
+    "countryCodePlaceholder": "JP",
     "ipAddress": "IP Address",
+    "ipAddresses": "IP Addresses",
+    "ipAddressesPlaceholder": "192.168.0.1, 10.0.0.0/24",
     "location": "Location",
+    "noIpAddresses": "No IP addresses registered.",
     "noDeployments": "No deployments registered.",
     "notSet": "Not set",
-    "removeDeployment": "Remove deployment"
+    "removeDeployment": "Remove deployment",
+    "tooLongAssetAddress": "Too long asset address. Max length is {{maxHalf}} in half-width or {{maxFull}} in full-width"
   },
   "DependenciesCard": {
     "license": "License",

--- a/web/public/locales/ja/status.json
+++ b/web/public/locales/ja/status.json
@@ -80,11 +80,19 @@
     "deployments": "デプロイ先",
     "done": "完了",
     "edit": "編集",
+    "address": "住所",
+    "addressPlaceholder": "東京オフィス、本番リージョンなど",
+    "countryCode": "国コード",
+    "countryCodePlaceholder": "JP",
     "ipAddress": "IPアドレス",
+    "ipAddresses": "IPアドレス",
+    "ipAddressesPlaceholder": "192.168.0.1, 10.0.0.0/24",
     "location": "ロケーション",
+    "noIpAddresses": "IPアドレスが未登録です。",
     "noDeployments": "デプロイ先が未登録です。",
     "notSet": "未設定",
-    "removeDeployment": "デプロイ先を削除"
+    "removeDeployment": "デプロイ先を削除",
+    "tooLongAssetAddress": "アセットの住所が長すぎます。最大長は半角で{{maxHalf}}文字、全角で{{maxFull}}文字です。"
   },
   "DependenciesCard": {
     "license": "ライセンス",

--- a/web/src/pages/Status/SBOMManagement/DeploymentsContent.jsx
+++ b/web/src/pages/Status/SBOMManagement/DeploymentsContent.jsx
@@ -1,0 +1,196 @@
+/* eslint-disable react/prop-types */
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import { Box, CardContent, Stack, TextField, Typography } from "@mui/material";
+import { useSnackbar } from "notistack";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { maxAssetAddressLengthInHalf } from "../../../utils/const";
+import { getLengthError } from "../../../utils/SBOMManagement/formValidation";
+import { normalizeCommaSeparatedValues } from "../../../utils/SBOMManagement/sbomManagementUtils";
+
+import { fieldSx, labelSx, slate, uiRadii } from "./styleTokens";
+
+export function DeploymentsContent({ ipAddresses, address, countryCode, editing, onUpdate, open }) {
+  const { t } = useTranslation("status", { keyPrefix: "DeploymentsPanel" });
+  const { enqueueSnackbar } = useSnackbar();
+  const [ipAddressesText, setIpAddressesText] = useState(ipAddresses.join(", "));
+  const display = { md: "block", xs: open ? "block" : "none" };
+  const normalizedCountryCode = countryCode || "";
+  const normalizedAddress = address || "";
+  const hasLocation = normalizedCountryCode || normalizedAddress;
+
+  useEffect(() => {
+    if (editing) {
+      setIpAddressesText(ipAddresses.join(", "));
+    }
+    // Reset only when entering edit mode; keep the raw comma-separated text while typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editing]);
+
+  const emptyText = (
+    <Box component="span" sx={{ color: slate[400] }}>
+      {t("notSet")}
+    </Box>
+  );
+
+  if (editing) {
+    return (
+      <CardContent sx={{ display, minWidth: 0, pb: 1.5, pt: 0, px: 2 }}>
+        <Stack sx={{ gap: 2 }}>
+          <Box>
+            <Typography component="label" sx={labelSx}>
+              {t("ipAddresses")}
+            </Typography>
+            <TextField
+              fullWidth
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                setIpAddressesText(nextValue);
+                onUpdate({ ipAddresses: normalizeCommaSeparatedValues(nextValue) });
+              }}
+              placeholder={t("ipAddressesPlaceholder")}
+              sx={{ ...fieldSx, mt: 1 }}
+              value={ipAddressesText}
+            />
+          </Box>
+          <Box>
+            <Typography component="label" sx={labelSx}>
+              {t("countryCode")}
+            </Typography>
+            <TextField
+              fullWidth
+              inputProps={{ maxLength: 2 }}
+              onChange={(event) => {
+                onUpdate({ countryCode: event.target.value.toUpperCase() });
+              }}
+              placeholder={t("countryCodePlaceholder")}
+              sx={{ ...fieldSx, mt: 1 }}
+              value={normalizedCountryCode}
+            />
+          </Box>
+          <Box>
+            <Typography component="label" sx={labelSx}>
+              {t("address")}
+            </Typography>
+            <TextField
+              fullWidth
+              onChange={(event) => {
+                const nextAddress = event.target.value;
+                const error = getLengthError(
+                  t,
+                  nextAddress,
+                  maxAssetAddressLengthInHalf,
+                  "tooLongAssetAddress",
+                );
+                if (error) {
+                  enqueueSnackbar(error, { variant: "error" });
+                  return;
+                }
+
+                onUpdate({ address: nextAddress });
+              }}
+              placeholder={t("addressPlaceholder")}
+              sx={{ ...fieldSx, mt: 1 }}
+              value={normalizedAddress}
+            />
+          </Box>
+        </Stack>
+      </CardContent>
+    );
+  }
+
+  return (
+    <CardContent sx={{ display, minWidth: 0, pb: 1.5, pt: 0, px: 2 }}>
+      <Stack sx={{ gap: 2 }}>
+        <Box>
+          <Typography sx={labelSx}>{t("ipAddresses")}</Typography>
+          <Stack sx={{ gap: 1, mt: 1 }}>
+            {ipAddresses.length > 0 ? (
+              ipAddresses.map((ipAddress, index) => (
+                <Box
+                  key={`${ipAddress}-${index}`}
+                  sx={{
+                    bgcolor: slate[50],
+                    border: `1px solid ${slate[200]}`,
+                    borderRadius: uiRadii.field,
+                    color: slate[800],
+                    fontSize: 14,
+                    fontWeight: 600,
+                    p: 1.5,
+                  }}
+                >
+                  {ipAddress}
+                </Box>
+              ))
+            ) : (
+              <Box
+                sx={{
+                  border: `1px dashed ${slate[300]}`,
+                  borderRadius: uiRadii.field,
+                  color: slate[500],
+                  fontSize: 14,
+                  p: 2.5,
+                  textAlign: "center",
+                }}
+              >
+                {t("noIpAddresses")}
+              </Box>
+            )}
+          </Stack>
+        </Box>
+
+        <Box>
+          <Typography sx={labelSx}>{t("location")}</Typography>
+          {hasLocation ? (
+            <Box
+              sx={{
+                bgcolor: slate[50],
+                border: `1px solid ${slate[200]}`,
+                borderRadius: uiRadii.field,
+                mt: 1,
+                p: 1.5,
+              }}
+            >
+              <Stack
+                direction="row"
+                alignItems="flex-start"
+                sx={{ color: slate[800], gap: 1.25, minWidth: 0 }}
+              >
+                <LocationOnIcon sx={{ color: slate[400], flexShrink: 0, fontSize: 18, mt: 0.25 }} />
+                <Stack sx={{ gap: 1, minWidth: 0 }}>
+                  <Box>
+                    <Typography sx={{ color: slate[500], fontSize: 12, fontWeight: 700 }}>
+                      {t("countryCode")}
+                    </Typography>
+                    <Typography sx={{ color: slate[800], fontSize: 14, fontWeight: 600, mt: 0.5 }}>
+                      {normalizedCountryCode || emptyText}
+                    </Typography>
+                  </Box>
+                  <Box>
+                    <Typography sx={{ color: slate[500], fontSize: 12, fontWeight: 700 }}>
+                      {t("address")}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        color: slate[800],
+                        fontSize: 14,
+                        fontWeight: 600,
+                        mt: 0.5,
+                        overflowWrap: "anywhere",
+                      }}
+                    >
+                      {normalizedAddress || emptyText}
+                    </Typography>
+                  </Box>
+                </Stack>
+              </Stack>
+            </Box>
+          ) : (
+            <Typography sx={{ color: slate[400], fontSize: 14, mt: 1 }}>{t("notSet")}</Typography>
+          )}
+        </Box>
+      </Stack>
+    </CardContent>
+  );
+}

--- a/web/src/pages/Status/SBOMManagement/DeploymentsPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/DeploymentsPanel.jsx
@@ -1,136 +1,20 @@
 /* eslint-disable react/prop-types */
-import AddIcon from "@mui/icons-material/Add";
 import CheckIcon from "@mui/icons-material/Check";
-import CloseIcon from "@mui/icons-material/Close";
 import EditIcon from "@mui/icons-material/Edit";
-import LocationOnIcon from "@mui/icons-material/LocationOn";
 import StorageRoundedIcon from "@mui/icons-material/StorageRounded";
-import { Box, Card, CardContent, IconButton, Stack, TextField, Typography } from "@mui/material";
+import { Card, Stack } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
+import { DeploymentsContent } from "./DeploymentsContent";
 import { AccordionHeader, CountBadge, HeaderActionButton } from "./sharedUiParts";
-import { fieldSx, slate, statusCardSx, uiRadii } from "./styleTokens";
-
-function DeploymentList({ deployments, editing, onRemove, onUpdate, open }) {
-  const { t } = useTranslation("status", { keyPrefix: "DeploymentsPanel" });
-  const display = { md: "block", xs: open ? "block" : "none" };
-
-  return (
-    <CardContent sx={{ display, minWidth: 0, pb: 1.5, pt: 0, px: 2 }}>
-      <Stack sx={{ gap: 1.5 }}>
-        {deployments.length > 0 ? (
-          deployments.map((deployment, index) => (
-            <Box
-              key={deployment.id}
-              sx={{
-                bgcolor: slate[50],
-                border: `1px solid ${slate[200]}`,
-                borderRadius: uiRadii.field,
-                p: 1.5,
-              }}
-            >
-              <Stack
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-                sx={{ mb: 1.25 }}
-              >
-                <Typography sx={{ color: slate[700], fontSize: 14, fontWeight: 700 }}>
-                  {t("deploymentN", { n: index + 1 })}
-                </Typography>
-                {editing && (
-                  <IconButton
-                    aria-label={t("removeDeployment")}
-                    onClick={() => onRemove(deployment.id)}
-                    size="small"
-                    sx={{ color: slate[400], "&:hover": { bgcolor: "white", color: slate[900] } }}
-                  >
-                    <CloseIcon sx={{ fontSize: 18 }} />
-                  </IconButton>
-                )}
-              </Stack>
-              {editing ? (
-                <Stack sx={{ gap: 1.25 }}>
-                  <TextField
-                    fullWidth
-                    onChange={(event) => onUpdate(deployment.id, { ip: event.target.value })}
-                    placeholder={t("ipAddress")}
-                    sx={fieldSx}
-                    value={deployment.ip}
-                  />
-                  <TextField
-                    disabled
-                    fullWidth
-                    placeholder={t("location")}
-                    sx={fieldSx}
-                    value={deployment.location}
-                  />
-                </Stack>
-              ) : (
-                <Stack sx={{ gap: 1.25 }}>
-                  <Box>
-                    <Typography sx={{ color: slate[500], fontSize: 12, fontWeight: 700 }}>
-                      {t("ipAddress")}
-                    </Typography>
-                    <Typography sx={{ color: slate[800], fontSize: 14, fontWeight: 600, mt: 0.5 }}>
-                      {deployment.ip || (
-                        <Box component="span" sx={{ color: slate[400] }}>
-                          {t("notSet")}
-                        </Box>
-                      )}
-                    </Typography>
-                  </Box>
-                  <Box>
-                    <Typography sx={{ color: slate[500], fontSize: 12, fontWeight: 700 }}>
-                      {t("location")}
-                    </Typography>
-                    <Stack
-                      direction="row"
-                      alignItems="center"
-                      sx={{ color: slate[800], fontSize: 14, fontWeight: 600, gap: 1, mt: 0.5 }}
-                    >
-                      <LocationOnIcon sx={{ color: slate[400], fontSize: 18 }} />
-                      <Typography
-                        component="span"
-                        sx={{ color: "inherit", fontSize: 14, fontWeight: 600 }}
-                      >
-                        {deployment.location || (
-                          <Box component="span" sx={{ color: slate[400] }}>
-                            {t("notSet")}
-                          </Box>
-                        )}
-                      </Typography>
-                    </Stack>
-                  </Box>
-                </Stack>
-              )}
-            </Box>
-          ))
-        ) : (
-          <Box
-            sx={{
-              border: `1px dashed ${slate[300]}`,
-              borderRadius: uiRadii.field,
-              color: slate[500],
-              fontSize: 14,
-              p: 2.5,
-              textAlign: "center",
-            }}
-          >
-            {t("noDeployments")}
-          </Box>
-        )}
-      </Stack>
-    </CardContent>
-  );
-}
+import { statusCardSx } from "./styleTokens";
 
 export function DeploymentsPanel({
-  deployments,
+  ipAddresses,
+  countryCode,
+  address,
   editing,
-  onAdd,
   onCommit,
-  onRemove,
   onToggle,
   onUpdate,
   open,
@@ -146,21 +30,7 @@ export function DeploymentsPanel({
       <AccordionHeader
         action={
           <Stack direction="row" alignItems="center" sx={{ gap: 1, height: 32 }}>
-            <CountBadge>{t("countItems", { count: deployments.length })}</CountBadge>
-            {editing && (
-              <HeaderActionButton
-                icon={AddIcon}
-                onClick={onAdd}
-                sx={{
-                  display: {
-                    md: "inline-flex",
-                    xs: open ? "inline-flex" : "none",
-                  },
-                }}
-              >
-                {t("add")}
-              </HeaderActionButton>
-            )}
+            <CountBadge>{t("countItems", { count: ipAddresses.length })}</CountBadge>
             <HeaderActionButton
               active={editing}
               icon={editing ? CheckIcon : EditIcon}
@@ -175,10 +45,11 @@ export function DeploymentsPanel({
         open={open}
         title={t("deployments")}
       />
-      <DeploymentList
-        deployments={deployments}
+      <DeploymentsContent
+        ipAddresses={ipAddresses}
+        countryCode={countryCode}
+        address={address}
         editing={editing}
-        onRemove={onRemove}
         onUpdate={onUpdate}
         open={open}
       />

--- a/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
+++ b/web/src/pages/Status/SBOMManagement/DetailsPanel.jsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
 import { maxDescriptionLengthInHalf, maxServiceNameLengthInHalf } from "../../../utils/const";
 import { collapseSpaces } from "../../../utils/displayText";
 import { getLengthError, getTagsError } from "../../../utils/SBOMManagement/formValidation";
-import { normalizeTags } from "../../../utils/SBOMManagement/sbomManagementUtils";
+import { normalizeCommaSeparatedValues } from "../../../utils/SBOMManagement/sbomManagementUtils";
 
 import { ServiceIdCopyButton } from "./ServiceIdCopyButton";
 import { AccordionHeader, AppButton, HeaderActionButton } from "./sharedUiParts";
@@ -345,7 +345,7 @@ function DetailsForm({ editing, onUpdate, open, sbom }) {
           fullWidth
           onChange={(event) => {
             const raw = event.target.value;
-            const nextTags = normalizeTags(raw);
+            const nextTags = normalizeCommaSeparatedValues(raw);
             const error = getTagsError(t, nextTags);
             if (error) {
               showInputError(error);

--- a/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
+++ b/web/src/pages/Status/SBOMManagement/SBOMManagement.jsx
@@ -173,9 +173,10 @@ export function SBOMManagement({
               <RiskSettingsCard onSave={riskSettings.onSave} sbom={activeService} />
 
               <DeploymentsPanel
-                deployments={activeService.deployments}
+                ipAddresses={activeService.ipAddresses}
+                countryCode={activeService.countryCode}
+                address={activeService.address}
                 editing={deployments.editing}
-                onAdd={deployments.onAdd}
                 onCommit={() => {
                   if (deployments.editing) {
                     deployments.onCommit();
@@ -183,7 +184,6 @@ export function SBOMManagement({
                     deployments.beginEditing();
                   }
                 }}
-                onRemove={deployments.onRemove}
                 onToggle={deployments.onToggle}
                 onUpdate={deployments.onUpdate}
                 open={deployments.open}

--- a/web/src/pages/Status/SBOMManagement/SBOMManagement.stories.helpers.js
+++ b/web/src/pages/Status/SBOMManagement/SBOMManagement.stories.helpers.js
@@ -64,10 +64,9 @@ export function createDefaultSboms() {
       tags: ["backend", "api", "critical"],
       imageUrl:
         "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?q=80&w=900&auto=format&fit=crop",
-      deployments: [
-        { id: "dep-1", ip: "10.24.8.15", location: "Tokyo / prod-a" },
-        { id: "dep-2", ip: "10.24.8.16", location: "Tokyo / prod-b" },
-      ],
+      ipAddresses: ["10.24.8.15", "10.24.8.16"],
+      countryCode: "JP",
+      address: "Tokyo / prod-a",
       dependencies: generateDependencies(97, "maven"),
     },
     {
@@ -77,7 +76,9 @@ export function createDefaultSboms() {
       tags: ["frontend", "react"],
       imageUrl:
         "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?q=80&w=900&auto=format&fit=crop",
-      deployments: [{ id: "dep-3", ip: "172.18.0.42", location: "Osaka / staging" }],
+      ipAddresses: ["172.18.0.42"],
+      countryCode: "JP",
+      address: "Osaka / staging",
       dependencies: generateDependencies(7, "npm"),
     },
   ];

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementController.js
@@ -61,11 +61,9 @@ export function useSBOMManagementController({
         state.setDeploymentsOpen(true);
         state.setDeploymentsEditing(true);
       },
-      onAdd: mutations.addDeployment,
       onCommit: mutations.commitDeploymentsEdit,
-      onRemove: mutations.removeDeployment,
       onToggle: () => state.setDeploymentsOpen((open) => !open),
-      onUpdate: mutations.updateDeployment,
+      onUpdate: mutations.updateDeploymentSettings,
       open: state.deploymentsOpen,
     },
     details: {

--- a/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
+++ b/web/src/pages/Status/SBOMManagement/useSBOMManagementMutations.js
@@ -8,9 +8,9 @@ import {
   useUpdatePTeamServiceThumbnailMutation,
 } from "../../../services/tcApi";
 import {
-  createId,
   getNextActiveIdAfterRemoval,
   NEW_SBOM_ID,
+  normalizeCommaSeparatedValues,
 } from "../../../utils/SBOMManagement/sbomManagementUtils";
 import { serviceImageMaxSize } from "../../../utils/const";
 import { errorToString } from "../../../utils/func";
@@ -57,42 +57,12 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
     resetUiState();
   };
 
-  const addDeployment = () => {
+  const updateDeploymentSettings = (patch) => {
     if (!activeService) {
       return;
     }
 
-    updateActiveService({
-      deployments: [...activeService.deployments, { id: createId("dep"), ip: "", location: "" }],
-    });
-  };
-
-  const updateDeployment = (deploymentId, patch) => {
-    if (!activeService) {
-      return;
-    }
-
-    updateActiveService({
-      deployments: activeService.deployments.map((deployment) =>
-        deployment.id === deploymentId ? { ...deployment, ...patch } : deployment,
-      ),
-    });
-  };
-
-  const removeDeployment = (deploymentId) => {
-    if (!activeService) {
-      return;
-    }
-
-    const confirmed = typeof window === "undefined" || window.confirm(t("confirmRemoveDeployment"));
-
-    if (!confirmed) {
-      return;
-    }
-
-    updateActiveService({
-      deployments: activeService.deployments.filter((deployment) => deployment.id !== deploymentId),
-    });
+    updateActiveService(patch);
   };
 
   const openUpdateSbomDialog = () => {
@@ -194,14 +164,20 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
       return;
     }
 
-    const ipAddresses = activeService.deployments
-      .map((deployment) => deployment.ip.trim())
-      .filter(Boolean);
+    const ipAddresses = normalizeCommaSeparatedValues((activeService.ipAddresses || []).join(","));
+    const countryCode = (activeService.countryCode || "").trim().toUpperCase();
+    const address = (activeService.address || "").trim();
 
     try {
       await updatePTeamService({
         path: { pteam_id: pteamId, service_id: activeService.id },
-        body: { asset: { ip_addresses: ipAddresses } },
+        body: {
+          asset: {
+            ip_addresses: ipAddresses,
+            country_code: countryCode || null,
+            address: address || null,
+          },
+        },
       }).unwrap();
       enqueueSnackbar(t("updateDeploymentsSuccess"), { variant: "success" });
       setDeploymentsEditing(false);
@@ -241,7 +217,6 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
   };
 
   return {
-    addDeployment,
     commitDeploymentsEdit,
     commitDetailsEdit,
     commitServiceImpactEdit,
@@ -249,7 +224,6 @@ export function useSBOMManagementMutations({ actions, callbacks, state }) {
     handleImageUpload,
     handleRemoveImage,
     removeActiveSbom,
-    removeDeployment,
-    updateDeployment,
+    updateDeploymentSettings,
   };
 }

--- a/web/src/pages/Status/__tests__/StatusPage.test.jsx
+++ b/web/src/pages/Status/__tests__/StatusPage.test.jsx
@@ -208,7 +208,7 @@ const updateServiceInPTeamData = (serviceId, patch) => {
   };
 };
 
-const updateServiceAssetInPTeamData = (serviceId, ipAddresses) => {
+const updateServiceAssetInPTeamData = (serviceId, assetPatch) => {
   queryPTeamData = {
     ...queryPTeamData,
     services: queryPTeamData.services.map((service) =>
@@ -217,7 +217,7 @@ const updateServiceAssetInPTeamData = (serviceId, ipAddresses) => {
             ...service,
             asset: {
               ...service.asset,
-              ip_addresses: ipAddresses,
+              ...(Array.isArray(assetPatch) ? { ip_addresses: assetPatch } : assetPatch),
             },
           }
         : service,
@@ -1272,6 +1272,107 @@ describe("StatusPage", () => {
       });
     });
 
+    it("updates ip addresses and one service location from deployments settings", async () => {
+      const testLocation = {
+        pathname: "/",
+        search:
+          "?pteamId=1d9d71ec-a341--b159-74b6d1bfffff&serviceId=50604348-fd06-4152-afd1-2f3e73c4eb9f",
+      };
+      useLocation.mockReturnValue(testLocation);
+      useSkipUntilAuthUserIsReady.mockReturnValue(false);
+
+      const testPTeamWithAsset = {
+        ...testPTeamData,
+        services: [
+          {
+            ...testPTeamData.services[0],
+            asset: {
+              ip_addresses: ["10.0.0.1", "10.0.0.2"],
+              country_code: "JP",
+              address: "Tokyo",
+            },
+          },
+          testPTeamData.services[1],
+        ],
+      };
+
+      queryPTeamData = structuredClone(testPTeamWithAsset);
+      useGetPTeamQuery.mockImplementation(() => ({
+        data: queryPTeamData,
+        error: false,
+        isFetching: false,
+        isLoading: false,
+      }));
+
+      useGetPTeamPackageVersionsSummaryQuery.mockReturnValue({
+        currentData: testPackageVersionsData,
+        error: false,
+        isFetching: false,
+      });
+
+      const updateService = createResolvedMutation(undefined, () =>
+        updateServiceAssetInPTeamData(testPTeamData.services[0].service_id, {
+          ip_addresses: ["192.168.0.1/32", "10.0.0.0/24"],
+          country_code: "US",
+          address: "New York",
+        }),
+      );
+      useUpdatePTeamServiceMutation.mockReturnValue([updateService]);
+
+      const ue = userEvent.setup();
+      const renderResult = renderStatusPage();
+
+      expect(screen.getByText("10.0.0.1")).toBeInTheDocument();
+      expect(screen.getByText("10.0.0.2")).toBeInTheDocument();
+      expect(screen.getByText("JP")).toBeInTheDocument();
+      expect(screen.getByText("Tokyo")).toBeInTheDocument();
+
+      await ue.click(screen.getAllByRole("button", { name: "Edit" })[2]);
+      await ue.clear(screen.getByPlaceholderText("192.168.0.1, 10.0.0.0/24"));
+      await ue.type(
+        screen.getByPlaceholderText("192.168.0.1, 10.0.0.0/24"),
+        "192.168.0.1, 10.0.0.0/24",
+      );
+      await ue.clear(screen.getByPlaceholderText("JP"));
+      await ue.type(screen.getByPlaceholderText("JP"), "us");
+      await ue.clear(screen.getByPlaceholderText("Tokyo office, production region, etc."));
+      await ue.type(
+        screen.getByPlaceholderText("Tokyo office, production region, etc."),
+        "New York",
+      );
+
+      await ue.click(screen.getByRole("button", { name: "Done" }));
+
+      await waitFor(() => {
+        expect(updateService).toHaveBeenCalledWith({
+          path: {
+            pteam_id: testPTeamData.pteam_id,
+            service_id: testPTeamData.services[0].service_id,
+          },
+          body: {
+            asset: {
+              ip_addresses: ["192.168.0.1", "10.0.0.0/24"],
+              country_code: "US",
+              address: "New York",
+            },
+          },
+        });
+      });
+
+      renderResult.rerender(
+        <Provider store={store}>
+          <Status />
+        </Provider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("192.168.0.1/32")).toBeInTheDocument();
+      });
+      expect(screen.getByText("10.0.0.0/24")).toBeInTheDocument();
+      expect(screen.getByText("US")).toBeInTheDocument();
+      expect(screen.getByText("New York")).toBeInTheDocument();
+    });
+
     it("navigate to package detail when a package row is clicked", async () => {
       const testLocation = {
         pathname: "/",
@@ -1318,7 +1419,9 @@ describe("StatusPage", () => {
           systemExposure: "small",
           missionImpact: "mef_support_crippled",
           imageUrl: "",
-          deployments: [],
+          ipAddresses: [],
+          countryCode: "",
+          address: "",
         },
         pteamId: testPTeamData.pteam_id,
         serviceTabs: [
@@ -1348,7 +1451,9 @@ describe("StatusPage", () => {
           systemExposure: "small",
           missionImpact: "mef_support_crippled",
           imageUrl: "",
-          deployments: [],
+          ipAddresses: [],
+          countryCode: "",
+          address: "",
         },
         onActiveIdChange,
         pteamId: testPTeamData.pteam_id,

--- a/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
+++ b/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
@@ -5,6 +5,7 @@ import {
   buildDependencyRows,
   buildServiceTabsFromPTeam,
   isDeleteConfirmationValid,
+  normalizeCommaSeparatedValues,
 } from "../sbomManagementUtils";
 
 const services = [
@@ -51,6 +52,10 @@ const packages = [
 ];
 
 describe("sbomManagementUtils", () => {
+  it("normalizes comma-separated values by trimming and dropping empty items", () => {
+    expect(normalizeCommaSeparatedValues(" a, ,b ,")).toEqual(["a", "b"]);
+  });
+
   it("builds tab data without per-service details", () => {
     expect(buildServiceTabsFromPTeam(services)).toEqual([
       { id: "service-1", title: "Service One" },

--- a/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
+++ b/web/src/utils/SBOMManagement/__tests__/sbomManagementUtils.test.js
@@ -17,6 +17,8 @@ const services = [
     service_mission_impact: "mef_failure",
     asset: {
       ip_addresses: ["10.0.0.1", "10.0.0.2"],
+      country_code: "JP",
+      address: "Tokyo",
     },
   },
   {
@@ -67,10 +69,17 @@ describe("sbomManagementUtils", () => {
       systemExposure: "controlled",
       missionImpact: "mef_failure",
       imageUrl: "data:image/png;base64,abc",
-      deployments: [
-        { id: "dep-service-1-0", ip: "10.0.0.1", location: "" },
-        { id: "dep-service-1-1", ip: "10.0.0.2", location: "" },
-      ],
+      ipAddresses: ["10.0.0.1", "10.0.0.2"],
+      countryCode: "JP",
+      address: "Tokyo",
+    });
+  });
+
+  it("builds empty asset details when the current service has no asset", () => {
+    expect(buildCurrentServiceFromPTeam(services, "service-2")).toMatchObject({
+      ipAddresses: [],
+      countryCode: "",
+      address: "",
     });
   });
 

--- a/web/src/utils/SBOMManagement/sbomManagementUtils.js
+++ b/web/src/utils/SBOMManagement/sbomManagementUtils.js
@@ -11,6 +11,13 @@ export function normalizeTags(value) {
     .filter(Boolean);
 }
 
+export function normalizeCommaSeparatedValues(value) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export function getNextActiveIdAfterRemoval(items, removedId) {
   const removedIndex = items.findIndex((item) => item.id === removedId);
   const remaining = items.filter((item) => item.id !== removedId);
@@ -53,11 +60,9 @@ export function buildCurrentServiceFromPTeam(services, currentServiceId, imageUr
     systemExposure: service.system_exposure ?? "open",
     missionImpact: service.service_mission_impact ?? "mission_failure",
     imageUrl,
-    deployments: (service.asset?.ip_addresses || []).map((ip, index) => ({
-      id: `dep-${service.service_id}-${index}`,
-      ip,
-      location: "",
-    })),
+    ipAddresses: Array.isArray(service.asset?.ip_addresses) ? service.asset.ip_addresses : [],
+    countryCode: service.asset?.country_code || "",
+    address: service.asset?.address || "",
   };
 }
 

--- a/web/src/utils/SBOMManagement/sbomManagementUtils.js
+++ b/web/src/utils/SBOMManagement/sbomManagementUtils.js
@@ -11,10 +11,6 @@ export function normalizeCommaSeparatedValues(value) {
     .filter(Boolean);
 }
 
-export function normalizeTags(value) {
-  return normalizeCommaSeparatedValues(value);
-}
-
 export function getNextActiveIdAfterRemoval(items, removedId) {
   const removedIndex = items.findIndex((item) => item.id === removedId);
   const remaining = items.filter((item) => item.id !== removedId);

--- a/web/src/utils/SBOMManagement/sbomManagementUtils.js
+++ b/web/src/utils/SBOMManagement/sbomManagementUtils.js
@@ -4,18 +4,15 @@ export function createId(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
 }
 
-export function normalizeTags(value) {
-  return value
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
-}
-
 export function normalizeCommaSeparatedValues(value) {
   return value
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+export function normalizeTags(value) {
+  return normalizeCommaSeparatedValues(value);
 }
 
 export function getNextActiveIdAfterRemoval(items, removedId) {

--- a/web/src/utils/const.ts
+++ b/web/src/utils/const.ts
@@ -6,6 +6,7 @@ export const mainMaxWidth = 1100;
 export const maxReasonSafetyImpactLengthInHalf = 2000;
 export const maxServiceNameLengthInHalf = 255;
 export const maxDescriptionLengthInHalf = 300;
+export const maxAssetAddressLengthInHalf = 255;
 export const maxKeywordLengthInHalf = 20;
 export const maxKeywords = 5;
 export const maxPTeamNameLengthInHalf = 50;


### PR DESCRIPTION
## PR の目的

- Statusページで、API仕様に沿ってサービス単位のロケーション（country_code、address）を設定できるようにする
- IPアドレスは複数件登録できる状態を維持しつつ、編集UIをカンマ区切り入力に整理する

## 経緯・意図・意思決定

- APIではサービスに登録できるロケーションは country_code と address の1件のみだが、従来のUIはIPアドレスとロケーションをデプロイ先単位で複数件設定する形になっていた
- UIの複雑化を避けるため、IPアドレス編集は1つの入力欄にカンマ区切りで入力する方式にした
- 表示時は従来通り、IPアドレスを複数件に分けて表示する
- country_code はフロントで大文字化し、ISO 3166-1 alpha-2 としての妥当性はAPIの既存バリデーションに委ねる

## 実施したテスト項目

- UI上で下記実行
  - 国コード、住所を入力
  - IPアドレスを複数入力
  - IPアドレス、国コード、住所、をそれぞれ1件だけ入力し、入力無し項目の表示を確認
  - 国コードに存在しない2文字を入力し、エラーを確認