### PR TITLE
TypeScript移行: web/src/components と auth 関連ページ

### DIFF
--- a/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.tsx
+++ b/web/src/pages/AcceptPTeamInvitation/AcceptPTeamInvitationPage.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
+import type { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -21,13 +22,14 @@ export function AcceptPTeamInvitation() {
 
   const params = new URLSearchParams(useLocation().search);
   const tokenId = params.get("token");
+  const invitationId = tokenId ?? "";
 
-  const skip = useSkipUntilAuthUserIsReady();
+  const skip = useSkipUntilAuthUserIsReady() || !tokenId;
   const {
     data: detail,
     error: detailError,
     isLoading: detailIsLoading,
-  } = useGetPTeamInvitationQuery({ path: { invitation_id: tokenId } }, { skip });
+  } = useGetPTeamInvitationQuery({ path: { invitation_id: invitationId } }, { skip });
 
   if (skip) return <></>;
   if (detailError)
@@ -35,21 +37,28 @@ export function AcceptPTeamInvitation() {
       api: "getPTeamInvitation",
     });
   if (detailIsLoading) return <>{t("loadingUserInfo")}</>;
+  if (!detail) return <></>;
+  const invitationDetail = detail;
 
-  const handleAccept = async (event) => {
+  const handleAccept = async (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    async function onSuccess(success) {
-      enqueueSnackbar(t("nowMember", { pteamName: detail.pteam_name }), { variant: "info" });
+    async function onSuccess() {
+      enqueueSnackbar(t("nowMember", { pteamName: invitationDetail.pteam_name }), {
+        variant: "info",
+      });
       params.delete("token");
-      params.set("pteamId", detail.pteam_id);
+      params.set("pteamId", invitationDetail.pteam_id);
       navigate("/pteam?" + params.toString());
     }
-    function onError(error) {
-      enqueueSnackbar(t("acceptFailed", { error: errorToString(error) }), { variant: "error" });
+    function onError(error: unknown) {
+      enqueueSnackbar(
+        t("acceptFailed", { error: errorToString(error as Parameters<typeof errorToString>[0]) }),
+        { variant: "error" },
+      );
     }
-    await applyPTeamInvitation({ body: { invitation_id: tokenId } })
+    await applyPTeamInvitation({ body: { invitation_id: invitationId } })
       .unwrap()
-      .then((success) => onSuccess(success))
+      .then(() => onSuccess())
       .catch((error) => onError(error));
   };
 
@@ -57,16 +66,16 @@ export function AcceptPTeamInvitation() {
     <>
       <Typography variant="h6">{t("title")}</Typography>
       <Typography>
-        {t("teamName")}: {detail.pteam_name}
+        {t("teamName")}: {invitationDetail.pteam_name}
       </Typography>
       <Typography>
-        {t("teamId")}: {detail.pteam_id}
+        {t("teamId")}: {invitationDetail.pteam_id}
       </Typography>
       <Typography>
-        {t("invitationCreatedBy")}: {detail.email} ({detail.user_id})
+        {t("invitationCreatedBy")}: {invitationDetail.email} ({invitationDetail.user_id})
       </Typography>
       <Box display="flex" flexDirection="row">
-        <Button onClick={handleAccept} disabled={!detail.pteam_id} sx={commonButtonStyle}>
+        <Button onClick={handleAccept} disabled={!invitationDetail.pteam_id} sx={commonButtonStyle}>
           {t("accept")}
         </Button>
       </Box>

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/TwoFactorAuthSection/MfaSetupDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/TwoFactorAuthSection/MfaSetupDialog.jsx
@@ -23,6 +23,7 @@ import { SmsTroubleshootingTips } from "../../../../../components/SmsTroubleshoo
 import { SmsTroubleshootingToggleButton } from "../../../../../components/SmsTroubleshootingToggleButton";
 import { useAuth } from "../../../../../hooks/auth";
 import { useActionLock } from "../../../../../hooks/useActionLock";
+import { authErrorToString } from "../../../../../utils/authErrorUtils";
 import { normalizeFullwidthDigits } from "../../../../../utils/normalizeInput";
 import {
   getNationalPhoneNumber,
@@ -157,7 +158,7 @@ export function MfaSetupDialog({ open, onClose, onSuccess }) {
         setStep(1);
       })
       .catch((error) => {
-        setError(error.message);
+        setError(authErrorToString(error));
         setLoading(false);
       });
   };
@@ -172,7 +173,7 @@ export function MfaSetupDialog({ open, onClose, onSuccess }) {
         setLoading(false);
       })
       .catch((error) => {
-        setError(error.message);
+        setError(authErrorToString(error));
         setLoading(false);
       });
   };
@@ -222,7 +223,7 @@ export function MfaSetupDialog({ open, onClose, onSuccess }) {
         setRecaptchaResendKey(Date.now()); // Force re-mount recaptcha for resend
       })
       .catch((error) => {
-        setError(error.message);
+        setError(authErrorToString(error));
         setLoading(false);
       });
   };

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/TwoFactorAuthSection/TwoFactorAuthSection.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/TwoFactorAuthSection/TwoFactorAuthSection.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAuth } from "../../../../../hooks/auth";
+import { authErrorToString } from "../../../../../utils/authErrorUtils";
 
 import { DisabledMfaConfirmDialog } from "./DisabledMfaConfirmDialog";
 import { MfaSetupDialog } from "./MfaSetupDialog";
@@ -39,7 +40,7 @@ export function TwoFactorAuthSection({ onShowSnackbar }) {
         onShowSnackbar(t("disabledInfo"), "info");
       })
       .catch((error) => {
-        onShowSnackbar(error.message, "error");
+        onShowSnackbar(authErrorToString(error), "error");
       });
   };
 

--- a/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.tsx
+++ b/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.tsx
@@ -2,10 +2,12 @@ import { Link, Typography } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { useCreateUserMutation, useTryLoginMutation } from "../../services/tcApi";
+import type { RootState } from "../../store";
 import Supabase from "../../utils/Supabase";
+import { authErrorToString } from "../../utils/authErrorUtils";
 import { errorToString } from "../../utils/func";
 
 /* Note: currently, work with supabase only. */
@@ -15,11 +17,8 @@ const supabase =
 export function AuthKeycloakCallback() {
   const { t } = useTranslation("authKeycloakCallback", { keyPrefix: "AuthKeycloakCallbackPage" });
   const navigate = useNavigate();
-  const location = useLocation();
   const [message, setMessage] = useState(t("checkingAuthCode"));
-  const redirectedFrom = useSelector((state) => state.auth.redirectedFrom);
-
-  const params = new URLSearchParams(location.search);
+  const redirectedFrom = useSelector((state: RootState) => state.auth.redirectedFrom);
 
   const [tryLogin] = useTryLoginMutation();
   const [createUser] = useCreateUserMutation();
@@ -30,6 +29,10 @@ export function AuthKeycloakCallback() {
         pathname: redirectedFrom.from || "/",
         search: redirectedFrom.search ?? "",
       };
+      if (!supabase) {
+        setMessage(t("somethingWentWrong", { error: "Supabase is not configured" }));
+        return;
+      }
       const { data, error } = await supabase.auth.getSession();
       if (!data?.session) {
         console.log(error);
@@ -39,13 +42,17 @@ export function AuthKeycloakCallback() {
       try {
         await tryLogin()
           .unwrap()
-          .catch(async (error) => {
+          .catch(async (error: { data?: { detail?: string } }) => {
             switch (error.data?.detail) {
               case "No such user": {
                 await createUser({ body: {} })
                   .unwrap()
-                  .catch((error2) => {
-                    throw new Error(t("cannotCreateUser", { error: errorToString(error2) }));
+                  .catch((error2: unknown) => {
+                    throw new Error(
+                      t("cannotCreateUser", {
+                        error: errorToString(error2 as Parameters<typeof errorToString>[0]),
+                      }),
+                    );
                   });
                 if (navigateTo.pathname === "/") {
                   navigateTo.pathname = "/account";
@@ -54,11 +61,15 @@ export function AuthKeycloakCallback() {
                 break;
               }
               default:
-                throw new Error(t("somethingWentWrong", { error: errorToString(error) }));
+                throw new Error(
+                  t("somethingWentWrong", {
+                    error: errorToString(error as Parameters<typeof errorToString>[0]),
+                  }),
+                );
             }
           });
       } catch (error) {
-        setMessage(error.message);
+        setMessage(authErrorToString(error));
         console.error(error);
         return;
       }

--- a/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.tsx
+++ b/web/src/pages/AuthKeycloakCallback/AuthKeycloakCallbackPage.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { useCreateUserMutation, useTryLoginMutation } from "../../services/tcApi";
 import type { RootState } from "../../store";
 import Supabase from "../../utils/Supabase";
-import { authErrorToString } from "../../utils/authErrorUtils";
+import { authErrorToString, normalizeAuthErrorSource } from "../../utils/authErrorUtils";
 import { errorToString } from "../../utils/func";
 
 /* Note: currently, work with supabase only. */
@@ -69,7 +69,7 @@ export function AuthKeycloakCallback() {
             }
           });
       } catch (error) {
-        setMessage(authErrorToString(error));
+        setMessage(authErrorToString(normalizeAuthErrorSource(error)) ?? "An error occurred.");
         console.error(error);
         return;
       }

--- a/web/src/pages/EmailVerification/ResetPasswordForm.jsx
+++ b/web/src/pages/EmailVerification/ResetPasswordForm.jsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { PasswordField } from "../../components/PasswordField";
 import { useAuth } from "../../hooks/auth";
+import { authErrorToString } from "../../utils/authErrorUtils";
 
 export default function ResetPasswordForm(props) {
   const { t } = useTranslation("emailVerification", { keyPrefix: "ResetPasswordForm" });
@@ -40,7 +41,7 @@ export default function ResetPasswordForm(props) {
       .then(() => showMessage(t("success"), "info"))
       .catch((error) => {
         console.error(error);
-        showMessage(error.message);
+        showMessage(authErrorToString(error));
         setDisabled(false);
       });
     setIsLoading(false);

--- a/web/src/pages/EmailVerification/VerifyEmail.jsx
+++ b/web/src/pages/EmailVerification/VerifyEmail.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAuth } from "../../hooks/auth";
+import { authErrorToString } from "../../utils/authErrorUtils";
 
 export default function VerifyEmail(props) {
   const { t } = useTranslation("emailVerification", { keyPrefix: "VerifyEmail" });
@@ -21,7 +22,7 @@ export default function VerifyEmail(props) {
       })
       .catch((error) => {
         console.error(error);
-        setMessage(error.message);
+        setMessage(authErrorToString(error));
       });
   }
 

--- a/web/src/pages/Login/LoginPage.jsx
+++ b/web/src/pages/Login/LoginPage.jsx
@@ -22,6 +22,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/auth";
 import { useCreateUserMutation, useTryLoginMutation } from "../../services/tcApi";
 import Firebase from "../../utils/Firebase";
+import { authErrorToString } from "../../utils/authErrorUtils";
 
 import { TwoFactorAuth } from "./TwoFactorAuth";
 
@@ -98,7 +99,7 @@ export function Login() {
       password,
       recaptchaId: recaptchaId,
     }).catch((authError) => {
-      showMessage(authError.message);
+      showMessage(authErrorToString(authError));
       return undefined;
     });
   };
@@ -116,7 +117,7 @@ export function Login() {
           const actionCodeSettings = { url: `${window.location.origin}/login` };
           await sendEmailVerification({ actionCodeSettings })
             .then(() => showMessage(t("emailNotVerified"), "info"))
-            .catch((error) => showMessage(error.message));
+            .catch((error) => showMessage(authErrorToString(error)));
           break;
         }
         case "No such user":
@@ -185,7 +186,7 @@ export function Login() {
     const redirectTo = `${window.location.origin}/auth_keycloak_callback`;
     await signInWithRedirect({ provider: "keycloak", redirectTo })
       .catch((authError) => {
-        showMessage(authError.message);
+        showMessage(authErrorToString(authError));
         console.error(authError);
       })
       .finally(() => setIsLoggingIn(false));

--- a/web/src/pages/Login/TwoFactorAuth.jsx
+++ b/web/src/pages/Login/TwoFactorAuth.jsx
@@ -19,6 +19,7 @@ import { SmsTroubleshootingTips } from "../../components/SmsTroubleshootingTips"
 import { SmsTroubleshootingToggleButton } from "../../components/SmsTroubleshootingToggleButton";
 import { useAuth } from "../../hooks/auth";
 import { useActionLock } from "../../hooks/useActionLock";
+import { authErrorToString } from "../../utils/authErrorUtils";
 import { normalizeFullwidthDigits } from "../../utils/normalizeInput";
 
 export function TwoFactorAuth(props) {
@@ -57,7 +58,7 @@ export function TwoFactorAuth(props) {
         navigateInternalPage();
       })
       .catch((error) => {
-        setCodeError(error.message);
+        setCodeError(authErrorToString(error));
       });
   };
 
@@ -75,7 +76,7 @@ export function TwoFactorAuth(props) {
         setRecaptchaResendKey(Date.now()); // Force re-mount recaptcha for resend
       })
       .catch((error) => {
-        setCodeError(error.message);
+        setCodeError(authErrorToString(error));
       });
   };
 

--- a/web/src/pages/ResetPassword/ResetPasswordPage.tsx
+++ b/web/src/pages/ResetPassword/ResetPasswordPage.tsx
@@ -8,24 +8,24 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../hooks/auth";
+import { authErrorToString } from "../../utils/authErrorUtils";
 
 export function ResetPassword() {
   const { t } = useTranslation("resetPassword", { keyPrefix: "ResetPasswordPage" });
   const [disabled, setDisabled] = useState(false);
-  const [message, setMessage] = useState(null);
+  const [message, setMessage] = useState<string | null>(null);
 
-  const location = useLocation();
   const navigate = useNavigate();
   const { sendPasswordResetEmail } = useAuth();
 
   const handleBackToLogIn = () => navigate("/login");
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setDisabled(true);
     setMessage(t("processing"));
@@ -40,7 +40,7 @@ export function ResetPassword() {
       `${window.location.origin}${import.meta.env.VITE_PUBLIC_URL}` +
       "/email_verification?mode=resetPassword";
     await sendPasswordResetEmail({
-      email: data.get("email").trim(),
+      email: String(data.get("email") ?? "").trim(),
       actionCodeSettings,
       redirectTo,
     })
@@ -54,9 +54,9 @@ export function ResetPassword() {
         }
         setMessage(msg);
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         setDisabled(false);
-        setMessage(error.message);
+        setMessage(authErrorToString(error));
       });
   };
 

--- a/web/src/pages/ResetPassword/ResetPasswordPage.tsx
+++ b/web/src/pages/ResetPassword/ResetPasswordPage.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../hooks/auth";
-import { authErrorToString } from "../../utils/authErrorUtils";
+import { authErrorToString, normalizeAuthErrorSource } from "../../utils/authErrorUtils";
 
 export function ResetPassword() {
   const { t } = useTranslation("resetPassword", { keyPrefix: "ResetPasswordPage" });
@@ -56,7 +56,7 @@ export function ResetPassword() {
       })
       .catch((error: unknown) => {
         setDisabled(false);
-        setMessage(authErrorToString(error));
+        setMessage(authErrorToString(normalizeAuthErrorSource(error)) ?? "An error occurred.");
       });
   };
 

--- a/web/src/pages/ResetPassword/__tests__/ResetPasswordPage.test.tsx
+++ b/web/src/pages/ResetPassword/__tests__/ResetPasswordPage.test.tsx
@@ -1,14 +1,16 @@
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
 
 import { useAuth } from "../../../hooks/auth";
 import { AuthProvider } from "../../../providers/auth/AuthContext";
 import store from "../../../store";
 import { ResetPassword } from "../ResetPasswordPage";
 
-vi.mock("../../../hooks/auth", async (importOriginal) => {
+vi.mock("../../../hooks/auth", async (importOriginal: () => Promise<object>) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -20,15 +22,7 @@ const renderResetPassword = () => {
   render(
     <Provider store={store}>
       <AuthProvider>
-        <BrowserRouter
-          future={{
-            /* to prevent React Router Future Flag Warning.
-             * see https://reactrouter.com/v6/upgrading/future#v7_relativesplatpath for details.
-             */
-            v7_startTransition: true,
-            v7_relativeSplatPath: true,
-          }}
-        >
+        <BrowserRouter>
           <ResetPassword />
         </BrowserRouter>
       </AuthProvider>
@@ -36,18 +30,13 @@ const renderResetPassword = () => {
   );
 };
 
-const genApiMock = (isSuccess = true, returnValue = undefined) => {
-  const mockUnwrap = isSuccess
-    ? vi.fn().mockResolvedValue(returnValue)
-    : vi.fn().mockRejectedValue(returnValue);
-  return vi.fn().mockReturnValue({ unwrap: mockUnwrap });
-};
-
 describe("ResetPassword Component", () => {
   describe("Rendering", () => {
     it("should render ResetPassword form", () => {
-      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue();
-      useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useAuth).mockReturnValue({
+        sendPasswordResetEmail: mockSendPasswordResetEmail,
+      } as unknown as ReturnType<typeof useAuth>);
 
       renderResetPassword();
 
@@ -59,8 +48,10 @@ describe("ResetPassword Component", () => {
 
   it("should call auth API with correct parameters", async () => {
     const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
-    const mockSendPasswordResetEmail = vi.fn().mockResolvedValue();
-    useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+    const mockSendPasswordResetEmail = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useAuth).mockReturnValue({
+      sendPasswordResetEmail: mockSendPasswordResetEmail,
+    } as unknown as ReturnType<typeof useAuth>);
 
     renderResetPassword();
 
@@ -89,7 +80,9 @@ describe("ResetPassword Component", () => {
         code: "auth/invalid-email",
         message: "Invalid email format.",
       });
-      useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+      vi.mocked(useAuth).mockReturnValue({
+        sendPasswordResetEmail: mockSendPasswordResetEmail,
+      } as unknown as ReturnType<typeof useAuth>);
 
       renderResetPassword();
 
@@ -108,7 +101,9 @@ describe("ResetPassword Component", () => {
         code: "auth/user-not-found",
         message: "User not found.",
       });
-      useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+      vi.mocked(useAuth).mockReturnValue({
+        sendPasswordResetEmail: mockSendPasswordResetEmail,
+      } as unknown as ReturnType<typeof useAuth>);
 
       renderResetPassword();
 
@@ -125,8 +120,10 @@ describe("ResetPassword Component", () => {
   describe("Email trimming", () => {
     it("should trim surrounding whitespace from email before calling sendPasswordResetEmail", async () => {
       const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
-      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue();
-      useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useAuth).mockReturnValue({
+        sendPasswordResetEmail: mockSendPasswordResetEmail,
+      } as unknown as ReturnType<typeof useAuth>);
 
       renderResetPassword();
 
@@ -147,8 +144,10 @@ describe("ResetPassword Component", () => {
   describe("Form Validation", () => {
     it("should not call the callback when the Reset Password button is clicked and email is empty", async () => {
       const ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
-      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue();
-      useAuth.mockReturnValue({ sendPasswordResetEmail: mockSendPasswordResetEmail });
+      const mockSendPasswordResetEmail = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(useAuth).mockReturnValue({
+        sendPasswordResetEmail: mockSendPasswordResetEmail,
+      } as unknown as ReturnType<typeof useAuth>);
 
       renderResetPassword();
 

--- a/web/src/pages/SignUp/SignUpPage.tsx
+++ b/web/src/pages/SignUp/SignUpPage.tsx
@@ -15,7 +15,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { PasswordField } from "../../components/PasswordField";
 import { useAuth } from "../../hooks/auth";
 import { getBearerToken } from "../../services/tcApi";
-import { authErrorToString } from "../../utils/authErrorUtils";
+import { authErrorToString, normalizeAuthErrorSource } from "../../utils/authErrorUtils";
 
 type MessageState = {
   text: string;
@@ -109,7 +109,7 @@ export function SignUp() {
       await signOut();
     } catch (error) {
       console.error(error);
-      showMessage(authErrorToString(error));
+      showMessage(authErrorToString(normalizeAuthErrorSource(error)) ?? "An error occurred.");
       setDisabled(false);
 
       /**

--- a/web/src/pages/SignUp/SignUpPage.tsx
+++ b/web/src/pages/SignUp/SignUpPage.tsx
@@ -15,6 +15,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { PasswordField } from "../../components/PasswordField";
 import { useAuth } from "../../hooks/auth";
 import { getBearerToken } from "../../services/tcApi";
+import { authErrorToString } from "../../utils/authErrorUtils";
 
 type MessageState = {
   text: string;
@@ -108,7 +109,7 @@ export function SignUp() {
       await signOut();
     } catch (error) {
       console.error(error);
-      showMessage((error as Error).message);
+      showMessage(authErrorToString(error));
       setDisabled(false);
 
       /**

--- a/web/src/providers/auth/SupabaseProvider.ts
+++ b/web/src/providers/auth/SupabaseProvider.ts
@@ -11,8 +11,8 @@ import type {
 import i18n from "../../i18n/config";
 import Supabase from "../../utils/Supabase";
 import {
+  authErrorToString,
   getAuthErrorCode,
-  getAuthErrorLogMessage,
   getAuthErrorMessage,
   type AuthErrorSource,
 } from "../../utils/authErrorUtils";
@@ -47,7 +47,7 @@ function _errorToMessage(error: AuthErrorSource): string {
 class SupabaseAuthError extends AuthError {
   constructor(error: AuthErrorSource) {
     super(error, getAuthErrorCode(error), _errorToMessage(error));
-    console.error("Authentication error:", getAuthErrorLogMessage(error) ?? this.message);
+    console.error("Authentication error:", authErrorToString(error) ?? this.message);
   }
 }
 

--- a/web/src/services/tcApi.ts
+++ b/web/src/services/tcApi.ts
@@ -20,7 +20,6 @@ import type {
   PTeamMemberUpdateResponse,
   UpdatePteamServicePteamsPteamIdServicesServiceIdPutData,
   PTeamServiceUpdateResponse,
-  GetMyUserInfoUsersMeGetData,
   TicketResponse,
   UpdateUserUsersUserIdPutData,
   UserResponse,
@@ -147,12 +146,6 @@ type GetSbomProgressRequestQuery = Pick<
   "path"
 >["path"];
 
-type CreateActionLogRequestParams = Pick<CreateLogActionlogsPostData, "body">;
-
-type UpdatePTeamRequestParams = Pick<UpdatePteamPteamsPteamIdPutData, "body" | "path">;
-
-type DeletePTeamRequestParams = Pick<DeletePteamPteamsPteamIdDeleteData, "path">;
-
 type GetPteamTicketsRequestParams = Pick<
   GetTicketsByServiceIdAndPackageIdAndVulnIdPteamsPteamIdTicketsGetData,
   "path" | "query"
@@ -163,11 +156,26 @@ type UpdateTicketRequestParams = Pick<
   "body" | "path"
 >;
 
+type GetVulnRequestParams = Pick<GetVulnVulnsVulnIdGetData, "path">;
+
+type CreateActionLogRequestParams = Pick<CreateLogActionlogsPostData, "body">;
+
+type UpdatePTeamRequestParams = Pick<UpdatePteamPteamsPteamIdPutData, "body" | "path">;
+
+type DeletePTeamRequestParams = Pick<DeletePteamPteamsPteamIdDeleteData, "path">;
+
+type GetPTeamInvitationRequestParams = Pick<
+  InvitedPteamPteamsInvitationInvitationIdGetData,
+  "path"
+>;
+
+type ApplyPTeamInvitationRequestParams = Pick<ApplyInvitationPteamsApplyInvitationPostData, "body">;
+
+type CreateUserRequestParams = Pick<CreateUserUsersPostData, "body">;
+
 type CheckMailRequestParams = Pick<CheckEmailExternalEmailCheckPostData, "body">;
 
 type CheckSlackRequestParams = Pick<CheckWebhookUrlExternalSlackCheckPostData, "body">;
-
-type GetVulnRequestParams = Pick<GetVulnVulnsVulnIdGetData, "path">;
 
 export const getBearerToken =
   {
@@ -307,10 +315,7 @@ export const tcApi = createApi({
     }),
 
     /* PTeam Invitation */
-    getPTeamInvitation: builder.query<
-      PTeamInviterResponse,
-      InvitedPteamPteamsInvitationInvitationIdGetData
-    >({
+    getPTeamInvitation: builder.query<PTeamInviterResponse, GetPTeamInvitationRequestParams>({
       query: (arg) => ({
         url: `pteams/invitation/${arg.path.invitation_id}`,
       }),
@@ -337,19 +342,17 @@ export const tcApi = createApi({
       }),
       invalidatesTags: (_result, _error, _arg) => [{ type: "PTeamInvitation", id: "ALL" }],
     }),
-    applyPTeamInvitation: builder.mutation<PTeamInfo, ApplyInvitationPteamsApplyInvitationPostData>(
-      {
-        query: (arg) => ({
-          url: "pteams/apply_invitation",
-          method: "POST",
-          body: arg.body,
-        }),
-        invalidatesTags: (_result, _error, _arg) => [
-          { type: "PTeamAccountRole", id: "ALL" },
-          { type: "PTeamInvitation", id: "ALL" },
-        ],
-      },
-    ),
+    applyPTeamInvitation: builder.mutation<PTeamInfo, ApplyPTeamInvitationRequestParams>({
+      query: (arg) => ({
+        url: "pteams/apply_invitation",
+        method: "POST",
+        body: arg.body,
+      }),
+      invalidatesTags: (_result, _error, _arg) => [
+        { type: "PTeamAccountRole", id: "ALL" },
+        { type: "PTeamInvitation", id: "ALL" },
+      ],
+    }),
     getInvitationList: builder.query<Array<PTeamInvitationResponse>, GetInvitationListQuery>({
       query: (arg) => ({
         url: `pteams/${arg.pteam_id}/invitation`,
@@ -659,13 +662,13 @@ export const tcApi = createApi({
         ) ?? []),
       ],
     }),
-    tryLogin: builder.mutation<UserResponse, GetMyUserInfoUsersMeGetData>({
+    tryLogin: builder.mutation<UserResponse, void>({
       query: () => ({
         url: "users/me",
         method: "GET",
       }),
     }),
-    createUser: builder.mutation<UserResponse, CreateUserUsersPostData>({
+    createUser: builder.mutation<UserResponse, CreateUserRequestParams>({
       query: (arg) => ({
         url: "users",
         method: "POST",

--- a/web/src/utils/__tests__/authErrorUtils.test.ts
+++ b/web/src/utils/__tests__/authErrorUtils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { authErrorToString } from "../authErrorUtils";
+
+describe("authErrorToString", () => {
+  it("returns an Error message", () => {
+    expect(authErrorToString(new Error("Authentication failed"))).toBe("Authentication failed");
+  });
+
+  it("returns a string error as-is", () => {
+    expect(authErrorToString("Authentication failed")).toBe("Authentication failed");
+  });
+
+  it("returns message from message-like objects", () => {
+    expect(authErrorToString({ message: "Authentication failed" })).toBe("Authentication failed");
+  });
+
+  it("returns undefined when AuthErrorSource has no message", () => {
+    expect(authErrorToString({ code: "auth/internal-error" })).toBeUndefined();
+  });
+});

--- a/web/src/utils/authErrorUtils.ts
+++ b/web/src/utils/authErrorUtils.ts
@@ -53,6 +53,11 @@ export function getAuthErrorLogMessage(error: AuthErrorSource): string | undefin
   return undefined;
 }
 
+export function authErrorToString(error: unknown): string {
+  const normalized = normalizeAuthErrorSource(error);
+  return getAuthErrorLogMessage(normalized) ?? String(error);
+}
+
 export function getAuthErrorMessage(
   error: AuthErrorSource,
   options: GetAuthErrorMessageOptions = {},

--- a/web/src/utils/authErrorUtils.ts
+++ b/web/src/utils/authErrorUtils.ts
@@ -43,7 +43,7 @@ export function getAuthErrorCode(error: AuthErrorSource): string | undefined {
   return undefined;
 }
 
-export function getAuthErrorLogMessage(error: AuthErrorSource): string | undefined {
+export function authErrorToString(error: AuthErrorSource): string | undefined {
   if (typeof error === "object" && error !== null && "message" in error) {
     return typeof error.message === "string" ? error.message : undefined;
   }
@@ -51,11 +51,6 @@ export function getAuthErrorLogMessage(error: AuthErrorSource): string | undefin
     return error;
   }
   return undefined;
-}
-
-export function authErrorToString(error: unknown): string {
-  const normalized = normalizeAuthErrorSource(error);
-  return getAuthErrorLogMessage(normalized) ?? String(error);
 }
 
 export function getAuthErrorMessage(


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- `web/src/pages` の認証関連ページ (AcceptPTeamInvitation、AuthKeycloakCallback、ResetPassword) を TypeScript に移行する
  - 認証機能のエラーを文字列化する処理を、 `authErrorToString`（`authErrorUtils.ts`）として共通化した

## 経緯・意図・意思決定

- componentsのTS移行PRレビュー中に本作業を開始したため、componentsを参照しない、かつ小さいPageであるAcceptPTeamInvitation、AuthKeycloakCallback、ResetPasswordを１つのPRにまとめた

## 実施したテスト項目
- チーム招待作成、招待を受理
- パスワードリセット実行
  - シミュレータのため、firebaseコンテナにログが出るだけ


<!-- I want to review in Japanese. -->