### PR TITLE
Convert PTeam pages to TypeScript

### DIFF
--- a/web/src/pages/PTeam/AuthAdminCheckbox.tsx
+++ b/web/src/pages/PTeam/AuthAdminCheckbox.tsx
@@ -1,7 +1,14 @@
 import { Box, Checkbox } from "@mui/material";
-import PropTypes from "prop-types";
+import type { ChangeEvent } from "react";
 
-export function AuthAdminCheckbox(props) {
+type AuthAdminCheckboxProps = {
+  checked: boolean;
+  editable: boolean;
+  modified: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function AuthAdminCheckbox(props: AuthAdminCheckboxProps) {
   const { checked, editable, modified, onChange } = props;
 
   return (
@@ -18,10 +25,3 @@ export function AuthAdminCheckbox(props) {
     </>
   );
 }
-
-AuthAdminCheckbox.propTypes = {
-  checked: PropTypes.bool.isRequired,
-  editable: PropTypes.bool.isRequired,
-  modified: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
-};

--- a/web/src/pages/PTeam/CopiedIcon.tsx
+++ b/web/src/pages/PTeam/CopiedIcon.tsx
@@ -1,10 +1,13 @@
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { IconButton, Tooltip } from "@mui/material";
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-export function CopiedIcon(props) {
+type CopiedIconProps = {
+  invitationLink: string;
+};
+
+export function CopiedIcon(props: CopiedIconProps) {
   const { invitationLink } = props;
 
   const [tooltipOpen, setTooltipOpen] = useState(false);
@@ -43,7 +46,3 @@ export function CopiedIcon(props) {
     </>
   );
 }
-
-CopiedIcon.propTypes = {
-  invitationLink: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
-};

--- a/web/src/pages/PTeam/PTeamAuthEditor.tsx
+++ b/web/src/pages/PTeam/PTeamAuthEditor.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
+import type { ChangeEvent } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,7 +22,16 @@ import { errorToString } from "../../utils/func";
 import { AuthAdminCheckbox } from "./AuthAdminCheckbox";
 import { UpdateAuthButton } from "./UpdateAuthButton";
 
-export function PTeamAuthEditor(props) {
+type PTeamAuthEditorProps = {
+  pteamId: string;
+  memberUserId: string;
+  userEmail: string;
+  isTargetMemberAdmin: boolean;
+  isCurrentUserAdmin: boolean;
+  onClose?: () => void;
+};
+
+export function PTeamAuthEditor(props: PTeamAuthEditorProps) {
   const { pteamId, memberUserId, userEmail, isTargetMemberAdmin, isCurrentUserAdmin, onClose } =
     props;
   const { t } = useTranslation("pteam", { keyPrefix: "PTeamAuthEditor" });
@@ -33,15 +42,15 @@ export function PTeamAuthEditor(props) {
 
   const { enqueueSnackbar } = useSnackbar();
 
-  const handleCheckedChange = (event) => {
+  const handleCheckedChange = (event: ChangeEvent<HTMLInputElement>) => {
     setChecked(event.target.checked);
   };
 
   const handleSave = async () => {
-    function onSuccess(success) {
+    function onSuccess() {
       enqueueSnackbar(t("updateSucceeded"), { variant: "success" });
     }
-    function onError(error) {
+    function onError(error: Parameters<typeof errorToString>[0]) {
       enqueueSnackbar(t("updateFailed", { error: errorToString(error) }), {
         variant: "error",
       });
@@ -51,8 +60,8 @@ export function PTeamAuthEditor(props) {
 
     await updatePTeamMember({ path: { pteam_id: pteamId, user_id: memberUserId }, body: data })
       .unwrap()
-      .then((success) => onSuccess(success))
-      .catch((error) => onError(error));
+      .then(() => onSuccess())
+      .catch((error: Parameters<typeof errorToString>[0]) => onError(error));
   };
 
   return (
@@ -102,12 +111,3 @@ export function PTeamAuthEditor(props) {
     </>
   );
 }
-
-PTeamAuthEditor.propTypes = {
-  pteamId: PropTypes.string.isRequired,
-  memberUserId: PropTypes.string.isRequired,
-  userEmail: PropTypes.string.isRequired,
-  isTargetMemberAdmin: PropTypes.bool.isRequired,
-  isCurrentUserAdmin: PropTypes.bool.isRequired,
-  onClose: PropTypes.func,
-};

--- a/web/src/pages/PTeam/PTeamMember.tsx
+++ b/web/src/pages/PTeam/PTeamMember.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-import PropTypes from "prop-types";
+import type { Theme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 import { UUIDTypography } from "../../components/UUIDTypography";
@@ -22,18 +22,24 @@ import { useGetUserMeQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
 import { experienceColors } from "../../utils/const";
 import { errorToString } from "../../utils/func";
+import type { PteamMemberGetResponse } from "../../../types/types.gen";
 
 import { InvitationManageDialog } from "./InvitationManageDialog";
 import { PTeamMemberMenu } from "./PTeamMemberMenu";
 
-export function PTeamMember(props) {
+type PTeamMemberProps = {
+  pteamId: string;
+  members: Array<PteamMemberGetResponse>;
+};
+
+export function PTeamMember(props: PTeamMemberProps) {
   const { pteamId, members } = props;
   const { t } = useTranslation("pteam", { keyPrefix: "PTeamMember" });
-  const isMdDown = useMediaQuery((theme) => theme.breakpoints.down("md"));
+  const isMdDown = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
 
   const filteredMembers = members
     ? [...members]
-        .sort((memberA, memberB) => memberB.email < memberA.email)
+        .sort((memberA, memberB) => memberB.email.localeCompare(memberA.email))
         .sort((memberA, memberB) => memberB.years - memberA.years)
         .filter((member) => member.disabled === false)
     : [];
@@ -53,6 +59,8 @@ export function PTeamMember(props) {
     });
 
   if (userMeIsLoading) return <>{t("loadingUserInfo")}</>;
+
+  if (!userMe) return <>{t("loadingUserInfo")}</>;
 
   const currentMember = members.find((member) => member.user_id === userMe.user_id);
   if (!currentMember) {
@@ -112,7 +120,7 @@ export function PTeamMember(props) {
                   variant="rounded"
                   sizes="small"
                   sx={{
-                    bgcolor: experienceColors[member.years],
+                    bgcolor: experienceColors[member.years as keyof typeof experienceColors],
                     color: "black",
                     ml: 1,
                     width: 30,
@@ -156,7 +164,7 @@ export function PTeamMember(props) {
                       <Avatar
                         variant="rounded"
                         sx={{
-                          bgcolor: experienceColors[member.years],
+                          bgcolor: experienceColors[member.years as keyof typeof experienceColors],
                           color: "black",
                           m: 0.5,
                         }}
@@ -184,17 +192,3 @@ export function PTeamMember(props) {
     </>
   );
 }
-
-PTeamMember.propTypes = {
-  pteamId: PropTypes.string,
-  members: PropTypes.arrayOf(
-    PropTypes.shape({
-      user_id: PropTypes.string.isRequired,
-      uid: PropTypes.string,
-      email: PropTypes.string.isRequired,
-      disabled: PropTypes.bool,
-      years: PropTypes.number.isRequired,
-      is_admin: PropTypes.bool.isRequired,
-    }),
-  ).isRequired,
-};

--- a/web/src/pages/PTeam/PTeamMemberMenu.tsx
+++ b/web/src/pages/PTeam/PTeamMemberMenu.tsx
@@ -4,8 +4,8 @@ import {
   PersonOff as PersonOffIcon,
 } from "@mui/icons-material";
 import { Dialog, DialogContent, IconButton, Menu, MenuItem } from "@mui/material";
-import PropTypes from "prop-types";
 import { useState } from "react";
+import type { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
@@ -16,7 +16,16 @@ import { errorToString } from "../../utils/func";
 import { PTeamAuthEditor } from "./PTeamAuthEditor";
 import { PTeamMemberRemoveModal } from "./PTeamMemberRemoveModal";
 
-export function PTeamMemberMenu(props) {
+type PTeamMemberMenuProps = {
+  pteamId: string;
+  memberUserId: string;
+  userEmail: string;
+  isTargetMemberAdmin: boolean;
+  currentUserId: string;
+  isCurrentUserAdmin: boolean;
+};
+
+export function PTeamMemberMenu(props: PTeamMemberMenuProps) {
   const {
     pteamId,
     memberUserId,
@@ -29,7 +38,7 @@ export function PTeamMemberMenu(props) {
 
   const [openAuth, setOpenAuth] = useState(false);
   const [openRemove, setOpenRemove] = useState(false);
-  const [anchorEl, setAnchorEl] = useState(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const open = Boolean(anchorEl);
 
   const skip = useSkipUntilAuthUserIsReady() || !pteamId;
@@ -44,9 +53,9 @@ export function PTeamMemberMenu(props) {
     throw new APIError(errorToString(pteamError), {
       api: "getPTeam",
     });
-  if (pteamIsLoading) return <>{t("nowLoadingTeam")}</>;
+  if (pteamIsLoading || !pteam) return <>{t("nowLoadingTeam")}</>;
 
-  const handleClick = (event) => setAnchorEl(event.currentTarget);
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
   const handleAuthorities = () => {
     handleClose();
@@ -114,12 +123,3 @@ export function PTeamMemberMenu(props) {
     </>
   );
 }
-
-PTeamMemberMenu.propTypes = {
-  pteamId: PropTypes.string.isRequired,
-  memberUserId: PropTypes.string.isRequired,
-  userEmail: PropTypes.string.isRequired,
-  isTargetMemberAdmin: PropTypes.bool.isRequired,
-  currentUserId: PropTypes.string.isRequired,
-  isCurrentUserAdmin: PropTypes.bool.isRequired,
-};

--- a/web/src/pages/PTeam/PTeamMemberRemoveModal.tsx
+++ b/web/src/pages/PTeam/PTeamMemberRemoveModal.tsx
@@ -9,14 +9,21 @@ import {
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 import dialogStyle from "../../cssModule/dialog.module.css";
 import { useDeletePTeamMemberMutation } from "../../services/tcApi";
 import { errorToString } from "../../utils/func";
 
-export function PTeamMemberRemoveModal(props) {
+type PTeamMemberRemoveModalProps = {
+  memberUserId: string;
+  userName: string;
+  pteamId: string;
+  pteamName: string;
+  onClose?: () => void;
+};
+
+export function PTeamMemberRemoveModal(props: PTeamMemberRemoveModalProps) {
   const { memberUserId, userName, pteamId, pteamName, onClose } = props;
   const { t } = useTranslation("pteam", { keyPrefix: "PTeamMemberRemoveModal" });
 
@@ -25,19 +32,19 @@ export function PTeamMemberRemoveModal(props) {
   const [deletePTeamMember] = useDeletePTeamMemberMutation();
 
   const handleRemove = async () => {
-    function onSuccess(success) {
+    function onSuccess() {
       enqueueSnackbar(t("removeMemberSucceeded"), { variant: "success" });
       if (onClose) onClose();
     }
-    function onError(error) {
+    function onError(error: Parameters<typeof errorToString>[0]) {
       enqueueSnackbar(t("removeMemberFailed", { error: errorToString(error) }), {
         variant: "error",
       });
     }
     await deletePTeamMember({ path: { pteam_id: pteamId, user_id: memberUserId } })
       .unwrap()
-      .then((success) => onSuccess(success))
-      .catch((error) => onError(error));
+      .then(() => onSuccess())
+      .catch((error: Parameters<typeof errorToString>[0]) => onError(error));
   };
 
   return (
@@ -64,11 +71,3 @@ export function PTeamMemberRemoveModal(props) {
     </>
   );
 }
-
-PTeamMemberRemoveModal.propTypes = {
-  memberUserId: PropTypes.string.isRequired,
-  userName: PropTypes.string.isRequired,
-  pteamId: PropTypes.string.isRequired,
-  pteamName: PropTypes.string.isRequired,
-  onClose: PropTypes.func,
-};

--- a/web/src/pages/PTeam/PTeamPage.tsx
+++ b/web/src/pages/PTeam/PTeamPage.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Box, Tab, Tabs, Tooltip } from "@mui/material";
 import { useState } from "react";
+import type { SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
@@ -11,7 +12,7 @@ import { APIError } from "../../utils/APIError";
 import { experienceColors, getNoPTeamMessage } from "../../utils/const";
 import { a11yProps, errorToString } from "../../utils/func";
 
-import { PTeamMember } from "./PTeamMember.jsx";
+import { PTeamMember } from "./PTeamMember";
 
 export function PTeam() {
   const { t } = useTranslation("pteam", { keyPrefix: "PTeamPage" });
@@ -26,7 +27,7 @@ export function PTeam() {
     data: members,
     error: membersError,
     isLoading: membersIsLoading,
-  } = useGetPTeamMembersQuery({ path: { pteam_id: pteamId } }, { skip });
+  } = useGetPTeamMembersQuery({ path: { pteam_id: pteamId ?? "" } }, { skip });
 
   if (!pteamId) return <>{getNoPTeamMessage()}</>;
   if (skip) return <></>;
@@ -36,9 +37,9 @@ export function PTeam() {
       api: "getPTeamMembers",
     });
 
-  if (membersIsLoading) return <>{t("nowLoadingMembers")}</>;
+  if (membersIsLoading || !members) return <>{t("nowLoadingMembers")}</>;
 
-  const tabHandleChange = (event, newValue) => {
+  const tabHandleChange = (_event: SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
 
@@ -60,7 +61,7 @@ export function PTeam() {
                     <Avatar
                       variant="rounded"
                       sx={{
-                        bgcolor: experienceColors[maxYears],
+                        bgcolor: experienceColors[maxYears as keyof typeof experienceColors],
                         color: "black",
                         m: 0.5,
                       }}

--- a/web/src/pages/PTeam/UpdateAuthButton.tsx
+++ b/web/src/pages/PTeam/UpdateAuthButton.tsx
@@ -1,10 +1,14 @@
 import { Button } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 import dialogStyle from "../../cssModule/dialog.module.css";
 
-export function UpdateAuthButton(props) {
+type UpdateAuthButtonProps = {
+  disabled: boolean;
+  onUpdate: () => void;
+};
+
+export function UpdateAuthButton(props: UpdateAuthButtonProps) {
   const { disabled, onUpdate } = props;
   const { t } = useTranslation("pteam", { keyPrefix: "UpdateAuthButton" });
 
@@ -14,8 +18,3 @@ export function UpdateAuthButton(props) {
     </Button>
   );
 }
-
-UpdateAuthButton.propTypes = {
-  disabled: PropTypes.bool.isRequired,
-  onUpdate: PropTypes.func.isRequired,
-};

--- a/web/src/pages/PTeam/__tests__/AuthAdminCheckbox.test.tsx
+++ b/web/src/pages/PTeam/__tests__/AuthAdminCheckbox.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
+import type { ChangeEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 import { AuthAdminCheckbox } from "../AuthAdminCheckbox";
 
-const mockTemplate = () => {
+const mockTemplate = (_event: ChangeEvent<HTMLInputElement>) => {
   throw new Error("Not implemented: You should override mock using vi.fn().");
 };
 

--- a/web/src/pages/PTeam/__tests__/PTeamMember.test.tsx
+++ b/web/src/pages/PTeam/__tests__/PTeamMember.test.tsx
@@ -1,12 +1,16 @@
 import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
 
 import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
 import { useGetPTeamQuery, useGetUserMeQuery } from "../../../services/tcApi";
 import { PTeamMember } from "../PTeamMember";
+import type { PteamMemberGetResponse, UserResponse } from "../../../../types/types.gen";
 
-vi.mock("../../../hooks/auth", async (importOriginal) => {
+vi.mock("../../../hooks/auth", async (importOriginal: () => Promise<object>) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -14,7 +18,7 @@ vi.mock("../../../hooks/auth", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../services/tcApi", async (importOriginal) => {
+vi.mock("../../../services/tcApi", async (importOriginal: () => Promise<object>) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -25,7 +29,7 @@ vi.mock("../../../services/tcApi", async (importOriginal) => {
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key) => key,
+    t: (key: string) => key,
   }),
 }));
 
@@ -34,7 +38,7 @@ vi.mock("../InvitationManageDialog", () => ({
 }));
 
 vi.mock("../PTeamAuthEditor", () => ({
-  PTeamAuthEditor: ({ isCurrentUserAdmin }) => (
+  PTeamAuthEditor: ({ isCurrentUserAdmin }: { isCurrentUserAdmin: boolean }) => (
     <label>
       admin authority
       <input type="checkbox" disabled={!isCurrentUserAdmin} />
@@ -50,9 +54,10 @@ const pteamId = "pteam-1";
 const currentUserId = "user-current";
 const theme = createTheme();
 
-const members = [
+const members: Array<PteamMemberGetResponse> = [
   {
     user_id: currentUserId,
+    uid: "uid-current",
     email: "current@example.com",
     disabled: false,
     years: 3,
@@ -60,6 +65,7 @@ const members = [
   },
   {
     user_id: "user-member",
+    uid: "uid-member",
     email: "member@example.com",
     disabled: false,
     years: 1,
@@ -67,19 +73,32 @@ const members = [
   },
 ];
 
-const renderPTeamMember = ({ userMe = {}, memberOverrides = {} } = {}) => {
+type RenderPTeamMemberOptions = {
+  userMe?: Partial<UserResponse>;
+  memberOverrides?: Record<string, Partial<PteamMemberGetResponse>>;
+};
+
+const renderPTeamMember = ({
+  userMe = {},
+  memberOverrides = {},
+}: RenderPTeamMemberOptions = {}) => {
   vi.mocked(useSkipUntilAuthUserIsReady).mockReturnValue(false);
-  vi.mocked(useGetUserMeQuery).mockReturnValue({
+  (useGetUserMeQuery as Mock).mockReturnValue({
     data: {
       user_id: currentUserId,
+      uid: "uid-current",
+      email: "current@example.com",
+      disabled: false,
+      years: 3,
       pteam_roles: [],
+      default_pteam_id: null,
       ...userMe,
     },
     error: undefined,
     isLoading: false,
     isFetching: false,
   });
-  vi.mocked(useGetPTeamQuery).mockReturnValue({
+  (useGetPTeamQuery as Mock).mockReturnValue({
     data: {
       pteam_id: pteamId,
       pteam_name: "Test PTeam",
@@ -120,6 +139,7 @@ describe("PTeamMember", () => {
 
     const memberMenuButton = container.querySelector("#pteam-member-button-user-member");
     expect(memberMenuButton).not.toBeNull();
+    if (!memberMenuButton) throw new Error("member menu button was not found");
     await ue.click(memberMenuButton);
 
     expect(screen.getByText("removeFromTeam")).toBeInTheDocument();

--- a/web/src/pages/PTeam/__tests__/UpdateAuthButton.test.tsx
+++ b/web/src/pages/PTeam/__tests__/UpdateAuthButton.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import { UpdateAuthButton } from "../UpdateAuthButton";
 

--- a/web/src/services/tcApi.ts
+++ b/web/src/services/tcApi.ts
@@ -120,6 +120,16 @@ type DeleteInvitationRequestParams = Pick<
 
 type GetPTeamMembersRequestParams = Pick<GetPteamMembersPteamsPteamIdMembersGetData, "path">;
 
+type DeletePTeamMemberRequestParams = Pick<
+  DeleteMemberPteamsPteamIdMembersUserIdDeleteData,
+  "path"
+>;
+
+type UpdatePTeamMemberRequestParams = Pick<
+  UpdatePteamMemberPteamsPteamIdMembersUserIdPutData,
+  "body" | "path"
+>;
+
 type GetPTeamServicesRequestParams = Pick<GetPteamServicesPteamsPteamIdServicesGetData, "path">;
 
 type GetPTeamVulnIdsRequestParams = Pick<
@@ -372,7 +382,7 @@ export const tcApi = createApi({
           : []),
       ],
     }),
-    deletePTeamMember: builder.mutation<void, DeleteMemberPteamsPteamIdMembersUserIdDeleteData>({
+    deletePTeamMember: builder.mutation<void, DeletePTeamMemberRequestParams>({
       query: (arg) => ({
         url: `pteams/${arg.path.pteam_id}/members/${arg.path.user_id}`,
         method: "DELETE",
@@ -382,10 +392,7 @@ export const tcApi = createApi({
         { type: "PTeamAccountRole", id: "ALL" },
       ],
     }),
-    updatePTeamMember: builder.mutation<
-      PTeamMemberUpdateResponse,
-      UpdatePteamMemberPteamsPteamIdMembersUserIdPutData
-    >({
+    updatePTeamMember: builder.mutation<PTeamMemberUpdateResponse, UpdatePTeamMemberRequestParams>({
       query: (arg) => ({
         url: `pteams/${arg.path.pteam_id}/members/${arg.path.user_id}`,
         method: "PUT",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- PTeam ページ配下のコンポーネントを JSX から TSX へ移行し、型安全性を向上させる。

## 経緯・意図・意思決定

TypeScript 移行シリーズの一環として、`web/src/pages/PTeam/` 配下の 8 コンポーネントと対応するテストファイルを `.jsx` → `.tsx` へリネーム・型付けした。

合わせて `web/src/services/tcApi.ts` の `deletePTeamMember` / `updatePTeamMember` エンドポイント定義を、AGENTS.md の RTK Query ルールに従い `Pick` スタイルの型引数へ更新した（呼び出し元で `url` を指定させない形式への統一）。

## 実施したテスト項目

- ToDoを開く
  - ToDoの詳細の各ページを開く


<!-- I want to review in Japanese. -->