### PR TITLE
Port VulnManagement pages to TypeScript

### DIFF
--- a/web/src/pages/VulnManagement/FormattedDateTimeWithTooltip.tsx
+++ b/web/src/pages/VulnManagement/FormattedDateTimeWithTooltip.tsx
@@ -1,9 +1,16 @@
 import { Tooltip, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
 import { format } from "date-fns";
-import PropTypes from "prop-types";
 
-export function FormattedDateTimeWithTooltip(props) {
+type FormattedDateTimeWithTooltipProps = {
+  utcString?: string | null;
+  formatString?: string;
+  sx?: SxProps<Theme>;
+};
+
+export function FormattedDateTimeWithTooltip(props: FormattedDateTimeWithTooltipProps) {
   const { utcString, formatString = "PPp", sx } = props; // see https://date-fns.org/v3.0.0/docs/format for details
+  const typographySx = [{ overflowWrap: "anywhere" }, ...(Array.isArray(sx) ? sx : [sx])];
 
   try {
     if (!utcString) throw new Error("empty string");
@@ -12,15 +19,10 @@ export function FormattedDateTimeWithTooltip(props) {
     const formattedDate = format(localDate, formatString);
     return (
       <Tooltip title={tipTitle}>
-        <Typography sx={{ overflowWrap: "anywhere", ...sx }}>{formattedDate}</Typography>
+        <Typography sx={typographySx}>{formattedDate}</Typography>
       </Tooltip>
     );
   } catch (error) {
-    return <Typography sx={{ overflowWrap: "anywhere", ...sx }}> - </Typography>;
+    return <Typography sx={typographySx}> - </Typography>;
   }
 }
-FormattedDateTimeWithTooltip.propTypes = {
-  utcString: PropTypes.string,
-  formatString: PropTypes.string,
-  sx: PropTypes.object,
-};

--- a/web/src/pages/VulnManagement/VulnManagementCardList.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementCardList.tsx
@@ -1,16 +1,20 @@
 import UpdateIcon from "@mui/icons-material/Update";
 import { Card, CardContent, Chip, Box, Typography, Stack } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
+import type { VulnResponse } from "../../../types/types.gen";
 
 import { cvssProps, cvssConvertToName } from "../../utils/cvssUtils";
 import { preserveParams } from "../../utils/urlUtils";
 
 import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 
-export function VulnManagementCardList({ vulns }) {
+type VulnManagementCardListProps = {
+  vulns: VulnResponse[];
+};
+
+export function VulnManagementCardList({ vulns }: VulnManagementCardListProps) {
   const { t } = useTranslation("vulnManagement", { keyPrefix: "VulnManagementCardList" });
   const navigate = useNavigate();
   const location = useLocation();
@@ -19,13 +23,8 @@ export function VulnManagementCardList({ vulns }) {
     <Stack spacing={2} sx={{ mt: 1 }}>
       {vulns?.length > 0 ? (
         vulns.map((vuln) => {
-          const cvssScore =
-            vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null
-              ? "N/A"
-              : vuln.cvss_v3_score;
-
-          const cvss = cvssConvertToName(cvssScore);
-          const cveId = vuln.cve_id === null ? t("noKnownCve") : vuln.cve_id;
+          const cvss = cvssConvertToName(vuln.cvss_v3_score ?? 0) as keyof typeof cvssProps;
+          const cveId = vuln.cve_id == null ? t("noKnownCve") : vuln.cve_id;
 
           const handleCardClick = () => {
             const preservedParams = preserveParams(location.search);
@@ -65,7 +64,3 @@ export function VulnManagementCardList({ vulns }) {
     </Stack>
   );
 }
-
-VulnManagementCardList.propTypes = {
-  vulns: PropTypes.array.isRequired,
-};

--- a/web/src/pages/VulnManagement/VulnManagementCardList.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementCardList.tsx
@@ -23,7 +23,8 @@ export function VulnManagementCardList({ vulns }: VulnManagementCardListProps) {
     <Stack spacing={2} sx={{ mt: 1 }}>
       {vulns?.length > 0 ? (
         vulns.map((vuln) => {
-          const cvss = cvssConvertToName(vuln.cvss_v3_score ?? 0) as keyof typeof cvssProps;
+          const cvssScore = vuln.cvss_v3_score == null ? "N/A" : vuln.cvss_v3_score;
+          const cvss = cvssConvertToName(cvssScore);
           const cveId = vuln.cve_id == null ? t("noKnownCve") : vuln.cve_id;
 
           const handleCardClick = () => {

--- a/web/src/pages/VulnManagement/VulnManagementPage.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
+import type { GetVulnsVulnsGetData } from "../../../types/types.gen";
 
 import { Android12Switch } from "../../components/Android12Switch";
 import styles from "../../cssModule/button.module.css";
@@ -25,6 +26,9 @@ import { createUpdateParamsFunction } from "../../utils/urlUtils";
 import { VulnManagementCardList } from "./VulnManagementCardList";
 import { VulnManagementTable } from "./VulnManagementTable";
 import { VulnSearchModal } from "./VulnSearchModal";
+import type { VulnSearchParams } from "./VulnSearchModal";
+
+type GetVulnsQuery = NonNullable<GetVulnsVulnsGetData["query"]>;
 
 export function VulnManagement() {
   const { t } = useTranslation("vulnManagement", { keyPrefix: "VulnManagementPage" });
@@ -36,10 +40,10 @@ export function VulnManagement() {
   const params = new URLSearchParams(useLocation().search);
   const pteamId = params.get("pteamId");
   const checkedPteam = params.get("related") !== "off" && pteamId ? true : false;
-  const page = parseInt(params.get("page")) || 1;
-  const perPage = parseInt(params.get("perPage")) || perPageItems[0];
-  const getSearchConditionsFromURL = () => {
-    const conditions = {};
+  const page = parseInt(params.get("page") ?? "", 10) || 1;
+  const perPage = parseInt(params.get("perPage") ?? "", 10) || perPageItems[0];
+  const getSearchConditionsFromURL = (): Partial<GetVulnsQuery> => {
+    const conditions: Partial<GetVulnsQuery> = {};
 
     // titleWords
     const titleWords = params.get("titleWords");
@@ -96,7 +100,7 @@ export function VulnManagement() {
 
   const skip = useSkipUntilAuthUserIsReady();
 
-  const getVulnsParams = {
+  const getVulnsParams: GetVulnsQuery = {
     offset: perPage * (page - 1),
     limit: perPage,
     sort_keys: ["-updated_at", "-cvss_v3_score"],
@@ -118,10 +122,11 @@ export function VulnManagement() {
       api: "getVulns",
     });
   if (vulnsIsLoading) return <>{t("loadingVulns")}</>;
+  if (!vulnsList) return <>{t("loadingVulns")}</>;
 
   const pageMax = Math.ceil((vulnsList?.num_vulns ?? 0) / perPage);
 
-  const handleSearch = (params) => {
+  const handleSearch = (params: VulnSearchParams) => {
     setSearchMenuOpen(false);
 
     const newParams = {
@@ -164,7 +169,7 @@ export function VulnManagement() {
         count={pageMax}
         siblingCount={isMdDown ? 1 : undefined}
         boundaryCount={isMdDown ? 0 : undefined}
-        onChange={(event, value) => {
+        onChange={(_event, value) => {
           updateParams({ page: value });
         }}
       />

--- a/web/src/pages/VulnManagement/VulnManagementTable.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementTable.tsx
@@ -12,12 +12,16 @@ import {
   Paper,
 } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
+import type { VulnResponse } from "../../../types/types.gen";
 
 import { VulnManagementTableRow } from "./VulnManagementTableRow";
 
-export function VulnManagementTable(props) {
+type VulnManagementTableProps = {
+  vulns: VulnResponse[];
+};
+
+export function VulnManagementTable(props: VulnManagementTableProps) {
   const { t } = useTranslation("vulnManagement", { keyPrefix: "VulnManagementTable" });
   const { vulns } = props;
 
@@ -60,6 +64,3 @@ export function VulnManagementTable(props) {
     </TableContainer>
   );
 }
-VulnManagementTable.propTypes = {
-  vulns: PropTypes.array.isRequired,
-};

--- a/web/src/pages/VulnManagement/VulnManagementTableRow.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementTableRow.tsx
@@ -21,7 +21,8 @@ export function VulnManagementTableRow(props: VulnManagementTableRowProps) {
 
   const params = new URLSearchParams(location.search);
 
-  const cvss = cvssConvertToName(vuln.cvss_v3_score ?? 0) as keyof typeof cvssProps;
+  const cvssScore = vuln.cvss_v3_score == null ? "N/A" : vuln.cvss_v3_score;
+  const cvss = cvssConvertToName(cvssScore);
   const cveId = vuln.cve_id == null ? t("noKnownCve") : vuln.cve_id;
 
   return (

--- a/web/src/pages/VulnManagement/VulnManagementTableRow.tsx
+++ b/web/src/pages/VulnManagement/VulnManagementTableRow.tsx
@@ -1,14 +1,18 @@
 import { Chip, TableCell, TableRow, Typography } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
+import type { VulnResponse } from "../../../types/types.gen";
 
 import { cvssProps, cvssConvertToName } from "../../utils/cvssUtils";
 
 import { FormattedDateTimeWithTooltip } from "./FormattedDateTimeWithTooltip";
 
-export function VulnManagementTableRow(props) {
+type VulnManagementTableRowProps = {
+  vuln: VulnResponse;
+};
+
+export function VulnManagementTableRow(props: VulnManagementTableRowProps) {
   const { t } = useTranslation("vulnManagement", { keyPrefix: "VulnManagementCardList" });
   const { vuln } = props;
 
@@ -17,11 +21,8 @@ export function VulnManagementTableRow(props) {
 
   const params = new URLSearchParams(location.search);
 
-  const cvssScore =
-    vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null ? "N/A" : vuln.cvss_v3_score;
-
-  const cvss = cvssConvertToName(cvssScore);
-  const cveId = vuln.cve_id === null ? t("noKnownCve") : vuln.cve_id;
+  const cvss = cvssConvertToName(vuln.cvss_v3_score ?? 0) as keyof typeof cvssProps;
+  const cveId = vuln.cve_id == null ? t("noKnownCve") : vuln.cve_id;
 
   return (
     <TableRow
@@ -49,6 +50,3 @@ export function VulnManagementTableRow(props) {
     </TableRow>
   );
 }
-VulnManagementTableRow.propTypes = {
-  vuln: PropTypes.object.isRequired,
-};

--- a/web/src/pages/VulnManagement/VulnSearchModal.tsx
+++ b/web/src/pages/VulnManagement/VulnSearchModal.tsx
@@ -18,12 +18,13 @@ import {
   Select,
   MenuItem,
 } from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
 import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { addDays } from "date-fns";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useState } from "react";
+import type { ChangeEvent, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Android12Switch } from "../../components/Android12Switch";
@@ -31,7 +32,27 @@ import dialogStyle from "../../cssModule/dialog.module.css";
 import { cvssRatings, cvssConvertToScore } from "../../utils/cvssUtils";
 import { isValidCVEFormat } from "../../utils/vulnUtils";
 
-export function VulnSearchModal(props) {
+type CvssRatingName = keyof typeof cvssRatings;
+type DateFormList = "" | "range" | "since" | "until" | "in24hours" | "in7days";
+
+export type VulnSearchParams = {
+  titleWords: string;
+  cveIds: string;
+  vulnIds: string;
+  creatorIds: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  minCvssV3Score: string;
+  maxCvssV3Score: string;
+};
+
+type VulnSearchModalProps = {
+  show: boolean;
+  onSearch: (params: VulnSearchParams) => void;
+  onCancel: () => void;
+};
+
+export function VulnSearchModal(props: VulnSearchModalProps) {
   const { t } = useTranslation("vulnManagement", { keyPrefix: "VulnSearchModal" });
   const { show, onSearch, onCancel } = props;
 
@@ -39,19 +60,19 @@ export function VulnSearchModal(props) {
   const [cveIds, setCveIds] = useState("");
   const [creatorIds, setCreatorIds] = useState("");
   const [vulnIds, setVulnIds] = useState("");
-  const [updatedAfter, setUpdatedAfter] = useState(null); // Date object
-  const [updatedBefore, setUpdatedBefore] = useState(null); // Date object
+  const [updatedAfter, setUpdatedAfter] = useState<Date | null>(null);
+  const [updatedBefore, setUpdatedBefore] = useState<Date | null>(null);
   const [adModeChange, setAdModeChange] = useState(false);
-  const [dateFormList, setDateFormList] = useState("");
-  const [cvssName, setCvssName] = useState("");
+  const [dateFormList, setDateFormList] = useState<DateFormList>("");
+  const [cvssName, setCvssName] = useState<CvssRatingName | null>(null);
   const [minCvssScore, setMinCvssScore] = useState("");
   const [maxCvssScore, setMaxCvssScore] = useState("");
   const { enqueueSnackbar } = useSnackbar();
 
   const now = new Date();
-  const cvssRatingsKeys = Object.keys(cvssRatings);
+  const cvssRatingsKeys = Object.keys(cvssRatings) as CvssRatingName[];
 
-  const advancedChange = (event) => {
+  const advancedChange = (event: ChangeEvent<HTMLInputElement>) => {
     setAdModeChange(event.target.checked);
     if (!event.target.checked) clearAdvancedParams(); // clear on close
   };
@@ -69,7 +90,7 @@ export function VulnSearchModal(props) {
       });
       return;
     }
-    const params = {
+    const params: VulnSearchParams = {
       titleWords: titleWords.trim(),
       cveIds: trimmedCveIds,
       vulnIds: vulnIds.trim(),
@@ -89,7 +110,7 @@ export function VulnSearchModal(props) {
     setUpdatedAfter(null);
     setUpdatedBefore(null);
     setDateFormList("");
-    setCvssName("");
+    setCvssName(null);
     setMinCvssScore("");
     setMaxCvssScore("");
   };
@@ -100,7 +121,7 @@ export function VulnSearchModal(props) {
     clearAdvancedParams();
   };
 
-  const dateFormChange = (event) => {
+  const dateFormChange = (event: SelectChangeEvent<DateFormList>) => {
     setUpdatedBefore(null);
     switch (event.target.value) {
       case "":
@@ -121,24 +142,29 @@ export function VulnSearchModal(props) {
     setDateFormList(event.target.value);
   };
 
-  const handleCvssName = (event, newCvssName) => {
+  const handleCvssName = (_event: MouseEvent<HTMLElement>, newCvssName: CvssRatingName | null) => {
     setCvssName(newCvssName);
+    if (!newCvssName) {
+      setMinCvssScore("");
+      setMaxCvssScore("");
+      return;
+    }
     const score = cvssConvertToScore(newCvssName);
     setMinCvssScore(String(score[0]));
     setMaxCvssScore(String(score[1]));
   };
 
-  const handleMinCvssScore = (event) => {
-    setCvssName("");
+  const handleMinCvssScore = (event: ChangeEvent<HTMLInputElement>) => {
+    setCvssName(null);
     setMinCvssScore(event.target.value);
   };
 
-  const handleMaxCvssScore = (event) => {
-    setCvssName("");
+  const handleMaxCvssScore = (event: ChangeEvent<HTMLInputElement>) => {
+    setCvssName(null);
     setMaxCvssScore(event.target.value);
   };
 
-  const isValidCvssScore = (cvssScore) => {
+  const isValidCvssScore = (cvssScore: string) => {
     const trimmed = cvssScore.trim();
     const regex = /^\d+(\.\d{1})?$/; // Regular expression to allow only numbers to one decimal place
     const value = parseFloat(trimmed);
@@ -231,7 +257,7 @@ export function VulnSearchModal(props) {
       </Grid>
       <Grid size={{ xs: 10, md: 10 }} display="flex" flexDirection="column">
         <FormControl variant="standard" sx={{ m: 1, maxWidth: 200 }}>
-          <Select value={dateFormList} onChange={dateFormChange}>
+          <Select<DateFormList> value={dateFormList} onChange={dateFormChange}>
             <MenuItem value="">{t("none")}</MenuItem>
             <MenuItem value="in24hours">{t("last24h")}</MenuItem>
             <MenuItem value="in7days">{t("last7days")}</MenuItem>
@@ -244,7 +270,6 @@ export function VulnSearchModal(props) {
           <Grid size={{ xs: 5 }}>
             <DateTimePicker
               format="yyyy/MM/dd HH:mm"
-              mask="____/__/__ __:__"
               maxDateTime={now}
               value={dateFormList === "since" ? updatedAfter : updatedBefore}
               onChange={(newDate) =>
@@ -259,8 +284,7 @@ export function VulnSearchModal(props) {
         {dateFormList === "range" && (
           <Grid size={{ xs: 11.4 }} display="flex">
             <DateTimePicker
-              inputFormat="yyyy/MM/dd HH:mm"
-              mask="____/__/__ __:__"
+              format="yyyy/MM/dd HH:mm"
               maxDateTime={updatedBefore || now}
               value={updatedAfter}
               onChange={(newDate) => setUpdatedAfter(newDate)}
@@ -270,9 +294,8 @@ export function VulnSearchModal(props) {
             />
             <Typography sx={{ margin: "20px" }}>~</Typography>
             <DateTimePicker
-              inputFormat="yyyy/MM/dd HH:mm"
-              mask="____/__/__ __:__"
-              minDateTime={updatedAfter}
+              format="yyyy/MM/dd HH:mm"
+              minDateTime={updatedAfter ?? undefined}
               maxDateTime={now}
               value={updatedBefore}
               onChange={(newDate) => setUpdatedBefore(newDate)}
@@ -368,8 +391,3 @@ export function VulnSearchModal(props) {
     </>
   );
 }
-VulnSearchModal.propTypes = {
-  show: PropTypes.bool.isRequired,
-  onSearch: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-};

--- a/web/src/services/tcApi.ts
+++ b/web/src/services/tcApi.ts
@@ -94,6 +94,8 @@ type GetDependenciesRequestParams = Pick<
   "path" | "query"
 >;
 
+type GetVulnsRequestParams = Pick<GetVulnsVulnsGetData, "query">;
+
 type GetDependencyRequestParams = Pick<
   GetDependencyPteamsPteamIdDependenciesDependencyIdGetData,
   "path"
@@ -688,7 +690,7 @@ export const tcApi = createApi({
     }),
 
     /* Vuln */
-    getVulns: builder.query<VulnsListResponse, GetVulnsVulnsGetData>({
+    getVulns: builder.query<VulnsListResponse, GetVulnsRequestParams>({
       query: (arg) => ({
         url: "vulns",
         params: arg.query,

--- a/web/src/utils/__tests__/cvssUtils.test.ts
+++ b/web/src/utils/__tests__/cvssUtils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { cvssConvertToName } from "../cvssUtils";
+
+describe("cvssConvertToName", () => {
+  it("keeps an explicit zero score in the None rating", () => {
+    expect(cvssConvertToName(0)).toBe("None");
+  });
+
+  it("keeps missing scores in the fallback None rating", () => {
+    expect(cvssConvertToName("N/A")).toBe("None");
+    expect(cvssConvertToName(null)).toBe("None");
+    expect(cvssConvertToName(undefined)).toBe("None");
+  });
+});

--- a/web/src/utils/cvssUtils.ts
+++ b/web/src/utils/cvssUtils.ts
@@ -39,16 +39,18 @@ export const getCvssColor = (score: number | null | undefined) => {
   return "success.main";
 };
 
-export const cvssConvertToName = (cvssScore: number) => {
+export type CVSSRatingName = keyof typeof cvssRatings;
+
+export const cvssConvertToName = (cvssScore: number | "N/A" | null | undefined): CVSSRatingName => {
+  if (typeof cvssScore !== "number") return "None";
+
   for (const [name, range] of Object.entries(cvssRatings)) {
     if (range.min <= cvssScore && cvssScore <= range.max) {
-      return name;
+      return name as CVSSRatingName;
     }
   }
   return "None";
 };
-
-type CVSSRatingName = "None" | "Low" | "Medium" | "High" | "Critical";
 
 export const cvssConvertToScore = (cvssName: CVSSRatingName) => {
   const rating = cvssRatings[cvssName];

--- a/web/src/utils/urlUtils.ts
+++ b/web/src/utils/urlUtils.ts
@@ -1,4 +1,4 @@
-import { NavigateFunction } from "react-router-dom";
+import type { Location, NavigateFunction } from "react-router-dom";
 import { preserveKeys } from "./const";
 
 export const preserveParams = (currentParams: string) => {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- VulnManagement 関連ページ・コンポーネントを JSX から TypeScript (TSX) に移行する。

## 経緯・意図・意思決定

対象ファイル:
- `FormattedDateTimeWithTooltip.jsx` → `.tsx`
- `VulnManagementCardList.jsx` → `.tsx`
- `VulnManagementPage.jsx` → `.tsx`
- `VulnManagementTable.jsx` → `.tsx`
- `VulnManagementTableRow.jsx` → `.tsx`
- `VulnSearchModal.jsx` → `.tsx`

合わせて以下の修正も実施:
- `tcApi.ts`: `getVulns` エンドポイントの引数型を `GetVulnsRequestParams`（`Pick` スタイル）に変更


## 実施したテスト項目

- Vulnページを表示


<!-- I want to review in Japanese. -->