### PR TITLE
fix(web): normalize years to experience bucket to prevent undefined bgcolor

### DIFF
--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/AccountSettingsDialog.jsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAuth } from "../../../../hooks/auth";
+import { getExperienceBucket } from "../../../../utils/const";
 import { DeleteAccountDialog } from "../DeleteAccountDialog";
 
 import { TwoFactorAuthSection } from "./TwoFactorAuthSection/TwoFactorAuthSection";
@@ -89,9 +90,9 @@ export function AccountSettingsDialog(props) {
                 </Box>
                 <Select
                   size="small"
-                  value={userMe.years}
+                  value={getExperienceBucket(userMe.years)}
                   onChange={(e) => {
-                    onUpdateUser({ years: e.target.value });
+                    onUpdateUser({ years: Number(e.target.value) });
                   }}
                   sx={{ minWidth: 130 }}
                 >

--- a/web/src/pages/App/UserMenu/AccountSettingsDialog/__tests__/AccountSettingsDialog.test.jsx
+++ b/web/src/pages/App/UserMenu/AccountSettingsDialog/__tests__/AccountSettingsDialog.test.jsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
+import i18n from "i18next";
 
 import { useAuth } from "../../../../../hooks/auth";
 import { AccountSettingsDialog } from "../AccountSettingsDialog";
+import enApp from "../../../../../../public/locales/en/app.json";
 
 vi.mock("../../../../../hooks/auth", async (importOriginal) => {
   const actual = await importOriginal();
@@ -20,11 +22,17 @@ vi.mock("../TwoFactorAuthSection/TwoFactorAuthSection", () => ({
 }));
 
 describe("AccountSettingsDialog", () => {
-  it("renders team names without preserving repeated half-width spaces", () => {
+  beforeAll(() => {
+    i18n.addResourceBundle("en", "app", enApp, true, true);
+  });
+
+  beforeEach(() => {
     vi.mocked(useAuth).mockReturnValue({
       isAuthenticatedWithSaml: vi.fn().mockReturnValue(false),
     });
+  });
 
+  it("renders team names without preserving repeated half-width spaces", () => {
     render(
       <AccountSettingsDialog
         accountSettingOpen
@@ -51,5 +59,24 @@ describe("AccountSettingsDialog", () => {
       .getAllByText((_, element) => element?.textContent === "Gamma  Delta")
       .find((element) => element.tagName === "P");
     expect(window.getComputedStyle(teamName).whiteSpace).not.toBe("pre");
+  });
+
+  it("shows the lowest experience bucket when user years are below 2", () => {
+    render(
+      <AccountSettingsDialog
+        accountSettingOpen
+        setAccountSettingOpen={vi.fn()}
+        onUpdateUser={vi.fn()}
+        userMe={{
+          email: "test@example.com",
+          user_id: "user-1",
+          years: 1,
+          default_pteam_id: null,
+          pteam_roles: [],
+        }}
+      />,
+    );
+
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("0+ year");
   });
 });

--- a/web/src/pages/PTeam/PTeamMember.tsx
+++ b/web/src/pages/PTeam/PTeamMember.tsx
@@ -20,7 +20,7 @@ import { UUIDTypography } from "../../components/UUIDTypography";
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetUserMeQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
-import { experienceColors } from "../../utils/const";
+import { experienceColors, getExperienceBucket } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 import type { PteamMemberGetResponse } from "../../../types/types.gen";
 
@@ -120,7 +120,7 @@ export function PTeamMember(props: PTeamMemberProps) {
                   variant="rounded"
                   sizes="small"
                   sx={{
-                    bgcolor: experienceColors[member.years as keyof typeof experienceColors],
+                    bgcolor: experienceColors[getExperienceBucket(member.years)],
                     color: "black",
                     ml: 1,
                     width: 30,
@@ -164,7 +164,7 @@ export function PTeamMember(props: PTeamMemberProps) {
                       <Avatar
                         variant="rounded"
                         sx={{
-                          bgcolor: experienceColors[member.years as keyof typeof experienceColors],
+                          bgcolor: experienceColors[getExperienceBucket(member.years)],
                           color: "black",
                           m: 0.5,
                         }}

--- a/web/src/pages/PTeam/PTeamPage.tsx
+++ b/web/src/pages/PTeam/PTeamPage.tsx
@@ -9,7 +9,7 @@ import { TabPanel } from "../../components/TabPanel";
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetPTeamMembersQuery } from "../../services/tcApi";
 import { APIError } from "../../utils/APIError";
-import { experienceColors, getNoPTeamMessage } from "../../utils/const";
+import { experienceColors, getExperienceBucket, getNoPTeamMessage } from "../../utils/const";
 import { a11yProps, errorToString } from "../../utils/func";
 
 import { PTeamMember } from "./PTeamMember";
@@ -61,7 +61,7 @@ export function PTeam() {
                     <Avatar
                       variant="rounded"
                       sx={{
-                        bgcolor: experienceColors[maxYears as keyof typeof experienceColors],
+                        bgcolor: experienceColors[getExperienceBucket(maxYears)],
                         color: "black",
                         m: 0.5,
                       }}

--- a/web/src/utils/__tests__/const.test.ts
+++ b/web/src/utils/__tests__/const.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getExperienceBucket } from "../const";
+
+describe("getExperienceBucket", () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [2, 2],
+    [4, 2],
+    [5, 5],
+    [6, 5],
+    [7, 7],
+    [10, 7],
+  ])("maps %i years to bucket %i", (years, bucket) => {
+    expect(getExperienceBucket(years)).toBe(bucket);
+  });
+});

--- a/web/src/utils/const.ts
+++ b/web/src/utils/const.ts
@@ -26,6 +26,7 @@ export const experienceColors = {
 
 export type ExperienceBucket = 0 | 2 | 5 | 7;
 
+// Use the lower-bound bucket that matches the displayed labels: 0+, 2+, 5+, 7+.
 export const getExperienceBucket = (years: number): ExperienceBucket => {
   if (years >= 7) return 7;
   if (years >= 5) return 5;

--- a/web/src/utils/const.ts
+++ b/web/src/utils/const.ts
@@ -24,6 +24,15 @@ export const experienceColors = {
   7: red[500],
 };
 
+export type ExperienceBucket = 0 | 2 | 5 | 7;
+
+export const getExperienceBucket = (years: number): ExperienceBucket => {
+  if (years >= 7) return 7;
+  if (years >= 5) return 5;
+  if (years >= 2) return 2;
+  return 0;
+};
+
 /* Safety Impact */
 export const sortedSafetyImpacts = [
   // should match with strings which api returns


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- `years` が 0/2/5/7 以外の値のとき アカウント設定の「セキュリティ運用の経験年数」が空欄になるバグを修正

## 経緯・意図・意思決定

APIから返る `years` はユーザーが入力した任意の整数だが、`experienceColors` のキーは 0/2/5/7 の4値のみ。
従来コードは `member.years as keyof typeof experienceColors` の型キャストで誤魔化していたため、
例えば `years=1` のような中間値を受け取ると実行時に `undefined` が返りアバターの `bgcolor` が壊れた。

`getExperienceBucket(years: number): ExperienceBucket` を `const.ts` に追加し、
任意の整数を最近い bucket（0/2/5/7）へ丸めるよう修正した。
0/2/5/7の意味は0年以上、2年以上、など範囲を持つものとする。

Select コンポーネントの `value` も同関数で正規化することで、bucket 外の値が設定されていても正しいオプションが選択状態になる。

## 実施したテスト項目

- APIで経験年数を1年に設定
  - チームページの経験年数を表示
  - アカウント設定の「セキュリティ運用の経験年数」を表示
    - 「セキュリティ運用の経験年数」を2年以上に変更

<!-- I want to review in Japanese. -->