### PR TITLE
TypeScript移行: VulnDetailページ

### DIFF
--- a/web/src/pages/VulnDetail/VulnCVSSCard.tsx
+++ b/web/src/pages/VulnDetail/VulnCVSSCard.tsx
@@ -1,15 +1,22 @@
 import { Avatar, Box, Card, Typography } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import PropTypes from "prop-types";
 
+import type { VulnResponse } from "../../../types/types.gen";
 import { cvssProps, cvssConvertToName } from "../../utils/cvssUtils";
 
-export function VulnCVSSCard(props) {
+type CVSSName = keyof typeof cvssProps;
+
+type VulnCVSSCardProps = {
+  vuln: VulnResponse;
+};
+
+export function VulnCVSSCard(props: VulnCVSSCardProps) {
   const { vuln } = props;
   const cvssScore =
-    vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null ? "N/A" : vuln.cvss_v3_score;
+    vuln.cvss_v3_score === undefined || vuln.cvss_v3_score === null ? null : vuln.cvss_v3_score;
 
-  const cvss = cvssConvertToName(cvssScore);
+  const cvss = (cvssScore === null ? "None" : cvssConvertToName(cvssScore)) as CVSSName;
+  const displayCvssScore = cvssScore === null ? "N/A" : cvssScore.toFixed(1);
 
   return (
     <Card variant="outlined" sx={{ margin: 1, backgroundColor: cvssProps[cvss].threatCardBgcolor }}>
@@ -25,7 +32,7 @@ export function VulnCVSSCard(props) {
             }}
             variant="rounded"
           >
-            {cvssScore === "N/A" ? cvssScore : cvssScore.toFixed(1)}
+            {displayCvssScore}
           </Avatar>
           <Typography variant="h5">{vuln.title}</Typography>
         </Box>
@@ -36,6 +43,3 @@ export function VulnCVSSCard(props) {
     </Card>
   );
 }
-VulnCVSSCard.propTypes = {
-  vuln: PropTypes.object,
-};

--- a/web/src/pages/VulnDetail/VulnDetailPage.tsx
+++ b/web/src/pages/VulnDetail/VulnDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 
 import { useSkipUntilAuthUserIsReady } from "../../hooks/auth";
 import { useGetVulnQuery } from "../../services/tcApi";
+import type { VulnResponse } from "../../../types/types.gen";
 import { APIError } from "../../utils/APIError";
 import { errorToString } from "../../utils/func";
 import { getUpdateActions } from "../../utils/vulnUtils";
@@ -10,7 +11,7 @@ import { getUpdateActions } from "../../utils/vulnUtils";
 import { VulnDetailView } from "./VulnDetailView";
 
 export function VulnDetail() {
-  const { vulnId } = useParams();
+  const { vulnId = "" } = useParams();
   const { t } = useTranslation("vulnDetail", { keyPrefix: "VulnDetailPage" });
 
   const skip = useSkipUntilAuthUserIsReady();
@@ -24,7 +25,8 @@ export function VulnDetail() {
   if (vulnError) throw new APIError(errorToString(vulnError), { api: "getVuln" });
   if (vulnIsLoading) return <>{t("loadingVuln")}</>;
 
-  const updateActions = getUpdateActions(vuln);
+  const vulnResponse = vuln as VulnResponse;
+  const updateActions = getUpdateActions(vulnResponse);
 
-  return <VulnDetailView vuln={vuln} updateActions={updateActions} />;
+  return <VulnDetailView vuln={vulnResponse} updateActions={updateActions} />;
 }

--- a/web/src/pages/VulnDetail/VulnDetailView.tsx
+++ b/web/src/pages/VulnDetail/VulnDetailView.tsx
@@ -3,27 +3,33 @@ import {
   KeyboardArrowDown as KeyboardArrowDownIcon,
 } from "@mui/icons-material";
 import { Badge, Box, Button, Card, Chip, MenuItem, Typography } from "@mui/material";
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { PackageView } from "../../components/PackageView";
+import type { VulnResponse } from "../../../types/types.gen";
 import { utcStringToLocalDate } from "../../utils/func";
 
 import { VulnCVSSCard } from "./VulnCVSSCard";
 import { VulnSSVCCards } from "./VulnSSVCCards";
 
-const packageChip = (chipNumber) => {
+type VulnDetailViewProps = {
+  vuln: VulnResponse;
+  updateActions: string[];
+};
+
+const packageChip = (chipNumber: number) => {
   const packageMax = 99;
   return chipNumber <= packageMax ? chipNumber : `${packageMax}+`;
 };
 
-export function VulnDetailView(props) {
+export function VulnDetailView(props: VulnDetailViewProps) {
   const { vuln, updateActions } = props;
   const { t } = useTranslation("vulnDetail", { keyPrefix: "VulnDetailView" });
 
   const [showAllPackages, setShowAllPackages] = useState(false);
+  const vulnerablePackages = vuln.vulnerable_packages ?? [];
 
   return (
     <>
@@ -33,7 +39,7 @@ export function VulnDetailView(props) {
         <Card variant="outlined" sx={{ margin: 1 }}>
           <Box sx={{ margin: 3 }}>
             <Typography sx={{ fontWeight: "bold" }}>{t("package")}</Typography>
-            {vuln.vulnerable_packages
+            {vulnerablePackages
               .filter((_, index) => (showAllPackages ? true : index === 0))
               .map((vulnPackage) => (
                 <PackageView
@@ -42,7 +48,7 @@ export function VulnDetailView(props) {
                 />
               ))}
             {/* hide or more button if needed */}
-            {vuln.vulnerable_packages.length > 1 && (
+            {vulnerablePackages.length > 1 && (
               <Box display="flex" justifyContent="center" sx={{ mr: 3 }}>
                 {showAllPackages ? (
                   <Button
@@ -56,7 +62,7 @@ export function VulnDetailView(props) {
                   </Button>
                 ) : (
                   <Badge
-                    badgeContent={packageChip(vuln.vulnerable_packages.length - 1)}
+                    badgeContent={packageChip(vulnerablePackages.length - 1)}
                     color="primary"
                     sx={{ mt: 1 }}
                   >
@@ -151,7 +157,3 @@ export function VulnDetailView(props) {
     </>
   );
 }
-VulnDetailView.propTypes = {
-  vuln: PropTypes.object.isRequired,
-  updateActions: PropTypes.array.isRequired,
-};

--- a/web/src/pages/VulnDetail/VulnSSVCCards.tsx
+++ b/web/src/pages/VulnDetail/VulnSSVCCards.tsx
@@ -1,10 +1,15 @@
 import { Box, Grid } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
+import type { AutomatableEnum, ExploitationEnum } from "../../../types/types.gen";
 import { VulnSSVCElement } from "./VulnSSVCElement";
 
-export function VulnSSVCCards(props) {
+type VulnSSVCCardsProps = {
+  exploitation?: ExploitationEnum | null;
+  automatable?: AutomatableEnum | null;
+};
+
+export function VulnSSVCCards(props: VulnSSVCCardsProps) {
   const { exploitation, automatable } = props;
   const { t } = useTranslation("vulnDetail", { keyPrefix: "VulnSSVCCards" });
 
@@ -66,7 +71,3 @@ export function VulnSSVCCards(props) {
     </Box>
   );
 }
-VulnSSVCCards.propTypes = {
-  exploitation: PropTypes.string.isRequired,
-  automatable: PropTypes.string.isRequired,
-};

--- a/web/src/pages/VulnDetail/VulnSSVCElement.tsx
+++ b/web/src/pages/VulnDetail/VulnSSVCElement.tsx
@@ -8,9 +8,21 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
 
-export function VulnSSVCElement(props) {
+type SSVCValue = {
+  key: string;
+  name: string;
+  valueDescription: string;
+};
+
+type VulnSSVCElementProps = {
+  title: string;
+  titleDescription: string;
+  values: SSVCValue[];
+  value?: string | null;
+};
+
+export function VulnSSVCElement(props: VulnSSVCElementProps) {
   const { title, titleDescription, values, value } = props;
 
   const filterValue = values.filter((item) => value === item.key)[0];
@@ -46,9 +58,3 @@ export function VulnSSVCElement(props) {
     </Grid>
   );
 }
-VulnSSVCElement.propTypes = {
-  title: PropTypes.string.isRequired,
-  titleDescription: PropTypes.string.isRequired,
-  values: PropTypes.array.isRequired,
-  value: PropTypes.string.isRequired,
-};


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

`web/src/pages/VulnDetail` 配下のページ・コンポーネントを `.jsx` から `.tsx` へ移行し、型安全性を高める。

## 変更内容

以下の `VulnDetail` 関連ファイルを TypeScript 化した。

- `VulnCVSSCard.jsx` -> `VulnCVSSCard.tsx`
- `VulnDetailPage.jsx` -> `VulnDetailPage.tsx`
- `VulnDetailView.jsx` -> `VulnDetailView.tsx`
- `VulnSSVCCards.jsx` -> `VulnSSVCCards.tsx`
- `VulnSSVCElement.jsx` -> `VulnSSVCElement.tsx`

## 実施したテスト項目

- Vuln詳細ページを表示
