### PR TITLE
Port ToDo pages to TypeScript

### DIFF
--- a/web/src/hooks/ToDo/useTodoState.ts
+++ b/web/src/hooks/ToDo/useTodoState.ts
@@ -2,9 +2,11 @@ import type { ChangeEvent, MouseEvent } from "react";
 import { useMemo, useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import type { TicketHandlingStatusType } from "../../../types/types.gen";
+
 export type SortConfig = {
   key: string;
-  direction: string;
+  direction: "asc" | "desc";
 };
 
 export type TodoApiParams = {
@@ -14,12 +16,12 @@ export type TodoApiParams = {
   limit: number;
   sort_keys: string[];
   assigned_to_me: boolean;
-  exclude_statuses: string[];
+  exclude_statuses: TicketHandlingStatusType[];
   cve_ids: string[];
 };
 
 type UpdateParamValue = string | number | null | undefined;
-type PageChangeEvent = ChangeEvent<HTMLElement> | MouseEvent<HTMLButtonElement> | null;
+type PageChangeEvent = ChangeEvent<unknown> | MouseEvent<HTMLButtonElement> | null;
 
 export type UseTodoStateReturn = {
   apiParams: TodoApiParams;
@@ -42,7 +44,7 @@ export const useTodoState = (): UseTodoStateReturn => {
   const sortConfig = useMemo<SortConfig>(
     () => ({
       key: params.get("sortKey") || "ssvc_deployer_priority",
-      direction: params.get("sortDirection") || "desc",
+      direction: params.get("sortDirection") === "asc" ? "asc" : "desc",
     }),
     [params],
   );

--- a/web/src/pages/ToDo/CVESearchField.tsx
+++ b/web/src/pages/ToDo/CVESearchField.tsx
@@ -1,13 +1,18 @@
 import SearchIcon from "@mui/icons-material/Search";
 import { InputAdornment, TextField } from "@mui/material";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import { isValidCVEFormat } from "../../utils/vulnUtils";
 
-export function CVESearchField({ word, onApply, variant = "default" }) {
+type CVESearchFieldProps = {
+  word: string;
+  onApply: (word: string) => void;
+  variant?: "default" | "mobile";
+};
+
+export function CVESearchField({ word, onApply, variant = "default" }: CVESearchFieldProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "CVESearchField" });
   const [newWord, setNewWord] = useState("");
   const { enqueueSnackbar } = useSnackbar();
@@ -16,7 +21,7 @@ export function CVESearchField({ word, onApply, variant = "default" }) {
     setNewWord(word);
   }, [word]);
 
-  const handleApply = (value) => {
+  const handleApply = (value: string) => {
     const trimmedValue = value.trim();
     const success = isValidCVEFormat(trimmedValue);
     if (!success) {
@@ -47,7 +52,7 @@ export function CVESearchField({ word, onApply, variant = "default" }) {
       value={newWord}
       onChange={(event) => setNewWord(event.target.value)}
       onKeyDown={(event) => {
-        if (event.key === "Enter") {
+        if (event.key === "Enter" && event.target instanceof HTMLInputElement) {
           handleApply(event.target.value);
         }
       }}
@@ -66,9 +71,3 @@ export function CVESearchField({ word, onApply, variant = "default" }) {
     />
   );
 }
-
-CVESearchField.propTypes = {
-  word: PropTypes.string.isRequired,
-  onApply: PropTypes.func.isRequired,
-  variant: PropTypes.oneOf(["default", "mobile"]),
-};

--- a/web/src/pages/ToDo/Insights/AffectedObject.tsx
+++ b/web/src/pages/ToDo/Insights/AffectedObject.tsx
@@ -1,10 +1,14 @@
 import { List, ListItem, ListItemIcon, ListItemText, Typography } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
-import { objectCategoryIcons } from "./insightConst.js";
+import type { AffectedObject as AffectedObjectType } from "../../../../types/types.gen";
+import { objectCategoryIcons } from "./insightConst";
 
-export function AffectedObject(props) {
+type AffectedObjectProps = {
+  affectedObjects: AffectedObjectType[];
+};
+
+export function AffectedObject(props: AffectedObjectProps) {
   const { affectedObjects } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "Insights.AffectedObject" });
 
@@ -37,7 +41,3 @@ export function AffectedObject(props) {
     </>
   );
 }
-
-AffectedObject.propTypes = {
-  affectedObjects: PropTypes.arrayOf(PropTypes.object).isRequired,
-};

--- a/web/src/pages/ToDo/Insights/InsightReference.tsx
+++ b/web/src/pages/ToDo/Insights/InsightReference.tsx
@@ -10,10 +10,16 @@ import {
   Typography,
   Divider,
 } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
-export function InsightReference(props) {
+import type { InsightReference as InsightReferenceType } from "../../../../types/types.gen";
+
+type InsightReferenceProps = {
+  dataProcessingStrategy: string;
+  insightReferences: InsightReferenceType[];
+};
+
+export function InsightReference(props: InsightReferenceProps) {
   const { dataProcessingStrategy, insightReferences } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "Insights.InsightReference" });
 
@@ -77,8 +83,3 @@ export function InsightReference(props) {
     </>
   );
 }
-
-InsightReference.propTypes = {
-  dataProcessingStrategy: PropTypes.string.isRequired,
-  insightReferences: PropTypes.arrayOf(PropTypes.object).isRequired,
-};

--- a/web/src/pages/ToDo/Insights/RiskAnalysis.stories.tsx
+++ b/web/src/pages/ToDo/Insights/RiskAnalysis.stories.tsx
@@ -1,11 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/react";
 import { http, HttpResponse } from "msw";
 
 import emptyInsightData from "../../../mocks/emptyInsightData.json";
 import generalInsightData from "../../../mocks/generalInsightData.json";
 
-import { RiskAnalysis } from "./RiskAnalysis.jsx";
+import { RiskAnalysis } from "./RiskAnalysis";
 
-export default {
+const meta = {
   component: RiskAnalysis,
   args: {
     ticketId: "ticket-123",
@@ -23,11 +24,15 @@ export default {
       ],
     },
   },
-};
+} satisfies Meta<typeof RiskAnalysis>;
 
-export const Default = {};
+export default meta;
 
-export const EmptyState = {
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const EmptyState: Story = {
   parameters: {
     msw: {
       handlers: [
@@ -39,7 +44,7 @@ export const EmptyState = {
   },
 };
 
-export const NotFoundError = {
+export const NotFoundError: Story = {
   parameters: {
     msw: {
       handlers: [

--- a/web/src/pages/ToDo/Insights/RiskAnalysis.tsx
+++ b/web/src/pages/ToDo/Insights/RiskAnalysis.tsx
@@ -1,14 +1,26 @@
-import PropTypes from "prop-types";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { useTranslation } from "react-i18next";
 
-import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth.js";
-import { useGetInsightQuery } from "../../../services/tcApi.js";
+import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
+import { useGetInsightQuery } from "../../../services/tcApi";
 import { APIError } from "../../../utils/APIError";
 import { errorToString } from "../../../utils/func";
 
-import { RiskAnalysisView } from "./RiskAnalysisView.jsx";
+import { RiskAnalysisView } from "./RiskAnalysisView";
 
-export function RiskAnalysis(props) {
+type RiskAnalysisProps = {
+  ticketId: string;
+  serviceName: string;
+  ecosystem: string;
+  cveId: string;
+  cvss: string;
+};
+
+function isFetchBaseQueryError(error: unknown): error is FetchBaseQueryError {
+  return typeof error === "object" && error !== null && "status" in error;
+}
+
+export function RiskAnalysis(props: RiskAnalysisProps) {
   const { ticketId, serviceName, ecosystem, cveId, cvss } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "Insights.RiskAnalysis" });
 
@@ -28,7 +40,7 @@ export function RiskAnalysis(props) {
 
   if (skip) return <></>;
   if (insightError) {
-    if (insightError.status === 404) {
+    if (isFetchBaseQueryError(insightError) && insightError.status === 404) {
       return <>{t("noInsight")}</>;
     }
     throw new APIError(errorToString(insightError), {
@@ -36,6 +48,7 @@ export function RiskAnalysis(props) {
     });
   }
   if (insightIsLoading) return <>{t("loadingInsight")}</>;
+  if (!insight) return <>{t("noInsight")}</>;
 
   return (
     <RiskAnalysisView
@@ -47,11 +60,3 @@ export function RiskAnalysis(props) {
     />
   );
 }
-
-RiskAnalysis.propTypes = {
-  ticketId: PropTypes.string.isRequired,
-  serviceName: PropTypes.string.isRequired,
-  ecosystem: PropTypes.string.isRequired,
-  cveId: PropTypes.string.isRequired,
-  cvss: PropTypes.string.isRequired,
-};

--- a/web/src/pages/ToDo/Insights/RiskAnalysisView.tsx
+++ b/web/src/pages/ToDo/Insights/RiskAnalysisView.tsx
@@ -13,32 +13,49 @@ import {
   Tabs,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
+import type { SyntheticEvent } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type {
+  InsightResponse,
+  ThreatScenario as ThreatScenarioType,
+} from "../../../../types/types.gen";
 import { CustomTabPanel } from "../../../components/CustomTabPanel";
 
-import { AffectedObject } from "./AffectedObject.jsx";
-import { InsightReference } from "./InsightReference.jsx";
-import { ThreatScenario } from "./ThreatScenario.jsx";
-import { impactCategoryIcons } from "./insightConst.js";
+import { AffectedObject } from "./AffectedObject";
+import { InsightReference } from "./InsightReference";
+import { ThreatScenario } from "./ThreatScenario";
+import { impactCategoryIcons } from "./insightConst";
 
-export function RiskAnalysisView(props) {
+type RiskAnalysisViewProps = {
+  insight: InsightResponse;
+  serviceName: string;
+  ecosystem: string;
+  cveId: string;
+  cvss: string;
+};
+
+export function RiskAnalysisView(props: RiskAnalysisViewProps) {
   const { insight, serviceName, ecosystem, cveId, cvss } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "Insights.RiskAnalysisView" });
 
   const [tabValue, setTabValue] = useState(0);
 
-  const handleTabChange = (event, newValue) => {
+  const handleTabChange = (_event: SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
   };
-  const uniqueThreatScenarios = insight.threat_scenarios.filter(
+  const threatScenarios = insight.threat_scenarios ?? [];
+  const affectedObjects = insight.affected_objects ?? [];
+  const insightReferences = insight.insight_references ?? [];
+
+  const uniqueThreatScenarios = threatScenarios.filter(
     (scenario, index, self) =>
       index === self.findIndex((s) => s.impact_category === scenario.impact_category),
   );
 
-  const isIconValid = (scenario) => Boolean(impactCategoryIcons[scenario.impact_category]?.icon);
+  const isIconValid = (scenario: ThreatScenarioType) =>
+    Boolean(impactCategoryIcons[scenario.impact_category]?.icon);
   if (!uniqueThreatScenarios.every((scenario) => isIconValid(scenario))) {
     return (
       <Typography variant="body2" color="text.secondary">
@@ -139,17 +156,17 @@ export function RiskAnalysisView(props) {
               </Tabs>
             </Box>
             <CustomTabPanel value={tabValue} index={0}>
-              <ThreatScenario threatScenarios={insight.threat_scenarios} />
+              <ThreatScenario threatScenarios={threatScenarios} />
             </CustomTabPanel>
 
             <CustomTabPanel value={tabValue} index={1}>
-              <AffectedObject affectedObjects={insight.affected_objects} />
+              <AffectedObject affectedObjects={affectedObjects} />
             </CustomTabPanel>
 
             <CustomTabPanel value={tabValue} index={2}>
               <InsightReference
                 dataProcessingStrategy={insight.data_processing_strategy}
-                insightReferences={insight.insight_references}
+                insightReferences={insightReferences}
               />
             </CustomTabPanel>
           </Grid>
@@ -176,11 +193,3 @@ export function RiskAnalysisView(props) {
     </>
   );
 }
-
-RiskAnalysisView.propTypes = {
-  insight: PropTypes.object.isRequired,
-  serviceName: PropTypes.string.isRequired,
-  ecosystem: PropTypes.string.isRequired,
-  cveId: PropTypes.string.isRequired,
-  cvss: PropTypes.string.isRequired,
-};

--- a/web/src/pages/ToDo/Insights/ThreatScenario.tsx
+++ b/web/src/pages/ToDo/Insights/ThreatScenario.tsx
@@ -1,10 +1,14 @@
 import { Avatar, Card, CardContent, CardHeader, Grid, Typography } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
-import { impactCategoryIcons } from "./insightConst.js";
+import type { ThreatScenario as ThreatScenarioType } from "../../../../types/types.gen";
+import { impactCategoryIcons } from "./insightConst";
 
-export function ThreatScenario(props) {
+type ThreatScenarioProps = {
+  threatScenarios: ThreatScenarioType[];
+};
+
+export function ThreatScenario(props: ThreatScenarioProps) {
   const { threatScenarios } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "Insights.ThreatScenario" });
 
@@ -20,7 +24,7 @@ export function ThreatScenario(props) {
     <>
       <Grid container spacing={2} sx={{ flexDirection: "column" }}>
         {threatScenarios.map((scenario, index) => {
-          const ImpactCategoryIcon = impactCategoryIcons[scenario.impact_category].icon;
+          const ImpactCategoryIcon = impactCategoryIcons[scenario.impact_category]?.icon;
           return (
             <Grid size={12} key={index}>
               <Card variant="outlined">
@@ -33,7 +37,9 @@ export function ThreatScenario(props) {
                         height: { xs: 32, md: 40 },
                       }}
                     >
-                      <ImpactCategoryIcon sx={{ fontSize: { xs: "1rem", md: "1.25rem" } }} />
+                      {ImpactCategoryIcon ? (
+                        <ImpactCategoryIcon sx={{ fontSize: { xs: "1rem", md: "1.25rem" } }} />
+                      ) : null}
                     </Avatar>
                   }
                   title={scenario.title}
@@ -61,7 +67,3 @@ export function ThreatScenario(props) {
     </>
   );
 }
-
-ThreatScenario.propTypes = {
-  threatScenarios: PropTypes.arrayOf(PropTypes.object).isRequired,
-};

--- a/web/src/pages/ToDo/Insights/insightConst.ts
+++ b/web/src/pages/ToDo/Insights/insightConst.ts
@@ -20,7 +20,14 @@ import VideogameAssetOffIcon from "@mui/icons-material/VideogameAssetOff";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 
-export const impactCategoryIcons = {
+import type { ImpactCategoryEnum, ObjectCategoryEnum } from "../../../../types/types.gen";
+
+type IconComponent = typeof BrokenImageIcon;
+
+export const impactCategoryIcons: Record<
+  ImpactCategoryEnum,
+  { icon: IconComponent; text: string }
+> = {
   damage_to_property: { icon: BrokenImageIcon, text: "Damage to Property" },
   denial_of_control: { icon: DoNotTouchIcon, text: "Denial of Control" },
   denial_of_view: { icon: DisabledVisibleIcon, text: "Denial of View" },
@@ -41,7 +48,7 @@ export const impactCategoryIcons = {
   },
 };
 
-export const objectCategoryIcons = {
+export const objectCategoryIcons: Record<ObjectCategoryEnum, IconComponent> = {
   server: DnsIcon,
   client_device: LaptopIcon,
   mobile_device: SmartphoneIcon,

--- a/web/src/pages/ToDo/SafetyImpactSelector.tsx
+++ b/web/src/pages/ToDo/SafetyImpactSelector.tsx
@@ -1,13 +1,24 @@
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
+import type { SafetyImpactEnum, TicketUpdateRequest } from "../../../types/types.gen";
 import { useUpdateTicketMutation } from "../../services/tcApi";
 import { errorToString } from "../../utils/func";
 
 import { SafetyImpactSelectorView } from "./SafetyImpactSelectorView";
 
-export function SafetyImpactSelector(props) {
+type SafetyImpactSelectorTicket = {
+  ticket_id: string;
+  ticket_safety_impact: SafetyImpactEnum | null;
+  ticket_safety_impact_change_reason: string | null;
+};
+
+type SafetyImpactSelectorProps = {
+  pteamId: string;
+  ticket: SafetyImpactSelectorTicket;
+};
+
+export function SafetyImpactSelector(props: SafetyImpactSelectorProps) {
   const { pteamId, ticket } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "SafetyImpactSelector" });
 
@@ -15,7 +26,7 @@ export function SafetyImpactSelector(props) {
 
   const { enqueueSnackbar } = useSnackbar();
 
-  const updateTicketFunction = async (requestData) => {
+  const updateTicketFunction = async (requestData: TicketUpdateRequest) => {
     await updateTicket({
       path: { pteam_id: pteamId, ticket_id: ticket.ticket_id },
       body: requestData,
@@ -31,8 +42,11 @@ export function SafetyImpactSelector(props) {
       );
   };
 
-  const handleSave = async (safetyImpact, ticketSafetyImpactChangeReason) => {
-    const requestData = {
+  const handleSave = async (
+    safetyImpact: SafetyImpactEnum | null,
+    ticketSafetyImpactChangeReason: string,
+  ) => {
+    const requestData: TicketUpdateRequest = {
       ticket_safety_impact: safetyImpact,
       ticket_safety_impact_change_reason:
         ticketSafetyImpactChangeReason === "" ? null : ticketSafetyImpactChangeReason,
@@ -48,7 +62,3 @@ export function SafetyImpactSelector(props) {
     />
   );
 }
-SafetyImpactSelector.propTypes = {
-  pteamId: PropTypes.string.isRequired,
-  ticket: PropTypes.object.isRequired,
-};

--- a/web/src/pages/ToDo/SafetyImpactSelectorView.tsx
+++ b/web/src/pages/ToDo/SafetyImpactSelectorView.tsx
@@ -16,13 +16,15 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import type { SelectChangeEvent } from "@mui/material";
 import { tooltipClasses } from "@mui/material/Tooltip";
+import type { TooltipProps } from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { SafetyImpactEnum } from "../../../types/types.gen";
 import { useViewportOffset } from "../../hooks/useViewportOffset";
 import {
   safetyImpactProps,
@@ -32,29 +34,52 @@ import {
 import { countFullWidthAndHalfWidthCharacters } from "../../utils/func";
 
 const TOOLTIP_TEXT_LIMIT = 150;
+const DEFAULT_SAFETY_IMPACT_ITEM = "Default";
 
-export function SafetyImpactSelectorView(props) {
+type SafetyImpactSelectorViewProps = {
+  fixedTicketSafetyImpact: SafetyImpactEnum | null;
+  fixedTicketSafetyImpactChangeReason: string | null;
+  onSave: (safetyImpact: SafetyImpactEnum | null, reason: string) => void;
+};
+
+const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <Tooltip {...props} classes={{ popper: className }} leaveDelay={500} />
+))(() => ({
+  [`& .${tooltipClasses.arrow}`]: {
+    "&:before": {
+      border: "1px solid #dadde9",
+    },
+    color: "#f5f5f9",
+  },
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "#f5f5f9",
+    color: "rgba(0, 0, 0, 0.87)",
+    border: "1px solid #dadde9",
+  },
+}));
+
+export function SafetyImpactSelectorView(props: SafetyImpactSelectorViewProps) {
   const { fixedTicketSafetyImpact, fixedTicketSafetyImpactChangeReason, onSave } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "SafetyImpactSelectorView" });
 
-  const [pendingSafetyImpact, setPendingSafetyImpact] = useState("");
+  const [pendingSafetyImpact, setPendingSafetyImpact] = useState<
+    SafetyImpactEnum | typeof DEFAULT_SAFETY_IMPACT_ITEM
+  >(DEFAULT_SAFETY_IMPACT_ITEM);
   const [pendingReasonSafetyImpact, setPendingReasonSafetyImpact] = useState("");
   const [openDialog, setOpenDialog] = useState(false);
   const [readMoreDialogOpen, setReadMoreDialogOpen] = useState(false);
-
-  const defaultSafetyImpactItem = "Default";
 
   const { enqueueSnackbar } = useSnackbar();
   const viewportOffsetTop = useViewportOffset();
 
   const handleOpenDialog = () => {
-    setPendingSafetyImpact(fixedTicketSafetyImpact || defaultSafetyImpactItem);
+    setPendingSafetyImpact(fixedTicketSafetyImpact || DEFAULT_SAFETY_IMPACT_ITEM);
     setPendingReasonSafetyImpact(fixedTicketSafetyImpactChangeReason || "");
     setOpenDialog(true);
   };
 
-  const handleSelectSafetyImpact = (e) => {
-    setPendingSafetyImpact(e.target.value);
+  const handleSelectSafetyImpact = (e: SelectChangeEvent) => {
+    setPendingSafetyImpact(e.target.value as SafetyImpactEnum | typeof DEFAULT_SAFETY_IMPACT_ITEM);
   };
 
   const handleClose = () => {
@@ -63,13 +88,13 @@ export function SafetyImpactSelectorView(props) {
 
   const handleSave = () => {
     onSave(
-      pendingSafetyImpact === defaultSafetyImpactItem ? null : pendingSafetyImpact,
+      pendingSafetyImpact === DEFAULT_SAFETY_IMPACT_ITEM ? null : pendingSafetyImpact,
       pendingReasonSafetyImpact,
     );
     setOpenDialog(false);
   };
 
-  const handleReasonSafetyImpactLengthCheck = (string) => {
+  const handleReasonSafetyImpactLengthCheck = (string: string) => {
     if (countFullWidthAndHalfWidthCharacters(string.trim()) > maxReasonSafetyImpactLengthInHalf) {
       enqueueSnackbar(
         t("reasonTooLong", {
@@ -89,24 +114,8 @@ export function SafetyImpactSelectorView(props) {
   };
 
   const isSaveDisabled =
-    (fixedTicketSafetyImpact || defaultSafetyImpactItem) === pendingSafetyImpact &&
+    (fixedTicketSafetyImpact || DEFAULT_SAFETY_IMPACT_ITEM) === pendingSafetyImpact &&
     (fixedTicketSafetyImpactChangeReason || "") === pendingReasonSafetyImpact;
-
-  const StyledTooltip = styled(({ className, ...props }) => (
-    <Tooltip {...props} classes={{ popper: className }} leaveDelay={500} />
-  ))(() => ({
-    [`& .${tooltipClasses.arrow}`]: {
-      "&:before": {
-        border: "1px solid #dadde9",
-      },
-      color: "#f5f5f9",
-    },
-    [`& .${tooltipClasses.tooltip}`]: {
-      backgroundColor: "#f5f5f9",
-      color: "rgba(0, 0, 0, 0.87)",
-      border: "1px solid #dadde9",
-    },
-  }));
 
   const handleOpenReadMoreDialog = () => {
     setReadMoreDialogOpen(true);
@@ -144,13 +153,13 @@ export function SafetyImpactSelectorView(props) {
       <FormControl size="small" variant="standard">
         <Select
           open={false}
-          value={fixedTicketSafetyImpact ? fixedTicketSafetyImpact : defaultSafetyImpactItem}
+          value={fixedTicketSafetyImpact ? fixedTicketSafetyImpact : DEFAULT_SAFETY_IMPACT_ITEM}
           onOpen={handleOpenDialog}
         >
-          <MenuItem key={defaultSafetyImpactItem} value={defaultSafetyImpactItem}>
-            {defaultSafetyImpactItem}
+          <MenuItem key={DEFAULT_SAFETY_IMPACT_ITEM} value={DEFAULT_SAFETY_IMPACT_ITEM}>
+            {DEFAULT_SAFETY_IMPACT_ITEM}
           </MenuItem>
-          {sortedSafetyImpacts.map((safetyImpact) => (
+          {(sortedSafetyImpacts as SafetyImpactEnum[]).map((safetyImpact) => (
             <MenuItem key={safetyImpact} value={safetyImpact}>
               {safetyImpactProps[safetyImpact].displayName}
             </MenuItem>
@@ -174,10 +183,10 @@ export function SafetyImpactSelectorView(props) {
                 onChange={handleSelectSafetyImpact}
                 inputProps={{ "aria-label": "Safety Impact" }}
               >
-                <MenuItem key={defaultSafetyImpactItem} value={defaultSafetyImpactItem}>
-                  {defaultSafetyImpactItem}
+                <MenuItem key={DEFAULT_SAFETY_IMPACT_ITEM} value={DEFAULT_SAFETY_IMPACT_ITEM}>
+                  {DEFAULT_SAFETY_IMPACT_ITEM}
                 </MenuItem>
-                {sortedSafetyImpacts.map((safetyImpact) => (
+                {(sortedSafetyImpacts as SafetyImpactEnum[]).map((safetyImpact) => (
                   <MenuItem key={safetyImpact} value={safetyImpact}>
                     {safetyImpactProps[safetyImpact]?.displayName}
                   </MenuItem>
@@ -224,8 +233,3 @@ export function SafetyImpactSelectorView(props) {
     </Box>
   );
 }
-SafetyImpactSelectorView.propTypes = {
-  fixedTicketSafetyImpact: PropTypes.string,
-  fixedTicketSafetyImpactChangeReason: PropTypes.string,
-  onSave: PropTypes.func.isRequired,
-};

--- a/web/src/pages/ToDo/TicketDetailView.tsx
+++ b/web/src/pages/ToDo/TicketDetailView.tsx
@@ -11,11 +11,12 @@ import {
   Tabs,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
+import type { ReactNode, SyntheticEvent } from "react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import type { DependencyResponse, TicketResponse } from "../../../types/types.gen";
 import { CustomTabPanel } from "../../components/CustomTabPanel";
 import { AssigneesSelector } from "../../components/Ticket/AssigneesSelector";
 import {
@@ -27,14 +28,28 @@ import {
 import { APIError } from "../../utils/APIError";
 import { errorToString, utcStringToLocalDate } from "../../utils/func";
 import { getSsvcPriorityProps } from "../../utils/ssvcUtils";
-import { preserveParams } from "../../utils/urlUtils.js";
-import { RiskAnalysis } from "../ToDo/Insights/RiskAnalysis.jsx";
+import { preserveParams } from "../../utils/urlUtils";
+import { RiskAnalysis } from "../ToDo/Insights/RiskAnalysis";
 
-import { SafetyImpactSelector } from "./SafetyImpactSelector.jsx";
-import { TicketHandlingStatusSelector } from "./TicketHandlingStatusSelector.jsx";
-import { VulnerabilityView } from "./VulnerabilityView.jsx";
+import { SafetyImpactSelector } from "./SafetyImpactSelector";
+import { TicketHandlingStatusSelector } from "./TicketHandlingStatusSelector";
+import { VulnerabilityView } from "./VulnerabilityView";
 
-function DetailRow({ label, children }) {
+type DetailRowProps = {
+  label: string;
+  children: ReactNode;
+};
+
+type TicketDetailViewProps = {
+  ticket: TicketResponse;
+};
+
+type CurrentPackage = Pick<
+  DependencyResponse,
+  "package_name" | "package_source_name" | "package_ecosystem" | "vuln_matching_ecosystem"
+>;
+
+function DetailRow({ label, children }: DetailRowProps) {
   return (
     <Stack
       spacing={{ xs: 0.5, sm: 2 }}
@@ -54,7 +69,7 @@ function DetailRow({ label, children }) {
   );
 }
 
-export function TicketDetailView({ ticket }) {
+export function TicketDetailView({ ticket }: TicketDetailViewProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "TicketDetailView" });
   const [tabValue, setTabValue] = useState(0);
   const navigate = useNavigate();
@@ -117,7 +132,8 @@ export function TicketDetailView({ ticket }) {
 
   const ssvc = ticket.ssvc_deployer_priority;
   const ssvcPriorityProps = getSsvcPriorityProps();
-  const ssvcPriority = ssvcPriorityProps[ssvc?.toLowerCase()] || ssvcPriorityProps["defer"];
+  const ssvcKey = (ssvc?.toLowerCase() ?? "defer") as keyof typeof ssvcPriorityProps;
+  const ssvcPriority = ssvcPriorityProps[ssvcKey] || ssvcPriorityProps["defer"];
 
   const dueDate = useMemo(() => {
     if (!ticket.ticket_status?.scheduled_at) return "-";
@@ -159,17 +175,25 @@ export function TicketDetailView({ ticket }) {
     );
   }
 
-  const currentPackage = {
-    package_name: dependency?.package_name,
-    package_source_name: dependency?.package_source_name,
-    package_ecosystem: dependency?.package_ecosystem,
-    vuln_matching_ecosystem: dependency?.vuln_matching_ecosystem,
-  };
+  const currentPackage: CurrentPackage | null = dependency
+    ? {
+        package_name: dependency?.package_name,
+        package_source_name: dependency?.package_source_name,
+        package_ecosystem: dependency?.package_ecosystem,
+        vuln_matching_ecosystem: dependency?.vuln_matching_ecosystem,
+      }
+    : null;
+  const cvssScore = vuln?.cvss_v3_score;
+  const cvss =
+    typeof cvssScore === "number" && Number.isFinite(cvssScore) ? cvssScore.toFixed(1) : "N/A";
 
   return (
     <>
       <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-        <Tabs value={tabValue} onChange={(e, v) => setTabValue(v)}>
+        <Tabs
+          value={tabValue}
+          onChange={(_event: SyntheticEvent, value: number) => setTabValue(value)}
+        >
           <Tab label={t("tabTicket")} />
           <Tab label={t("tabVuln")} />
           <Tab label={t("tabInsights")} />
@@ -257,7 +281,11 @@ export function TicketDetailView({ ticket }) {
         </Stack>
       </CustomTabPanel>
       <CustomTabPanel value={tabValue} index={1}>
-        <VulnerabilityView vuln={vuln} currentPackage={currentPackage} />
+        {vuln && currentPackage ? (
+          <VulnerabilityView vuln={vuln} currentPackage={currentPackage} />
+        ) : (
+          <Typography>-</Typography>
+        )}
       </CustomTabPanel>
       <CustomTabPanel value={tabValue} index={2}>
         <RiskAnalysis
@@ -265,18 +293,9 @@ export function TicketDetailView({ ticket }) {
           serviceName={service?.service_name || "-"}
           ecosystem={dependency?.package_ecosystem || "-"}
           cveId={vuln?.cve_id || "No Known CVE"}
-          cvss={Number.isFinite(vuln?.cvss_v3_score) ? vuln.cvss_v3_score.toFixed(1) : "N/A"}
+          cvss={cvss}
         />
       </CustomTabPanel>
     </>
   );
 }
-
-TicketDetailView.propTypes = {
-  ticket: PropTypes.object.isRequired,
-};
-
-DetailRow.propTypes = {
-  label: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-};

--- a/web/src/pages/ToDo/TicketHandlingStatusSelector.tsx
+++ b/web/src/pages/ToDo/TicketHandlingStatusSelector.tsx
@@ -1,10 +1,15 @@
 import { ArrowDropDown as ArrowDropDownIcon } from "@mui/icons-material";
 import { Button, ClickAwayListener, Grow, MenuItem, MenuList, Paper, Popper } from "@mui/material";
 import { useSnackbar } from "notistack";
-import PropTypes from "prop-types";
 import { useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
+import type {
+  TicketHandlingStatusType,
+  TicketStatusRequest,
+  TicketStatusResponse,
+} from "../../../types/types.gen";
 import { CompleteTicketDialog } from "../../components/Ticket/CompleteTicketDialog";
 import { ScheduleTicketDialog } from "../../components/Ticket/ScheduleTicketDialog";
 import VulnDialogContext from "../../components/VulnDialogContext";
@@ -12,22 +17,36 @@ import { useUpdateTicketMutation } from "../../services/tcApi";
 import { ticketHandlingStatusProps } from "../../utils/const";
 import { errorToString } from "../../utils/func";
 
-export function TicketHandlingStatusSelector(props) {
+type TicketHandlingStatusSelectorProps = {
+  pteamId: string;
+  serviceId: string;
+  vulnId: string;
+  packageVersionId?: string;
+  ticketId: string;
+  currentStatus: TicketStatusResponse;
+};
+
+type SelectableStatusItem = {
+  display: string;
+  rawStatus: Exclude<TicketHandlingStatusType, "alerted">;
+  disabled: boolean;
+};
+
+export function TicketHandlingStatusSelector(props: TicketHandlingStatusSelectorProps) {
   const { pteamId, serviceId, vulnId, packageVersionId, ticketId, currentStatus } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "TicketHandlingStatusSelector" });
 
   const [open, setOpen] = useState(false);
-  const anchorRef = useRef(null);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
   const [datepickerOpen, setDatepickerOpen] = useState(false);
-  const [schedule, setSchedule] = useState(null); // Date object
+  const [schedule, setSchedule] = useState<Date | null>(null);
   const [completeDialogOpen, setCompleteDialogOpen] = useState(false);
 
   const { enqueueSnackbar } = useSnackbar();
 
   const [updateTicket] = useUpdateTicketMutation();
 
-  const dateFormat = "yyyy/MM/dd HH:mm";
-  const selectableItems = [
+  const selectableItems: SelectableStatusItem[] = [
     {
       display: "Acknowledge",
       rawStatus: "acknowledged",
@@ -41,13 +60,13 @@ export function TicketHandlingStatusSelector(props) {
     },
   ];
 
-  const modifyTicketStatus = async (selectedStatus) => {
-    let requestParams = { ticket_handling_status: selectedStatus };
+  const modifyTicketStatus = async (selectedStatus: TicketHandlingStatusType) => {
+    const requestParams: TicketStatusRequest = { ticket_handling_status: selectedStatus };
     if (selectedStatus === "scheduled") {
       if (!schedule) return;
-      requestParams["scheduled_at"] = schedule.toISOString();
+      requestParams.scheduled_at = schedule.toISOString();
     } else if (selectedStatus === "acknowledged") {
-      requestParams["scheduled_at"] = null;
+      requestParams.scheduled_at = null;
     }
     await updateTicket({
       path: { pteam_id: pteamId, ticket_id: ticketId },
@@ -64,7 +83,10 @@ export function TicketHandlingStatusSelector(props) {
       );
   };
 
-  const handleUpdateStatus = async (event, item) => {
+  const handleUpdateStatus = async (
+    _event: ReactMouseEvent<HTMLElement>,
+    item: SelectableStatusItem,
+  ) => {
     setOpen(false);
     switch (item.rawStatus) {
       case "completed":
@@ -84,8 +106,8 @@ export function TicketHandlingStatusSelector(props) {
     modifyTicketStatus("scheduled");
   };
 
-  const handleClose = (event) => {
-    if (anchorRef.current?.contains(event.target)) return;
+  const handleClose = (event: MouseEvent | TouchEvent) => {
+    if (event.target instanceof Node && anchorRef.current?.contains(event.target)) return;
     setOpen(false);
   };
 
@@ -94,8 +116,6 @@ export function TicketHandlingStatusSelector(props) {
   const handleHideDatepicker = () => {
     setDatepickerOpen(false);
   };
-  const now = new Date();
-
   return (
     <>
       <VulnDialogContext value={{ vulnId }}>
@@ -177,12 +197,3 @@ export function TicketHandlingStatusSelector(props) {
     </>
   );
 }
-
-TicketHandlingStatusSelector.propTypes = {
-  pteamId: PropTypes.string.isRequired,
-  serviceId: PropTypes.string.isRequired,
-  vulnId: PropTypes.string.isRequired,
-  packageVersionId: PropTypes.string.isRequired,
-  ticketId: PropTypes.string.isRequired,
-  currentStatus: PropTypes.object.isRequired,
-};

--- a/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.tsx
+++ b/web/src/pages/ToDo/ToDoCardView/DisplayOptionsController.tsx
@@ -1,10 +1,10 @@
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
-import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined"; // 👈 追加
+import DnsOutlinedIcon from "@mui/icons-material/DnsOutlined";
 import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import FlagOutlinedIcon from "@mui/icons-material/FlagOutlined";
 import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
-import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined"; // 👈 追加
+import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined";
 import TuneIcon from "@mui/icons-material/Tune";
 import {
   Box,
@@ -21,11 +21,13 @@ import {
   Typography,
 } from "@mui/material";
 import SwipeableDrawer from "@mui/material/SwipeableDrawer";
-import PropTypes from "prop-types";
+import type { MouseEvent, ReactNode } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-const sortableKeys = [
+import type { SortConfig } from "../../../hooks/ToDo/useTodoState";
+
+const sortableKeys: Array<{ key: string; icon: ReactNode }> = [
   { key: "cve_id", icon: <FingerprintIcon /> },
   { key: "pteam_name", icon: <GroupOutlinedIcon /> },
   { key: "service_name", icon: <DnsOutlinedIcon /> },
@@ -33,26 +35,36 @@ const sortableKeys = [
   { key: "ssvc_deployer_priority", icon: <FlagOutlinedIcon /> },
 ];
 
+type DisplayOptionsControllerProps = {
+  sortConfig: SortConfig;
+  onSortConfigChange: (newConfig: SortConfig) => void;
+  itemsPerPage: number;
+  onItemsPerPageChange: (newValue: number) => void;
+};
+
 export function DisplayOptionsController({
   sortConfig,
   onSortConfigChange,
   itemsPerPage,
   onItemsPerPageChange,
-}) {
+}: DisplayOptionsControllerProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoCardView.DisplayOptionsController" });
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  const handleSortKeyChange = (key) => {
+  const handleSortKeyChange = (key: string) => {
     onSortConfigChange({ ...sortConfig, key });
   };
 
-  const handleSortDirectionChange = (event, newDirection) => {
-    if (newDirection !== null) {
+  const handleSortDirectionChange = (
+    _event: MouseEvent<HTMLElement>,
+    newDirection: string | null,
+  ) => {
+    if (newDirection === "asc" || newDirection === "desc") {
       onSortConfigChange({ ...sortConfig, direction: newDirection });
     }
   };
 
-  const handleItemsPerPageChange = (event, newValue) => {
+  const handleItemsPerPageChange = (_event: MouseEvent<HTMLElement>, newValue: number | null) => {
     if (newValue !== null) {
       onItemsPerPageChange(newValue);
     }
@@ -159,10 +171,3 @@ export function DisplayOptionsController({
     </>
   );
 }
-
-DisplayOptionsController.propTypes = {
-  sortConfig: PropTypes.object.isRequired,
-  onSortConfigChange: PropTypes.func.isRequired,
-  itemsPerPage: PropTypes.number.isRequired,
-  onItemsPerPageChange: PropTypes.func.isRequired,
-};

--- a/web/src/pages/ToDo/ToDoCardView/ToDoCardView.tsx
+++ b/web/src/pages/ToDo/ToDoCardView/ToDoCardView.tsx
@@ -9,13 +9,13 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 import { Android12Switch } from "../../../components/Android12Switch";
 import { useGetTicketsQuery } from "../../../services/tcApi";
 import { APIError } from "../../../utils/APIError";
 import { errorToString } from "../../../utils/func";
+import type { TodoViewProps } from "../todoViewProps";
 import { CVESearchField } from "../CVESearchField";
 
 import { DisplayOptionsController } from "./DisplayOptionsController";
@@ -29,7 +29,7 @@ export default function ToDoCardView({
   onSortConfigChange,
   onItemsPerPageChange,
   onPageChange,
-}) {
+}: TodoViewProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoCardView.ToDoCardView" });
   const {
     page,
@@ -119,13 +119,3 @@ export default function ToDoCardView({
     </Box>
   );
 }
-
-ToDoCardView.propTypes = {
-  pteamIds: PropTypes.arrayOf(PropTypes.string),
-  apiParams: PropTypes.object.isRequired,
-  onMyTasksChange: PropTypes.func.isRequired,
-  onCveSearch: PropTypes.func.isRequired,
-  onSortConfigChange: PropTypes.func.isRequired,
-  onItemsPerPageChange: PropTypes.func.isRequired,
-  onPageChange: PropTypes.func.isRequired,
-};

--- a/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.tsx
+++ b/web/src/pages/ToDo/ToDoCardView/VulnerabilityCard.tsx
@@ -14,18 +14,22 @@ import {
   Grid,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import type { TicketResponse } from "../../../../types/types.gen";
 import { ResponsiveDrawer } from "../../../components/ResponsiveDrawer";
 import { useTodoItemState } from "../../../hooks/ToDo/useTodoItemState";
 import { getSsvcPriorityProps } from "../../../utils/ssvcUtils";
 import { preserveParams } from "../../../utils/urlUtils";
 import { TicketDetailView } from "../TicketDetailView";
 
-export function VulnerabilityCard({ ticket }) {
+type VulnerabilityCardProps = {
+  ticket: TicketResponse;
+};
+
+export function VulnerabilityCard({ ticket }: VulnerabilityCardProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoCardView.VulnerabilityCard" });
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const navigate = useNavigate();
@@ -78,8 +82,9 @@ export function VulnerabilityCard({ ticket }) {
   ];
 
   const ssvcPriorityProps = getSsvcPriorityProps();
-  const ssvcPriority =
-    ssvcPriorityProps[ticket.ssvc_deployer_priority.toLowerCase()] || ssvcPriorityProps["defer"];
+  const ssvcKey = (ticket.ssvc_deployer_priority?.toLowerCase() ??
+    "defer") as keyof typeof ssvcPriorityProps;
+  const ssvcPriority = ssvcPriorityProps[ssvcKey] || ssvcPriorityProps["defer"];
 
   const cardSx = {
     borderRadius: 5,
@@ -185,7 +190,3 @@ export function VulnerabilityCard({ ticket }) {
     </>
   );
 }
-
-VulnerabilityCard.propTypes = {
-  ticket: PropTypes.object.isRequired,
-};

--- a/web/src/pages/ToDo/ToDoPage.tsx
+++ b/web/src/pages/ToDo/ToDoPage.tsx
@@ -1,4 +1,5 @@
 import { useMediaQuery } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
 
 import { useTodoState } from "../../hooks/ToDo/useTodoState";
@@ -12,7 +13,7 @@ import { ToDoTableView } from "./ToDoTableView/ToDoTableView";
 
 export function ToDo() {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoPage" });
-  const isMobile = useMediaQuery((theme) => theme.breakpoints.down("md"));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
 
   // All URL state management for the ToDo page is encapsulated in this custom hook.
   // It includes ToDo-specific logic, such as resetting the page on filter/sort changes,

--- a/web/src/pages/ToDo/ToDoTableView/ToDoTable.tsx
+++ b/web/src/pages/ToDo/ToDoTableView/ToDoTable.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import { visuallyHidden } from "@mui/utils";
-import PropTypes from "prop-types";
+import type { ChangeEvent, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useSkipUntilAuthUserIsReady } from "../../../hooks/auth";
@@ -20,8 +20,14 @@ import { useGetTicketsQuery } from "../../../services/tcApi";
 import { APIError } from "../../../utils/APIError";
 import { errorToString } from "../../../utils/func";
 import { getSsvcPriorityProps } from "../../../utils/ssvcUtils";
+import type { TodoViewProps } from "../todoViewProps";
 
 import { ToDoTableRow } from "./ToDoTableRow";
+
+type ToDoTableProps = Pick<
+  TodoViewProps,
+  "pteamIds" | "apiParams" | "onSortConfigChange" | "onItemsPerPageChange" | "onPageChange"
+>;
 
 export function ToDoTable({
   pteamIds,
@@ -29,7 +35,7 @@ export function ToDoTable({
   onSortConfigChange,
   onPageChange,
   onItemsPerPageChange,
-}) {
+}: ToDoTableProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoTableView.ToDoTable" });
   const skip = useSkipUntilAuthUserIsReady();
 
@@ -46,18 +52,18 @@ export function ToDoTable({
   const { page, limit: rowsPerPage } = apiParams;
   const { key: sortKey, direction: sortDirection } = apiParams.sortConfig || {};
 
-  const handleRequestSort = (event, property) => {
+  const handleRequestSort = (_event: MouseEvent<unknown>, property: string) => {
     const isAsc = sortKey === property && sortDirection === "asc"; // Determines if the column currently in ascending order is clicked again
     const newDirection = isAsc ? "desc" : "asc";
     onSortConfigChange({ key: property, direction: newDirection });
   };
 
-  const handleChangePage = (event, newPage) => {
+  const handleChangePage = (event: MouseEvent<HTMLButtonElement> | null, newPage: number) => {
     onPageChange(event, newPage + 1);
   };
 
-  const handleChangeRowsPerPage = (event) => {
-    onItemsPerPageChange(event.target.value);
+  const handleChangeRowsPerPage = (event: ChangeEvent<HTMLInputElement>) => {
+    onItemsPerPageChange(Number(event.target.value));
   };
 
   const headCells = [
@@ -110,8 +116,9 @@ export function ToDoTable({
           <TableBody>
             {tickets.length > 0 ? (
               tickets.map((ticket) => {
-                const ssvcPriority =
-                  ssvcPriorityProps[ticket.ssvc_deployer_priority] || ssvcPriorityProps["defer"];
+                const ssvcKey = (ticket.ssvc_deployer_priority ??
+                  "defer") as keyof typeof ssvcPriorityProps;
+                const ssvcPriority = ssvcPriorityProps[ssvcKey] || ssvcPriorityProps["defer"];
                 return (
                   <ToDoTableRow
                     key={ticket.ticket_id}
@@ -147,11 +154,3 @@ export function ToDoTable({
     </Paper>
   );
 }
-
-ToDoTable.propTypes = {
-  pteamIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-  apiParams: PropTypes.object.isRequired,
-  onSortConfigChange: PropTypes.func.isRequired,
-  onPageChange: PropTypes.func.isRequired,
-  onItemsPerPageChange: PropTypes.func.isRequired,
-};

--- a/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.tsx
+++ b/web/src/pages/ToDo/ToDoTableView/ToDoTableRow.tsx
@@ -1,16 +1,26 @@
 import KeyboardDoubleArrowLeftIcon from "@mui/icons-material/KeyboardDoubleArrowLeft";
 import { Box, Button, TableCell, TableRow, Typography } from "@mui/material";
-import PropTypes from "prop-types";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import type { TicketResponse } from "../../../../types/types.gen";
 import { ResponsiveDrawer } from "../../../components/ResponsiveDrawer";
 import { useTodoItemState } from "../../../hooks/ToDo/useTodoItemState";
+import type { getSsvcPriorityProps } from "../../../utils/ssvcUtils";
 import { preserveParams } from "../../../utils/urlUtils";
 import { TicketDetailView } from "../TicketDetailView";
 
-export function ToDoTableRow(props) {
+type SsvcPriority = ReturnType<typeof getSsvcPriorityProps>[keyof ReturnType<
+  typeof getSsvcPriorityProps
+>];
+
+type ToDoTableRowProps = {
+  ticket: TicketResponse;
+  ssvcPriority: SsvcPriority;
+};
+
+export function ToDoTableRow(props: ToDoTableRowProps) {
   const { ticket, ssvcPriority } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoTableView.ToDoTableRow" });
   const Icon = ssvcPriority.icon;
@@ -98,12 +108,3 @@ export function ToDoTableRow(props) {
     </>
   );
 }
-
-ToDoTableRow.propTypes = {
-  ticket: PropTypes.object.isRequired,
-  ssvcPriority: PropTypes.shape({
-    icon: PropTypes.elementType.isRequired,
-    displayName: PropTypes.string.isRequired,
-    style: PropTypes.object.isRequired,
-  }).isRequired,
-};

--- a/web/src/pages/ToDo/ToDoTableView/ToDoTableView.tsx
+++ b/web/src/pages/ToDo/ToDoTableView/ToDoTableView.tsx
@@ -1,9 +1,9 @@
 import { Typography, Box } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
 import { Android12Switch } from "../../../components/Android12Switch";
 import { CVESearchField } from "../CVESearchField";
+import type { TodoViewProps } from "../todoViewProps";
 
 import { ToDoTable } from "./ToDoTable";
 
@@ -15,7 +15,7 @@ export function ToDoTableView({
   onSortConfigChange,
   onPageChange,
   onItemsPerPageChange,
-}) {
+}: TodoViewProps) {
   const { t } = useTranslation("toDo", { keyPrefix: "ToDoTableView.ToDoTableView" });
   const { assigned_to_me: myTasks, cve_ids: cveIds } = apiParams;
   const cveId = cveIds?.[0] ?? "";
@@ -39,13 +39,3 @@ export function ToDoTableView({
     </>
   );
 }
-
-ToDoTableView.propTypes = {
-  pteamIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-  apiParams: PropTypes.object.isRequired,
-  onMyTasksChange: PropTypes.func.isRequired,
-  onCveSearch: PropTypes.func.isRequired,
-  onSortConfigChange: PropTypes.func.isRequired,
-  onPageChange: PropTypes.func.isRequired,
-  onItemsPerPageChange: PropTypes.func.isRequired,
-};

--- a/web/src/pages/ToDo/VulnerabilityView.tsx
+++ b/web/src/pages/ToDo/VulnerabilityView.tsx
@@ -8,18 +8,28 @@ import {
   ListItemText,
   Typography,
 } from "@mui/material";
-import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 
+import type { DependencyResponse, VulnResponse } from "../../../types/types.gen";
 import { ActionTypeIcon } from "../../components/ActionTypeIcon";
 import { PackageView } from "../../components/PackageView";
-import { createUpdateAction, findMatchedVulnPackage } from "../../utils/vulnUtils.js";
+import { createUpdateAction, findMatchedVulnPackage } from "../../utils/vulnUtils";
 
-export function VulnerabilityView(props) {
+type CurrentPackage = Pick<
+  DependencyResponse,
+  "package_name" | "package_source_name" | "vuln_matching_ecosystem"
+>;
+
+type VulnerabilityViewProps = {
+  vuln: VulnResponse;
+  currentPackage: CurrentPackage;
+};
+
+export function VulnerabilityView(props: VulnerabilityViewProps) {
   const { vuln, currentPackage } = props;
   const { t } = useTranslation("toDo", { keyPrefix: "VulnerabilityView" });
   // Get the matched vulnerable package from vulnerable_packages and currentPackage
-  const matchedVulnPackage = findMatchedVulnPackage(vuln.vulnerable_packages, currentPackage);
+  const matchedVulnPackage = findMatchedVulnPackage(vuln.vulnerable_packages ?? [], currentPackage);
   if (!matchedVulnPackage) throw new Error("No matching package found for the vulnerability.");
 
   const affectedVersions = matchedVulnPackage?.affected_versions ?? [];
@@ -78,13 +88,9 @@ export function VulnerabilityView(props) {
           {t("detail")}
         </Typography>
         <Card variant="outlined" sx={{ m: 1, p: 2 }}>
-          <Typography variant="body1">{vuln.detail}</Typography>
+          <Typography variant="body1">{vuln.detail ?? "-"}</Typography>
         </Card>
       </Box>
     </>
   );
 }
-VulnerabilityView.propTypes = {
-  vuln: PropTypes.object.isRequired,
-  currentPackage: PropTypes.object.isRequired,
-};

--- a/web/src/pages/ToDo/todoViewProps.ts
+++ b/web/src/pages/ToDo/todoViewProps.ts
@@ -1,0 +1,12 @@
+import type { ChangeEvent } from "react";
+import type { TodoApiParams, SortConfig, UseTodoStateReturn } from "../../hooks/ToDo/useTodoState";
+
+export type TodoViewProps = {
+  pteamIds: string[];
+  apiParams: TodoApiParams;
+  onMyTasksChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onCveSearch: (word: string) => void;
+  onSortConfigChange: (newConfig: SortConfig) => void;
+  onItemsPerPageChange: (newValue: number) => void;
+  onPageChange: UseTodoStateReturn["onPageChange"];
+};

--- a/web/src/services/tcApi.ts
+++ b/web/src/services/tcApi.ts
@@ -163,6 +163,8 @@ type GetPteamTicketsRequestParams = Pick<
   "path" | "query"
 >;
 
+type GetTicketsRequestParams = Pick<GetTicketsTicketsGetData, "query">;
+
 type UpdateTicketRequestParams = Pick<
   UpdateTicketPteamsPteamIdTicketsTicketIdPutData,
   "body" | "path"
@@ -188,6 +190,8 @@ type CreateUserRequestParams = Pick<CreateUserUsersPostData, "body">;
 type CheckMailRequestParams = Pick<CheckEmailExternalEmailCheckPostData, "body">;
 
 type CheckSlackRequestParams = Pick<CheckWebhookUrlExternalSlackCheckPostData, "body">;
+
+type GetInsightRequestParams = Pick<GetInsightTicketsTicketIdInsightGetData, "path">;
 
 export const getBearerToken =
   {
@@ -265,7 +269,7 @@ export const tcApi = createApi({
     }),
 
     /* Insight  */
-    getInsight: builder.query<InsightResponse, GetInsightTicketsTicketIdInsightGetData>({
+    getInsight: builder.query<InsightResponse, GetInsightRequestParams>({
       query: (arg) => `tickets/${arg.path.ticket_id}/insight`,
       providesTags: (_result, _error, _arg) => [
         { type: "Service", id: "ALL" },
@@ -591,7 +595,7 @@ export const tcApi = createApi({
     ),
 
     /* Ticket */
-    getTickets: builder.query<TicketListResponse, GetTicketsTicketsGetData>({
+    getTickets: builder.query<TicketListResponse, GetTicketsRequestParams>({
       query: (arg) => ({
         url: "tickets",
         method: "GET",


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## PR の目的

- TypeScript移行: ToDo ページ関連コンポーネントを `.jsx` / `.js` から `.tsx` / `.ts` へ変換する

## 経緯・意図・意思決定

VulnManagement・VulnDetail・PTeam・auth 関連ページなどに続き、ToDo ページ群の TypeScript 移行を実施した。

対象ファイル:
- `web/src/pages/ToDo/` 配下の全コンポーネント（`ToDoPage`・`ToDoCardView`・`ToDoTableView` など）
- `web/src/hooks/ToDo/useTodoState.ts`（型注釈を修正）
- `web/src/services/tcApi.ts`（新 Pick スタイルへ追加エンドポイント定義）
- `web/src/pages/ToDo/todoViewProps.ts`（新規追加: 共通 Props 型定義）

## 実施したテスト項目

- ToDoページを表示
  - 詳細の各タブを開く
  - InsightデータがあるTicketとないTicketで確認

<!-- I want to review in Japanese. -->